### PR TITLE
Enable safe test parallelization across SDK test assemblies

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/AGENTS.md
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/AGENTS.md
@@ -71,6 +71,8 @@ the driver already implies them and the combination fails. To regenerate `.xlf` 
   upstream `dotnet/roslyn-analyzers` tests use xUnit and must be translated when ported.
   `tests/Test.Utilities/TheoryData.cs` is an MSTest-friendly shim for xUnit's `TheoryData`,
   consumable from `[DynamicData]`.
+- The unit-test assembly uses method-level parallelization. Keep new fixtures, data sources,
+  process-global state, and filesystem paths safe for concurrent test methods.
 - Embedded C# test sources default to `LanguageVersion.CSharp7_3`; set `LanguageVersion`
   explicitly when the source uses newer syntax.
 - `test/ConditionalTests.props` registers a `NetAnalyzers` scope, so PR validation can skip

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Nullable>disable</Nullable>
+    <!-- Overrides the repo-wide 'None' default from test/Directory.Build.props. These tests are
+         isolated: every test is a self-contained Roslyn compilation built by a fresh verifier
+         instance, there are no [AssemblyInitialize]/[ClassInitialize]/[TestInitialize] fixtures,
+         and the only shared state is init-once immutable data (Test.Utilities'
+         AdditionalMetadataReferences and the [DynamicData] providers). The package cache under
+         %TEMP%\test-packages is reached only through ReferenceAssemblies.ResolveAsync, which
+         serializes restores behind its own cross-process semaphore. -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <!-- RS1024: Compare symbols correctly https://github.com/dotnet/roslyn-analyzers/issues/6381 -->
     <NoWarn>$(NoWarn);RS1024</NoWarn>

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -29,15 +29,16 @@ Guidance for changes under `test/`.
   installed one.
 - **Test asset placement.** Put test inputs (projects, packages, workloads, etc.) in
   `test/TestAssets/`. They are automatically deployed to Helix via `test/UnitTests.proj`.
-- **Don't raise parallelism.** MSTest is repo-defaulted to `None` in
-  `test/Directory.Build.props` because of concurrency flakiness; a few projects opt
-  into `ClassLevel` or `MethodLevel` after auditing their shared resources. Cranking it
-  up without that audit causes Helix over-subscription/timeouts and test interference.
+- **Audit before raising parallelism.** New MSTest projects are repo-defaulted to `None`
+  in `test/Directory.Build.props` until their shared resources have been audited.
+  Runnable test projects override that default with `ClassLevel` or `MethodLevel` when
+  safe; keep `None` only when the whole assembly depends on one inherently serial
+  resource. Raising the scope without an audit causes Helix over-subscription/timeouts
+  and test interference.
 - **In parallelized projects, prefer `[ResourceLock]` over `[DoNotParallelize]`.** In the
-  projects that do opt in (`Microsoft.NET.Build.Tests`, `dotnet-watch.Tests`,
-  `Microsoft.NET.Build.Containers.UnitTests`, `Microsoft.TemplateEngine.Cli.UnitTests`),
-  MSTest's parallel-safety analyzers (MSTEST0073–MSTEST0077) are active, and
-  `MSTestAnalysisMode=Recommended` plus `TreatWarningsAsErrors` makes them build errors.
+  projects that opt in, MSTest's parallel-safety analyzers
+  (MSTEST0073–MSTEST0077) are active, and `MSTestAnalysisMode=Recommended` plus
+  `TreatWarningsAsErrors` makes them build errors.
   Fix them in this order:
   1. **Eliminate the shared state** — pass an environment variable to the child process
      via `TestCommand.WithEnvironmentVariable(...)` instead of

--- a/test/ArgumentForwarding.Tests/ArgumentForwarding.Tests.csproj
+++ b/test/ArgumentForwarding.Tests/ArgumentForwarding.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
   </PropertyGroup>
 

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tests/Microsoft.DotNet.ApiCompat.Tests.csproj
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tests/Microsoft.DotNet.ApiCompat.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/Microsoft.DotNet.PackageValidation.Tests.csproj
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/Microsoft.DotNet.PackageValidation.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
@@ -182,6 +182,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
         }
 
         [TestMethod]
+        [DoNotParallelize] // Concurrent pack/restore child processes can emit shared-cache diagnostics to stderr.
         public void ValidateReferencesAreRespectedForPlatformSpecificTFMs()
         {
             TestProject testProject = CreateTestProject("public class MyType { }", $"netstandard2.0;{ToolsetInfo.CurrentTargetFramework}-windows");

--- a/test/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.IntegrationTests/Microsoft.DotNet.ApiDiff.IntegrationTests.csproj
+++ b/test/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.IntegrationTests/Microsoft.DotNet.ApiDiff.IntegrationTests.csproj
@@ -5,6 +5,7 @@
          path that needs to be exercised from desktop MSBuild. Single-target the netcore TFM. -->
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.IntegrationTests/Microsoft.DotNet.GenAPI.IntegrationTests.csproj
+++ b/test/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.IntegrationTests/Microsoft.DotNet.GenAPI.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(SdkTargetFramework);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
+++ b/test/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/Microsoft.DotNet.ApiSymbolExtensions.Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj
+++ b/test/Compatibility/Microsoft.DotNet.ApiSymbolExtensions.Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -31,7 +31,7 @@
          (xunit.core/assert/runner.console/runner.visualstudio) into every MSTest test output. -->
     <UsingToolXUnit>false</UsingToolXUnit>
 
-    <!-- Parallelization disabled due to widespread concurrency-related intermittent test failures. -->
+    <!-- New test projects remain serialized until their shared resources have been audited. -->
     <MSTestParallelizeScope>None</MSTestParallelizeScope>
 
     <!-- Promote info-severity MSTest analyzer rules to warnings and critical rules to errors. -->

--- a/test/Microsoft.DotNet.Cli.Telemetry.Tests/Microsoft.DotNet.Cli.Telemetry.Tests.csproj
+++ b/test/Microsoft.DotNet.Cli.Telemetry.Tests/Microsoft.DotNet.Cli.Telemetry.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <Nullable>enable</Nullable>
     <!-- Strong naming deprecated on .NET Core -->

--- a/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
+++ b/test/Microsoft.DotNet.MSBuildSdkResolver.Tests/Microsoft.DotNet.MSBuildSdkResolver.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
   </PropertyGroup>
 

--- a/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/EndToEndToolTests.cs
@@ -8,7 +8,9 @@ using NuGet.Packaging.Core;
 
 namespace Microsoft.DotNet.PackageInstall.Tests
 {
+    // TestToolBuilder maintains a shared package cache and can mutate the NuGet global packages folder.
     [TestClass]
+    [DoNotParallelize]
     public class EndToEndToolTests : SdkTest
     {
         private static readonly TestToolBuilder ToolBuilder = TestToolBuilder.SharedInstance.Value;

--- a/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/Microsoft.DotNet.PackageInstall.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageDownloaderFactoryTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/NuGetPackageDownloaderFactoryTests.cs
@@ -64,7 +64,9 @@ public class NuGetPackageDownloaderFactoryTests : SdkTest
         downloader.Should().NotBeNull();
     }
 
+    // The production constructor reads this process-wide variable, while other tests do not acquire a matching lock.
     [TestMethod]
+    [DoNotParallelize]
     public void Constructor_WhenVerifyRequestedButPlatformUnsupported_LogsMessage()
     {
         // On non-Windows, requesting verification without the env var should log a message.

--- a/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
+++ b/test/Microsoft.DotNet.PackageInstall.Tests/ToolPackageDownloaderTests.cs
@@ -34,7 +34,9 @@ namespace Microsoft.DotNet.PackageInstall.Tests
         public void Dispose() => Environment.SetEnvironmentVariable(_PATH_VAR_NAME, _originalPath);
     }
 
+    // The class fixture mutates PATH, and the shared tool builder mutates the NuGet global packages folder.
     [TestClass]
+    [DoNotParallelize]
     public class ToolPackageDownloaderTests : SdkTest
     {
         private static DotnetEnvironmentTestFixture _envFixture;

--- a/test/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj
+++ b/test/Microsoft.DotNet.TemplateLocator.Tests/Microsoft.DotNet.TemplateLocator.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net472;$(SdkTargetFramework)</TargetFrameworks>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(SdkTargetFramework)</TargetFrameworks>
     <!-- For product build, the .NET Framework TFM only builds in the second build pass as it depends on assets from other
          verticals that are built in the first build pass. -->

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadAgentTest.cs
@@ -10,6 +10,7 @@ namespace Microsoft.DotNet.HotReload.UnitTests
     public class HotReloadAgentTest
     {
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void ClearHotReloadEnvironmentVariables_DoesNotThrow_WhenStartupHooksNotSet()
         {
             // Ensure DOTNET_STARTUP_HOOKS is not set

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests.csproj
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <RootNamespace>Microsoft.Extensions.DotNetDeltaApplier</RootNamespace>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
@@ -12,6 +12,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
 [TestClass]
+[ResourceLock(TestSettings.DockerDaemonResource)]
 public class CreateImageIndexTests : SdkTest
 {
     [TestMethod]
@@ -21,7 +22,7 @@ public class CreateImageIndexTests : SdkTest
         DirectoryInfo newProjectDir = CreateNewProject();
         (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
         string outputRegistry = DockerRegistryManager.LocalRegistry;
-        string repository = "dotnet/create-image-index-baseline";
+        string repository = $"dotnet/create-image-index-baseline-{TestSettings.TestRunId}";
         string[] tags = new[] { "tag1", "tag2" };
 
         // Create images for 2 rids
@@ -159,4 +160,3 @@ public class CreateImageIndexTests : SdkTest
 
     private static string FormatBuildMessages(List<string?> messages) => string.Join("\r\n", messages);
 }
-

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -10,6 +10,7 @@ using Microsoft.NET.Build.Containers.IntegrationTests;
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
 [TestClass]
+[ResourceLock(TestSettings.DockerDaemonResource)]
 public class CreateNewImageTests : SdkTest
 {
     [TestMethod]
@@ -47,7 +48,7 @@ public class CreateNewImageTests : SdkTest
         task.OutputRegistry = "localhost:5010";
         task.LocalRegistry = DockerUnavailableCondition.LocalRegistry;
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-arm64", "publish");
-        task.Repository = "dotnet/create-new-image-baseline";
+        task.Repository = $"dotnet/create-new-image-baseline-{TestSettings.TestRunId}";
         task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";
         task.ContainerRuntimeIdentifier = "linux-arm64";
@@ -90,10 +91,11 @@ public class CreateNewImageTests : SdkTest
         ParseContainerProperties pcp = new();
         (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
         pcp.BuildEngine = buildEngine;
+        string repository = $"dotnet/testimage-{TestSettings.TestRunId}";
 
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:7.0";
         pcp.ContainerRegistry = "localhost:5010";
-        pcp.ContainerRepository = "dotnet/testimage";
+        pcp.ContainerRepository = repository;
         pcp.ContainerImageTags = new[] { "5.0", "latest" };
 
         Assert.IsTrue(pcp.Execute(), FormatBuildMessages(errors));
@@ -101,7 +103,7 @@ public class CreateNewImageTests : SdkTest
         Assert.AreEqual("dotnet/runtime", pcp.ParsedContainerImage);
         Assert.AreEqual("7.0", pcp.ParsedContainerTag);
 
-        Assert.AreEqual("dotnet/testimage", pcp.NewContainerRepository);
+        Assert.AreEqual(repository, pcp.NewContainerRepository);
         pcp.NewContainerTags.Should().BeEquivalentTo(new[] { "5.0", "latest" });
 
         CreateNewImage cni = new();
@@ -159,10 +161,11 @@ public class CreateNewImageTests : SdkTest
         ParseContainerProperties pcp = new();
         (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
         pcp.BuildEngine = buildEngine;
+        string repository = $"dotnet/envvarvalidation-{TestSettings.TestRunId}";
 
         pcp.FullyQualifiedBaseImageName = $"mcr.microsoft.com/{DockerRegistryManager.RuntimeBaseImage}:{DockerRegistryManager.Net9ImageTag}";
         pcp.ContainerRegistry = "";
-        pcp.ContainerRepository = "dotnet/envvarvalidation";
+        pcp.ContainerRepository = repository;
         pcp.ContainerImageTag = "latest";
 
         Dictionary<string, string> dict = new();
@@ -177,7 +180,7 @@ public class CreateNewImageTests : SdkTest
         Assert.ContainsSingle(pcp.NewContainerEnvironmentVariables);
         Assert.AreEqual("Foo", pcp.NewContainerEnvironmentVariables[0].GetMetadata("Value"));
 
-        Assert.AreEqual("dotnet/envvarvalidation", pcp.NewContainerRepository);
+        Assert.AreEqual(repository, pcp.NewContainerRepository);
         Assert.AreEqual("latest", pcp.NewContainerTags[0]);
 
         CreateNewImage cni = new();
@@ -218,8 +221,8 @@ public class CreateNewImageTests : SdkTest
     [Ignore("https://github.com/dotnet/sdk/issues/49300")]
     public async System.Threading.Tasks.Task CreateNewImage_RootlessBaseImage()
     {
-        const string RootlessBase = "dotnet/rootlessbase";
-        const string AppImage = "dotnet/testimagerootless";
+        string rootlessBase = $"dotnet/rootlessbase-{TestSettings.TestRunId}";
+        string appImage = $"dotnet/testimagerootless-{TestSettings.TestRunId}";
         const string RootlessUser = "1654";
         var loggerFactory = new TestLoggerFactory(Log);
         var logger = loggerFactory.CreateLogger(nameof(CreateNewImage_RootlessBaseImage));
@@ -240,7 +243,7 @@ public class CreateNewImageTests : SdkTest
         BuiltImage builtImage = imageBuilder.Build();
 
         var sourceReference = new SourceImageReference(registry, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net8ImageTag, null);
-        var destinationReference = new DestinationImageReference(registry, RootlessBase, new[] { "latest" });
+        var destinationReference = new DestinationImageReference(registry, rootlessBase, new[] { "latest" });
 
         await registry.PushAsync(builtImage, sourceReference, destinationReference, cancellationToken: default).ConfigureAwait(false);
 
@@ -269,12 +272,12 @@ public class CreateNewImageTests : SdkTest
         var (buildEngine, errors) = SetupBuildEngine();
         task.BuildEngine = buildEngine;
         task.BaseRegistry = "localhost:5010";
-        task.BaseImageName = RootlessBase;
+        task.BaseImageName = rootlessBase;
         task.BaseImageTag = "latest";
 
         task.OutputRegistry = "localhost:5010";
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-x64", "publish");
-        task.Repository = AppImage;
+        task.Repository = appImage;
         task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";
         task.ContainerRuntimeIdentifier = "linux-x64";
@@ -286,7 +289,7 @@ public class CreateNewImageTests : SdkTest
 
         // Verify the application image uses the non-root user from the base image.
         imageBuilder = await registry.GetImageManifestAsync(
-            AppImage,
+            appImage,
             "latest",
             "linux-x64",
             ToolsetUtils.RidGraphManifestPicker,
@@ -323,10 +326,11 @@ public class CreateNewImageTests : SdkTest
         ParseContainerProperties pcp = new();
         (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
         pcp.BuildEngine = buildEngine;
+        string repository = $"dotnet/testimage-{TestSettings.TestRunId}";
 
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:9.0";
         pcp.ContainerRegistry = "localhost:5010";
-        pcp.ContainerRepository = "dotnet/testimage";
+        pcp.ContainerRepository = repository;
         pcp.ContainerImageTags = new[] { "5.0", "latest" };
 
         Assert.IsTrue(pcp.Execute(), FormatBuildMessages(errors));
@@ -334,7 +338,7 @@ public class CreateNewImageTests : SdkTest
         Assert.AreEqual("dotnet/runtime", pcp.ParsedContainerImage);
         Assert.AreEqual("9.0", pcp.ParsedContainerTag);
 
-        Assert.AreEqual("dotnet/testimage", pcp.NewContainerRepository);
+        Assert.AreEqual(repository, pcp.NewContainerRepository);
         pcp.NewContainerTags.Should().BeEquivalentTo(new[] { "5.0", "latest" });
 
         CreateNewImage cni = new();

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
@@ -5,6 +5,7 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 [TestClass]
+[ResourceLock(TestSettings.DockerDaemonResource)]
 public class DockerRegistryTests : SdkTest
 {
     private TestLoggerFactory? _loggerFactory;
@@ -40,6 +41,7 @@ public class DockerRegistryTests : SdkTest
         var registryAuthDir = new DirectoryInfo(Path.Combine(registryDir.FullName, "auth"));
         var registryCertsDir = new DirectoryInfo(Path.Combine(registryDir.FullName, "certs"));
         var registryName = "localhost:5555";
+        var registryContainerName = $"auth-registry-{TestSettings.TestRunId}";
         try
         {
             if (!registryCertsDir.Exists)
@@ -54,7 +56,7 @@ public class DockerRegistryTests : SdkTest
             // start up an authenticated registry using that dev cert
             ContainerCli.RunCommand(Log,
                 "-d", "--rm",
-                "--name", "auth-registry",
+                "--name", registryContainerName,
                 "-p", "5555:5000",
                 "-e", "REGISTRY_AUTH=htpasswd",
                 "-e", "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm",
@@ -66,7 +68,7 @@ public class DockerRegistryTests : SdkTest
                 "registry:2")
             .WithWorkingDirectory(registryDir.FullName).Execute().Should().Pass();
             // verify that the registry container started successfully
-            ContainerCli.InspectCommand(Log, "auth-registry").Execute().Should().Pass();
+            ContainerCli.InspectCommand(Log, registryContainerName).Execute().Should().Pass();
             // login to that registry
             ContainerCli.LoginCommand(Log, "--username", "testuser", "--password", "testpassword", registryName).Execute().Should().Pass();
             // push an image to that registry using username/password
@@ -88,7 +90,7 @@ public class DockerRegistryTests : SdkTest
         finally
         {
             //stop the registry
-            ContainerCli.StopCommand(Log, "auth-registry").WithWorkingDirectory(registryDir.FullName).Execute().Should().Pass();
+            ContainerCli.StopCommand(Log, registryContainerName).WithWorkingDirectory(registryDir.FullName).Execute().Should().Pass();
         }
     }
 }

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -14,6 +14,7 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 [TestClass]
+[ResourceLock(TestSettings.DockerDaemonResource)]
 public class EndToEndTests : SdkTest, IDisposable
 {
     private TestLoggerFactory? _loggerFactory;
@@ -21,7 +22,7 @@ public class EndToEndTests : SdkTest, IDisposable
 
     public static string NewImageName([CallerMemberName] string callerMemberName = "")
     {
-        var (normalizedName, warning, error) = ContainerHelpers.NormalizeRepository(callerMemberName);
+        var (normalizedName, warning, error) = ContainerHelpers.NormalizeRepository($"{callerMemberName}-{TestSettings.TestRunId}");
         if (error is (var format, var args))
         {
             throw new ArgumentException(string.Format(Strings.ResourceManager.GetString(format)!, args));
@@ -684,7 +685,7 @@ public class EndToEndTests : SdkTest, IDisposable
             .Execute()
             .Should().Pass();
 
-        var containerName = $"test-container-1-{projectType}-{addPackageReference}";
+        var containerName = $"test-container-1-{projectType}-{addPackageReference}-{TestSettings.TestRunId}";
         CommandResult processResult = ContainerCli.RunCommand(
             Log,
             [
@@ -834,7 +835,7 @@ public class EndToEndTests : SdkTest, IDisposable
             .Execute()
             .Should().Pass();
 
-        var containerName = "test-container-2";
+        var containerName = $"test-container-2-{TestSettings.TestRunId}";
         CommandResult processResult = ContainerCli.RunCommand(
             Log,
             "--rm",
@@ -875,7 +876,7 @@ public class EndToEndTests : SdkTest, IDisposable
             Log,
             "--rm",
             "--name",
-            $"test-container-singlearch-norid",
+            $"test-container-singlearch-norid-{TestSettings.TestRunId}",
             $"{imageName}:{imageTag}")
         .Execute();
         processResultX64.Should().Pass().And.HaveStdOut("Hello, World!");
@@ -991,8 +992,8 @@ public class EndToEndTests : SdkTest, IDisposable
     {
         string[] imageNames =
         [
-            "endtoendmultiarch-localregistry",
-            "myteam/endtoendmultiarch-localregistry"
+            $"endtoendmultiarch-localregistry-{TestSettings.TestRunId}",
+            $"myteam/endtoendmultiarch-localregistry-{TestSettings.TestRunId}"
         ];
 
         string[] localRegistries = [.. MultiArchLocalRegistryTestData.AvailableRuntimes()];

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/LayerEndToEndTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/LayerEndToEndTests.cs
@@ -8,6 +8,8 @@ using System.Security.Cryptography;
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 [TestClass]
+// ContentStore.ArtifactRoot is read by product code that cannot acquire a test resource lock.
+[DoNotParallelize]
 public sealed class LayerEndToEndTests : SdkTest, IDisposable
 {
     public LayerEndToEndTests()

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
@@ -7,6 +7,7 @@
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <!-- MSTest experimental APIs (Assert.ThrowsExactly, condition attributes, etc.). -->
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
@@ -55,10 +55,10 @@ public sealed class ProjectInitializer
         props["NETCoreSdkPortableRuntimeIdentifier"] = "linux-x64";
 
 
-        var safeBinlogFileName = projectName.Replace(" ", "_").Replace(":", "_").Replace("/", "_").Replace("\\", "_").Replace("*", "_");
+        var safeBinlogFileName = $"{projectName.Replace(" ", "_").Replace(":", "_").Replace("/", "_").Replace("\\", "_").Replace("*", "_")}-{Guid.NewGuid():N}";
         var loggers = new List<ILogger>
         {
-            new global::Microsoft.Build.Logging.BinaryLogger() {CollectProjectImports = global::Microsoft.Build.Logging.BinaryLogger.ProjectImportsCollectionMode.Embed, Verbosity = LoggerVerbosity.Diagnostic, Parameters = $"LogFile={safeBinlogFileName}.binlog" },
+            new global::Microsoft.Build.Logging.BinaryLogger() {CollectProjectImports = global::Microsoft.Build.Logging.BinaryLogger.ProjectImportsCollectionMode.Embed, Verbosity = LoggerVerbosity.Diagnostic, Parameters = $"LogFile={Path.Combine(TestSettings.TestArtifactsDirectory, safeBinlogFileName)}.binlog" },
             new global::Microsoft.Build.Logging.ConsoleLogger(LoggerVerbosity.Detailed)
         };
         CapturingLogger logs = new();

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
@@ -1,14 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 internal static class TestSettings
 {
+    internal const string DockerDaemonResource = "DockerDaemon";
+
     private static readonly object _tmpLock = new();
     private static string? _testArtifactsDir;
+
+    internal static string TestRunId { get; } = Guid.NewGuid().ToString("N");
 
     /// <summary>
     /// Gets temporary location for test artifacts.
@@ -23,7 +25,7 @@ internal static class TestSettings
                 {
                     if (_testArtifactsDir == null)
                     {
-                        string tmpDir = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "ContainersTests", DateTime.Now.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture));
+                        string tmpDir = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "ContainersTests", TestRunId);
                         if (!Directory.Exists(tmpDir))
                         {
                             Directory.CreateDirectory(tmpDir);

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGetDependsOnNETStandardMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/GivenAGetDependsOnNETStandardMultiThreading.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGetDependsOnNETStandardMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Extensions.Tasks.Tests/Microsoft.NET.Build.Extensions.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Extensions.Tasks.Tests/Microsoft.NET.Build.Extensions.Tasks.Tests.csproj
@@ -6,6 +6,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenACheckForUnsupportedWinMDReferencesMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenACheckForUnsupportedWinMDReferencesMultiThreading.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenACheckForUnsupportedWinMDReferencesMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
@@ -23,6 +23,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// back to <c>Environment.CurrentDirectory</c> / <c>Path.GetFullPath</c> would surface here.
     /// </summary>
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGenerateBundleMultiThreading : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateBundleMultiThreading.cs
@@ -23,7 +23,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// back to <c>Environment.CurrentDirectory</c> / <c>Path.GetFullPath</c> would surface here.
     /// </summary>
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGenerateBundleMultiThreading : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGenerateClsidMapMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateClsidMapMultiThreading.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGenerateClsidMapMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGenerateDepsFilePathResolution : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateDepsFileMultiThreading.cs
@@ -13,7 +13,7 @@ using Newtonsoft.Json.Linq;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGenerateDepsFilePathResolution : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGenerateRuntimeConfigMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGenerateRuntimeConfigMultiThreading.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGenerateRuntimeConfigMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
@@ -14,6 +14,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// current working directory differs from the project directory.
     /// </summary>
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAGetPackagesToPrune
     {
         private const string NetCoreApp = "Microsoft.NETCore.App";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAGetPackagesToPrune.cs
@@ -14,7 +14,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// current working directory differs from the project directory.
     /// </summary>
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAGetPackagesToPrune
     {
         private const string NetCoreApp = "Microsoft.NETCore.App";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
@@ -6,6 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAPickBestRidMultiThreading
     {
         private const string RuntimeGraphContent = @"{

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAPickBestRidMultiThreading.cs
@@ -6,7 +6,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAPickBestRidMultiThreading
     {
         private const string RuntimeGraphContent = @"{

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
@@ -19,6 +19,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// and that output metadata preserves the original path form.
     /// </summary>
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAResolveAppHostsMultiThreading : IDisposable
     {
         internal const string CollectionName = "ResolveAppHosts current directory tests";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveAppHostsMultiThreading.cs
@@ -19,7 +19,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// and that output metadata preserves the original path form.
     /// </summary>
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAResolveAppHostsMultiThreading : IDisposable
     {
         internal const string CollectionName = "ResolveAppHosts current directory tests";

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
@@ -7,6 +7,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAResolvePackageAssetsMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageAssetsMultiThreading.cs
@@ -7,7 +7,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAResolvePackageAssetsMultiThreading
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
@@ -8,6 +8,7 @@ using Microsoft.NET.Build.Tasks.ConflictResolution;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests;
 [TestClass]
+[ResourceLock(WellKnownResources.CurrentDirectory)]
 public class GivenAResolvePackageFileConflictsMultiThreading : IDisposable
 {
     private readonly string _originalCwd = Directory.GetCurrentDirectory();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolvePackageFileConflictsMultiThreading.cs
@@ -8,7 +8,7 @@ using Microsoft.NET.Build.Tasks.ConflictResolution;
 
 namespace Microsoft.NET.Build.Tasks.UnitTests;
 [TestClass]
-[ResourceLock(WellKnownResources.CurrentDirectory)]
+[DoNotParallelize]
 public class GivenAResolvePackageFileConflictsMultiThreading : IDisposable
 {
     private readonly string _originalCwd = Directory.GetCurrentDirectory();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
@@ -8,6 +8,7 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAResolveRuntimePackAssetsTask : SdkTest
     {
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAResolveRuntimePackAssetsTask.cs
@@ -8,7 +8,7 @@ using Microsoft.Build.Utilities;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAResolveRuntimePackAssetsTask : SdkTest
     {
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
@@ -20,6 +20,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// which uses live process state, equivalent to the legacy single-threaded behavior.
     /// </summary>
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenATaskEnvironmentDefault
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenATaskEnvironmentDefault.cs
@@ -20,7 +20,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
     /// which uses live process state, equivalent to the legacy single-threaded behavior.
     /// </summary>
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenATaskEnvironmentDefault
     {
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAWriteAppConfigWithSupportedRuntimeMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAWriteAppConfigWithSupportedRuntimeMultiThreading.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.CurrentDirectory)]
     public class GivenAWriteAppConfigWithSupportedRuntimeMultiThreading : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenAWriteAppConfigWithSupportedRuntimeMultiThreading.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenAWriteAppConfigWithSupportedRuntimeMultiThreading.cs
@@ -10,7 +10,7 @@ using Microsoft.Build.Framework;
 namespace Microsoft.NET.Build.Tasks.UnitTests
 {
     [TestClass]
-    [ResourceLock(WellKnownResources.CurrentDirectory)]
+    [DoNotParallelize]
     public class GivenAWriteAppConfigWithSupportedRuntimeMultiThreading : IDisposable
     {
         private readonly List<string> _tempDirs = new();

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
@@ -18,6 +18,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests;
 /// passing RELATIVE paths and expecting tasks to resolve them via TaskEnvironment.
 /// </summary>
 [TestClass]
+[ResourceLock(WellKnownResources.CurrentDirectory)]
 public class GivenTasksUseAbsolutePaths : IDisposable
 {
     private readonly TaskTestEnvironment _env;

--- a/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/GivenTasksUseAbsolutePaths.cs
@@ -18,7 +18,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests;
 /// passing RELATIVE paths and expecting tasks to resolve them via TaskEnvironment.
 /// </summary>
 [TestClass]
-[ResourceLock(WellKnownResources.CurrentDirectory)]
+[DoNotParallelize]
 public class GivenTasksUseAbsolutePaths : IDisposable
 {
     private readonly TaskTestEnvironment _env;

--- a/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
@@ -6,8 +6,8 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <!-- CWD-mutating tests must run serially; emits [assembly: DoNotParallelize]. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
+    <!-- CWD-mutating test classes use a shared resource lock. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Build.Tasks.Tests/Microsoft.NET.Build.Tasks.Tests.csproj
@@ -6,7 +6,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
-    <!-- CWD-mutating test classes use a shared resource lock. -->
+    <!-- CWD-mutating classes run in the serial tail because existing relative-path readers do not acquire a lock. -->
     <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>

--- a/test/Microsoft.NET.Clean.Tests/Microsoft.NET.Clean.Tests.csproj
+++ b/test/Microsoft.NET.Clean.Tests/Microsoft.NET.Clean.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.ILLink.Tests/Microsoft.NET.ILLink.Tests.csproj
+++ b/test/Microsoft.NET.ILLink.Tests/Microsoft.NET.ILLink.Tests.csproj
@@ -6,6 +6,7 @@
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
     <PackageId>testSdkILLink</PackageId>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.NET.Infrastructure.Tests/Microsoft.NET.Infrastructure.Tests.csproj
+++ b/test/Microsoft.NET.Infrastructure.Tests/Microsoft.NET.Infrastructure.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
@@ -102,7 +102,7 @@ namespace Microsoft.NET.Pack.Tests
         public void It_packs_with_release_if_PackRelease_property_set_in_csproj(string valueOfPackRelease)
         {
             var helloWorldAsset = TestAssetsManager
-               .CopyTestAsset("HelloWorld")
+               .CopyTestAsset("HelloWorld", identifier: valueOfPackRelease)
                .WithSource()
                .WithProjectChanges(project =>
                {

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Rebuild.Tests/Microsoft.NET.Rebuild.Tests.csproj
+++ b/test/Microsoft.NET.Rebuild.Tests/Microsoft.NET.Rebuild.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
@@ -6,6 +6,7 @@
 namespace Microsoft.NET.Restore.Tests
 {
     [TestClass]
+    [ResourceLock(RestoreTestResources.NuGetCache)]
     public class GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages : SdkTest
     {
         [TestMethod]

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreDotNetCliToolReference.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreDotNetCliToolReference.cs
@@ -10,6 +10,7 @@ using NuGet.ProjectModel;
 namespace Microsoft.NET.Restore.Tests
 {
     [TestClass]
+    [ResourceLock(RestoreTestResources.NuGetCache)]
     public class GivenThatWeWantToRestoreDotNetCliToolReference : SdkTest
     {
         private const string ProjectToolVersion = "1.0.0";

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
@@ -11,6 +11,7 @@ using NuGet.Packaging.Signing;
 namespace Microsoft.NET.Restore.Tests
 {
     [TestClass]
+    [ResourceLock(RestoreTestResources.NuGetCache)]
     public class GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties : SdkTest
     {
         [TestMethod]

--- a/test/Microsoft.NET.Restore.Tests/Microsoft.NET.Restore.Tests.csproj
+++ b/test/Microsoft.NET.Restore.Tests/Microsoft.NET.Restore.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Restore.Tests/RestoreTestResources.cs
+++ b/test/Microsoft.NET.Restore.Tests/RestoreTestResources.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Restore.Tests;
+
+internal static class RestoreTestResources
+{
+    public const string NuGetCache = "Restore.NuGetCache";
+}

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests/Microsoft.NET.Sdk.BlazorWebAssembly.AoT.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.BlazorWebAssembly.Tests/Microsoft.NET.Sdk.BlazorWebAssembly.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EnvironmentHelperTests.cs
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EnvironmentHelperTests.cs
@@ -6,6 +6,7 @@
 namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public class EnvironmentHelperTests
     {
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";
@@ -22,17 +23,20 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         {
             // Arrange
             string originalValue = Environment.GetEnvironmentVariable(TelemetryOptout);
-            Environment.SetEnvironmentVariable(TelemetryOptout, value);
+            try
+            {
+                Environment.SetEnvironmentVariable(TelemetryOptout, value);
 
-            // Act
-            bool actualOutput = EnvironmentHelper.GetEnvironmentVariableAsBool(TelemetryOptout);
+                // Act
+                bool actualOutput = EnvironmentHelper.GetEnvironmentVariableAsBool(TelemetryOptout);
 
-
-            // Assert
-            Assert.AreEqual<bool>(expectedOutput, actualOutput);
-
-            // reset the value back to the original value
-            Environment.SetEnvironmentVariable(TelemetryOptout, originalValue);
+                // Assert
+                Assert.AreEqual<bool>(expectedOutput, actualOutput);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(TelemetryOptout, originalValue);
+            }
         }
     }
 }

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
@@ -9,6 +9,7 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(SdkTargetFramework)</TargetFrameworks>
 
     <AssemblyName>Microsoft.NET.Sdk.Publish.Tasks.Tests</AssemblyName>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <EndToEndTestsDisabled>true</EndToEndTestsDisabled>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>

--- a/test/Microsoft.NET.Sdk.Razor.Tests/Microsoft.NET.Sdk.Razor.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/Microsoft.NET.Sdk.Razor.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Sdk.Razor.Tests/Microsoft.NET.Sdk.Razor.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/Microsoft.NET.Sdk.Razor.Tests.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
-    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
+    <!-- Integration tests share the Razor build server, which can cross-contaminate concurrent project builds. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Sdk.Razor.Tool.Tests/Microsoft.NET.Sdk.Razor.Tool.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Razor.Tool.Tests/Microsoft.NET.Sdk.Razor.Tool.Tests.csproj
@@ -4,6 +4,7 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerCommandTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerCommandTest.cs
@@ -6,6 +6,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using Microsoft.CodeAnalysis;
+using Microsoft.NET.TestFramework;
 using Moq;
 
 namespace Microsoft.NET.Sdk.Razor.Tool
@@ -56,6 +57,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void GetPidFilePath_ReturnsCorrectDefaultPath()
         {
             // Arrange
@@ -69,10 +71,12 @@ namespace Microsoft.NET.Sdk.Razor.Tool
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void GetPidFilePath_UsesEnvironmentVariablePathIfSpecified()
         {
             // Arrange
             var expectedPath = "/Some/directory/path/";
+            var previousPath = Environment.GetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY");
             Environment.SetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY", expectedPath);
             try
             {
@@ -84,7 +88,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             }
             finally
             {
-                Environment.SetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY", "");
+                Environment.SetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY", previousPath);
             }
         }
 

--- a/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerLifecycleTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerLifecycleTest.cs
@@ -10,6 +10,7 @@ using Microsoft.NET.TestFramework;
 namespace Microsoft.NET.Sdk.Razor.Tool.Tests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public class ServerLifecycleTest
     {
         public TestContext TestContext { get; set; }

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ComputeStaticWebAssetsTargetPathsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/ComputeStaticWebAssetsTargetPathsMultiThreadingTest.cs
@@ -14,6 +14,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class ComputeStaticWebAssetsTargetPathsMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/Microsoft.NET.Sdk.StaticWebAssets.Tests.csproj
@@ -10,15 +10,10 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- These tests were authored for xUnit with assembly-wide parallelization disabled
-         ([assembly: CollectionBehavior(DisableTestParallelization = true)]). They are not parallel-safe:
-         many integration tests in the same class share fixed test asset directories (e.g. helpers like
-         BuildFrameworkAssetsConsumer reuse the same [CallerMemberName]-derived path), and several task
-         tests mutate the process-global current directory via Directory.SetCurrentDirectory. Running any
-         of them concurrently causes file-in-use, file-already-exists, missing-metadata, and deleted-cwd
-         (GetCwd) races. Override the repo-wide MethodLevel default with None, which emits
-         [assembly: DoNotParallelize] to preserve the original fully-serialized semantics. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
+    <!-- Preserve same-class serialization because integration-test helpers share fixed asset directories
+         and caches. Tests that mutate the process current directory use DoNotParallelize: a ResourceLock
+         on only the writers cannot protect unrelated tests that implicitly resolve paths against CWD. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/CollectStaticWebAssetsToCopyMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/CollectStaticWebAssetsToCopyMultiThreadingTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Razor.Tasks;
 
+[DoNotParallelize]
 [TestClass]
 public class CollectStaticWebAssetsToCopyMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ComputeEndpointsForReferenceStaticWebAssetsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ComputeEndpointsForReferenceStaticWebAssetsMultiThreadingTest.cs
@@ -15,6 +15,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class ComputeEndpointsForReferenceStaticWebAssetsMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ComputeReferenceStaticWebAssetItemsTest.cs
@@ -437,6 +437,8 @@ namespace Microsoft.NET.Sdk.StaticWebAssets.Tests
             task.StaticWebAssets[0].GetMetadata("AssetGroups").Should().Be("MyGroup");
         }
 
+        // ResourceLock cannot protect unrelated tests that implicitly read the process current directory.
+        [DoNotParallelize]
         [TestMethod]
         public void MakeReferencedAssetOriginalItemSpecAbsolute_ResolvesAgainstProjectDirectoryNotProcessCurrentDirectory()
         {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ConcatenateCssFilesMultiThreadingTest.cs
@@ -10,9 +10,7 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Razor.Tasks;
 
-// Test parallelization is disabled assembly-wide: the MSTest.Sdk project sets
-// MSTestParallelizeScope=None, which emits [assembly: DoNotParallelize] and runs
-// tests sequentially, isolating the process-CWD mutation this test performs.
+[DoNotParallelize]
 [TestClass]
 public class ConcatenateCssFilesMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DefineStaticWebAssetsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DefineStaticWebAssetsMultiThreadingTest.cs
@@ -11,9 +11,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-// Test parallelization is disabled assembly-wide: the MSTest.Sdk project sets
-// MSTestParallelizeScope=None, which emits [assembly: DoNotParallelize] and runs
-// tests sequentially, isolating the process-CWD mutation this test performs.
+[DoNotParallelize]
 [TestClass]
 public class DefineStaticWebAssetsMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverPrecompressedAssetsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/DiscoverPrecompressedAssetsMultiThreadingTest.cs
@@ -14,6 +14,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class DiscoverPrecompressedAssetsMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/FilterStaticWebAssetEndpointsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/FilterStaticWebAssetEndpointsMultiThreadingTest.cs
@@ -9,9 +9,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests.StaticWebAssets;
 
-// Test parallelization is disabled assembly-wide: the MSTest.Sdk project sets
-// MSTestParallelizeScope=None, which emits [assembly: DoNotParallelize] and runs
-// tests sequentially, isolating the process-CWD mutation this test performs.
+[DoNotParallelize]
 [TestClass]
 public class FilterStaticWebAssetEndpointsMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsManifestMultiThreadingTest.cs
@@ -9,9 +9,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-// Test parallelization is disabled assembly-wide: the MSTest.Sdk project sets
-// MSTestParallelizeScope=None, which emits [assembly: DoNotParallelize] and runs
-// tests sequentially, isolating the process-CWD mutation this test performs.
+[DoNotParallelize]
 [TestClass]
 public class GenerateStaticWebAssetEndpointsManifestMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetEndpointsPropsFileTest.cs
@@ -166,10 +166,13 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
         errorMessages[0].Should().Be($"""The asset file '{Path.GetFullPath(Path.Combine("wwwroot", "js", "sample.js"))}' specified in the endpoint '{Path.Combine("js","sample.js").Replace('\\', '/')}' does not exist.""");
     }
 
+    // ResourceLock cannot protect unrelated tests that implicitly read the process current directory.
+    [DoNotParallelize]
     [TestMethod]
     public void Execute_RelativeTargetPropsFilePath_ResolvesAgainstProjectDirectory_NotProcessCurrentDirectory() =>
         AssertWritesEndpointsPropsFileRelativeToTaskEnvironmentProjectDirectory("endpoints.props");
 
+    [DoNotParallelize]
     [TestMethod]
     [OSCondition(OperatingSystems.Windows)]
     public void Execute_WhitespaceTargetPropsFilePath_FailsOnWindows()
@@ -182,6 +185,7 @@ public class GenerateStaticWebAssetEndpointsPropsFileTest
         });
     }
 
+    [DoNotParallelize]
     [TestMethod]
     [OSCondition(ConditionMode.Exclude, OperatingSystems.Windows)]
     public void Execute_WhitespaceTargetPropsFilePath_WritesRelativeToTaskEnvironmentProjectDirectoryOnUnix() =>

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsDevelopmentManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsDevelopmentManifestMultiThreadingTest.cs
@@ -10,9 +10,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
-// These tests mutate the process current directory, so they must run sequentially.
-// The project disables parallelization (MSTestParallelizeScope=None) and
-// [DoNotParallelize] enforces that for this class.
+// ResourceLock cannot protect unrelated tests that implicitly read the process current directory.
 [DoNotParallelize]
 [TestClass]
 public class GenerateStaticWebAssetsDevelopmentManifestMultiThreadingTest

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsManifestMultiThreadingTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class GenerateStaticWebAssetsManifestMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/GenerateStaticWebAssetsPropsFileMultiThreadingTest.cs
@@ -10,6 +10,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class GenerateStaticWebAssetsPropsFileMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/MergeConfigurationPropertiesMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/MergeConfigurationPropertiesMultiThreadingTest.cs
@@ -16,6 +16,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class MergeConfigurationPropertiesMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ReadStaticWebAssetsManifestFileMultiThreadingTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Razor.Tasks;
 
+[DoNotParallelize]
 [TestClass]
 public class ReadStaticWebAssetsManifestFileMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ResolveCompressedAssetsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/ResolveCompressedAssetsMultiThreadingTest.cs
@@ -9,6 +9,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class ResolveCompressedAssetsMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetTaskEnvironmentTests.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetTaskEnvironmentTests.cs
@@ -15,6 +15,7 @@ using Microsoft.Build.Utilities;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class StaticWebAssetTaskEnvironmentTests
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackManifestMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackManifestMultiThreadingTest.cs
@@ -10,6 +10,7 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Razor.Tasks;
 
+[DoNotParallelize]
 [TestClass]
 public class StaticWebAssetsGeneratePackManifestMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest.cs
@@ -15,6 +15,7 @@ using Moq;
 
 namespace Microsoft.AspNetCore.Razor.Tasks;
 
+[DoNotParallelize]
 [TestClass]
 public class StaticWebAssetsGeneratePackagePropsFileMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/UpdatePackageStaticWebAssetsMultiThreadingTest.cs
+++ b/test/Microsoft.NET.Sdk.StaticWebAssets.Tests/StaticWebAssets/UpdatePackageStaticWebAssetsMultiThreadingTest.cs
@@ -10,6 +10,7 @@ using Moq;
 
 namespace Microsoft.NET.Sdk.StaticWebAssets.Tests;
 
+[DoNotParallelize]
 [TestClass]
 public class UpdatePackageStaticWebAssetsMultiThreadingTest
 {

--- a/test/Microsoft.NET.Sdk.Web.Tests/Microsoft.NET.Sdk.Web.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Web.Tests/Microsoft.NET.Sdk.Web.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net472;$(SdkTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(SdkTargetFramework)</TargetFrameworks>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <!-- Test classes either use immutable inputs or isolated TestAssetsManager directories. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
 
     <!-- By default test projects don't append TargetFramework to output path, but for multi-targeted tests
          we need to -->

--- a/test/Microsoft.NET.ToolPack.Tests/Microsoft.NET.ToolPack.Tests.csproj
+++ b/test/Microsoft.NET.ToolPack.Tests/Microsoft.NET.ToolPack.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
+++ b/test/Microsoft.WebTools.AspireService.Tests/Microsoft.WebTools.AspireService.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <RootNamespace>Microsoft.WebTools.AspireServer.UnitTests</RootNamespace>
+    <!-- Keep server tests serial within their class because port discovery and Kestrel binding are not atomic. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
+++ b/test/Microsoft.Win32.Msi.Tests/Microsoft.Win32.Msi.Tests.csproj
@@ -5,6 +5,8 @@
     <OutputType Condition="'$(TargetFramework)' == '$(SdkTargetFramework)'">Exe</OutputType>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <!-- Tests only parse messages or query Windows Installer with invalid and unknown product codes. -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/System.CommandLine.StaticCompletions.Tests/System.CommandLine.StaticCompletions.Tests.csproj
+++ b/test/System.CommandLine.StaticCompletions.Tests/System.CommandLine.StaticCompletions.Tests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsTestProject>true</IsTestProject>
     <OutputType>Exe</OutputType>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ExportCommandFailureTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ExportCommandFailureTests.cs
@@ -10,6 +10,8 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
     [TestClass]
     public class ExportCommandFailureTests : IDisposable
     {
+        private readonly CultureInfo _originalCurrentCulture;
+        private readonly CultureInfo _originalCurrentUICulture;
         private readonly string _workingDirectory;
 
         public TestContext TestContext { get; set; } = null!;
@@ -18,6 +20,8 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 
         public ExportCommandFailureTests()
         {
+            _originalCurrentCulture = CultureInfo.CurrentCulture;
+            _originalCurrentUICulture = CultureInfo.CurrentUICulture;
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
@@ -27,7 +31,15 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 
         public void Dispose()
         {
-            Directory.Delete(_workingDirectory, true);
+            try
+            {
+                Directory.Delete(_workingDirectory, true);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = _originalCurrentCulture;
+                CultureInfo.CurrentUICulture = _originalCurrentUICulture;
+            }
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/Microsoft.TemplateEngine.Authoring.CLI.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/Microsoft.TemplateEngine.Authoring.CLI.UnitTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <Import Project="Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests.Shared.props" />
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests.csproj
@@ -3,6 +3,7 @@
   <Import Project="Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests.Shared.props" />
 
   <PropertyGroup>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <!-- Test classes use isolated settings helpers, while methods within several classes share
+         mutable package providers, package-manager state, and culture-sensitive fixtures. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsTestProject>true</IsTestProject>
+    <!-- Test classes have independent inputs and working directories. Preserve method isolation
+         so each StringUpdaterTests instance exclusively owns its temporary directory. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
@@ -4,6 +4,9 @@
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Test classes have isolated fixtures, but methods in environment-backed classes share
+         class-scoped EnvironmentSettingsHelper instances. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsTestProject>true</IsTestProject>
+    <!-- Test classes use separate virtualized environments, while methods within each class share
+         an EnvironmentSettingsHelper and, in some cases, mutable search-provider fixtures. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
+    <!-- Keep each integration-test class serial because TemplateDiscoveryTests methods pack into
+         shared package output locations and invoke tools against class-local hives. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
+++ b/test/dotnet-MsiInstallation.Tests/dotnet-MsiInstallation.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
     <RunSettingsFilePath>$(MSBuildThisFileDirectory)\dotnet-MsiInstallation.Tests.runsettings</RunSettingsFilePath>
+    <!-- Every test class shares one Hyper-V VM and persisted snapshot graph, so class-level locking would still serialize the assembly. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/dotnet-aot.Tests/AotParserTests.cs
+++ b/test/dotnet-aot.Tests/AotParserTests.cs
@@ -21,6 +21,8 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  <see cref="CommandNotAvailableInAotException"/> so the bridge can fall back.
 /// </summary>
 [TestClass]
+[ResourceLock(nameof(Reporter))]
+[ResourceLock(WellKnownResources.Console)]
 public partial class AotParserTests
 {
     private static Exception? RecordException(Action action)

--- a/test/dotnet-aot.Tests/AotRunCommandTests.cs
+++ b/test/dotnet-aot.Tests/AotRunCommandTests.cs
@@ -16,6 +16,9 @@ namespace Microsoft.DotNet.Cli.Tests;
 /// Tests Native AOT file-based run planning and launch invocation construction.
 /// </summary>
 [TestClass]
+[ResourceLock(nameof(NativeEntryPoint))]
+[ResourceLock(nameof(Reporter))]
+[ResourceLock(WellKnownResources.EnvironmentVariables)]
 public class AotRunCommandTests
 {
     /// <summary>Verifies that an explicit no-build invocation reaches the launcher without prevalidating output.</summary>

--- a/test/dotnet-aot.Tests/EnvironmentProviderTests.cs
+++ b/test/dotnet-aot.Tests/EnvironmentProviderTests.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Cli.Utils;
 namespace Microsoft.DotNet.Cli.Tests;
 
 [TestClass]
+[ResourceLock(nameof(SdkDirectoryScope))]
 public class EnvironmentProviderTests
 {
     [TestMethod]

--- a/test/dotnet-aot.Tests/FileBasedAppRunPlanTests.cs
+++ b/test/dotnet-aot.Tests/FileBasedAppRunPlanTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.Cli.Tests;
 /// Tests shared file-based application build and launch planning.
 /// </summary>
 [TestClass]
+[ResourceLock(nameof(Reporter))]
 public class FileBasedAppRunPlanTests
 {
     /// <summary>Verifies that a fresh simple application selects direct compilation.</summary>

--- a/test/dotnet-aot.Tests/FormatForwardingAppTests.cs
+++ b/test/dotnet-aot.Tests/FormatForwardingAppTests.cs
@@ -6,6 +6,7 @@ using Microsoft.DotNet.Cli.Commands.Format;
 namespace Microsoft.DotNet.Cli.Tests;
 
 [TestClass]
+[ResourceLock(nameof(SdkDirectoryScope))]
 public class FormatForwardingAppTests
 {
     [TestMethod]

--- a/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
+++ b/test/dotnet-aot.Tests/MSBuildEvaluationTests.cs
@@ -13,6 +13,7 @@ using Microsoft.DotNet.Cli.Utils;
 namespace Microsoft.DotNet.Cli.Tests;
 
 [TestClass]
+[ResourceLock(nameof(SdkDirectoryScope))]
 public class MSBuildEvaluationTests
 {
     public TestContext TestContext { get; set; } = null!;

--- a/test/dotnet-aot.Tests/NativeEntryPointTests.cs
+++ b/test/dotnet-aot.Tests/NativeEntryPointTests.cs
@@ -15,6 +15,11 @@ namespace Microsoft.DotNet.Cli.Tests;
 ///  "managed fallback not found" error because test env doesn't have dotnet.dll in sdkDir.
 /// </summary>
 [TestClass]
+[ResourceLock(nameof(NativeEntryPoint))]
+[ResourceLock(nameof(Reporter))]
+[ResourceLock(nameof(SdkDirectoryScope))]
+[ResourceLock(WellKnownResources.Console)]
+[ResourceLock(WellKnownResources.EnvironmentVariables)]
 public partial class NativeEntryPointTests
 {
     /// <summary>
@@ -30,6 +35,8 @@ public partial class NativeEntryPointTests
         string? originalTraceState = Environment.GetEnvironmentVariable(Activities.TRACESTATE);
         string? originalTelemetryOptout = Environment.GetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT");
         object? originalSdkRoot = AppContext.GetData(SdkPaths.DataName);
+        string? originalDotnetRoot = NativeEntryPoint.DotnetRoot;
+        string? originalSdkDirectory = NativeEntryPoint.SdkDirectory;
         try
         {
             action();
@@ -42,6 +49,9 @@ public partial class NativeEntryPointTests
             Environment.SetEnvironmentVariable(Activities.TRACESTATE, originalTraceState);
             Environment.SetEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", originalTelemetryOptout);
             AppContext.SetData(SdkPaths.DataName, originalSdkRoot);
+            NativeEntryPoint.DotnetRoot = originalDotnetRoot;
+            NativeEntryPoint.SdkDirectory = originalSdkDirectory;
+            SdkPaths.ClearSdkDirectoryCacheForTests();
         }
     }
 

--- a/test/dotnet-aot.Tests/SdkForwardingAppTests.cs
+++ b/test/dotnet-aot.Tests/SdkForwardingAppTests.cs
@@ -7,6 +7,8 @@ using Microsoft.DotNet.Cli.Commands.Test;
 namespace Microsoft.DotNet.Cli.Tests;
 
 [TestClass]
+[ResourceLock(nameof(SdkDirectoryScope))]
+[ResourceLock(WellKnownResources.EnvironmentVariables)]
 public class SdkForwardingAppTests
 {
     [TestMethod]

--- a/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
+++ b/test/dotnet-aot.Tests/dotnet-aot.Tests.csproj
@@ -6,8 +6,9 @@
     <DefineConstants>$(DefineConstants);CLI_AOT</DefineConstants>
     <RootNamespace>Microsoft.DotNet.Cli.Tests</RootNamespace>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
-    <!-- Tests modify process-global state; run serially. None makes MSTest.Sdk emit [assembly: DoNotParallelize]. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
+    <!-- Methods within a class share fixtures and process state. Audited classes use
+         ResourceLock for the process-global resources they share with other classes. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
 
     <!-- Strong naming deprecated on .NET Core -->
     <NoWarn>$(NoWarn);CS8002</NoWarn>

--- a/test/dotnet.Tests/CommandFactoryTests/GivenAProjectDependencyCommandResolver.cs
+++ b/test/dotnet.Tests/CommandFactoryTests/GivenAProjectDependencyCommandResolver.cs
@@ -9,17 +9,30 @@ using Microsoft.DotNet.Cli.Utils;
 namespace Microsoft.DotNet.Tests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public class GivenAProjectDependencyCommandResolver : SdkTest
     {
         private string _configuration;
+        private string _originalMSBuildExePath;
 
         public GivenAProjectDependencyCommandResolver()
         {
+            _configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
+        }
+
+        [TestInitialize]
+        public void SetMSBuildExePath()
+        {
+            _originalMSBuildExePath = Environment.GetEnvironmentVariable(Constants.MSBUILD_EXE_PATH);
             Environment.SetEnvironmentVariable(
                 Constants.MSBUILD_EXE_PATH,
                 Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "MSBuild.dll"));
+        }
 
-            _configuration = Environment.GetEnvironmentVariable("CONFIGURATION") ?? "Debug";
+        [TestCleanup]
+        public void RestoreMSBuildExePath()
+        {
+            Environment.SetEnvironmentVariable(Constants.MSBUILD_EXE_PATH, _originalMSBuildExePath);
         }
 
         [TestMethod]
@@ -162,10 +175,6 @@ namespace Microsoft.DotNet.Tests
             IEnvironmentProvider environment = null,
             IPackagedCommandSpecFactory packagedCommandSpecFactory = null)
         {
-            Environment.SetEnvironmentVariable(
-                Constants.MSBUILD_EXE_PATH,
-                Path.Combine(SdkTestContext.Current.ToolsetUnderTest.SdkFolderUnderTest, "MSBuild.dll"));
-
             environment = environment ?? new EnvironmentProvider();
 
             packagedCommandSpecFactory = packagedCommandSpecFactory ?? new PackagedCommandSpecFactory();

--- a/test/dotnet.Tests/CommandTests/Hidden/Complete/CompleteCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Hidden/Complete/CompleteCommandTests.cs
@@ -336,16 +336,19 @@ namespace Microsoft.DotNet.Tests.Commands
         }
 
         [TestMethod]
+        // CurrentDirectory and CliCompletionsTimeout are process-wide and are used by code that cannot participate in a resource lock.
+        [DoNotParallelize]
         public void CompletesNugetPackageIds()
         {
-            NuGetPackageDownloader.CliCompletionsTimeout = TimeSpan.FromDays(1);
             var testAsset = TestAssetsManager.CopyTestAsset("NugetCompletion").WithSource();
+            var originalTimeout = NuGetPackageDownloader.CliCompletionsTimeout;
 
             string[] expected = ["Newtonsoft.Json"];
             var reporter = new BufferedReporter();
             var currentDirectory = Directory.GetCurrentDirectory();
             try
             {
+                NuGetPackageDownloader.CliCompletionsTimeout = TimeSpan.FromDays(1);
                 Directory.SetCurrentDirectory(testAsset.Path);
                 CompleteCommand.RunWithReporter(GetArguments("dotnet add package Newt$"), reporter).Should().Be(0);
                 reporter.Lines.Should().Contain(expected);
@@ -353,14 +356,17 @@ namespace Microsoft.DotNet.Tests.Commands
             finally
             {
                 Directory.SetCurrentDirectory(currentDirectory);
+                NuGetPackageDownloader.CliCompletionsTimeout = originalTimeout;
             }
         }
 
         [TestMethod]
+        // CurrentDirectory and CliCompletionsTimeout are process-wide and are used by code that cannot participate in a resource lock.
+        [DoNotParallelize]
         public void CompletesNugetPackageVersions()
         {
-            NuGetPackageDownloader.CliCompletionsTimeout = TimeSpan.FromDays(1);
             var testAsset = TestAssetsManager.CopyTestAsset("NugetCompletion").WithSource();
+            var originalTimeout = NuGetPackageDownloader.CliCompletionsTimeout;
 
             string knownPackage = "Newtonsoft.Json";
             string knownVersion = "13.0.1"; // not exhaustive
@@ -368,6 +374,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var currentDirectory = Directory.GetCurrentDirectory();
             try
             {
+                NuGetPackageDownloader.CliCompletionsTimeout = TimeSpan.FromDays(1);
                 Directory.SetCurrentDirectory(testAsset.Path);
                 CompleteCommand.RunWithReporter(GetArguments($"dotnet add package {knownPackage} --version $"), reporter).Should().Be(0);
                 reporter.Lines.Should().Contain(knownVersion);
@@ -375,14 +382,17 @@ namespace Microsoft.DotNet.Tests.Commands
             finally
             {
                 Directory.SetCurrentDirectory(currentDirectory);
+                NuGetPackageDownloader.CliCompletionsTimeout = originalTimeout;
             }
         }
 
         [TestMethod]
+        // CurrentDirectory and CliCompletionsTimeout are process-wide and are used by code that cannot participate in a resource lock.
+        [DoNotParallelize]
         public void CompletesNugetPackageVersionsWithStem()
         {
-            NuGetPackageDownloader.CliCompletionsTimeout = TimeSpan.FromDays(1);
             var testAsset = TestAssetsManager.CopyTestAsset("NugetCompletion").WithSource();
+            var originalTimeout = NuGetPackageDownloader.CliCompletionsTimeout;
 
             string knownPackage = "Newtonsoft.Json";
             string knownVersion = "13.0"; // not exhaustive
@@ -391,6 +401,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var currentDirectory = Directory.GetCurrentDirectory();
             try
             {
+                NuGetPackageDownloader.CliCompletionsTimeout = TimeSpan.FromDays(1);
                 Directory.SetCurrentDirectory(testAsset.Path);
                 CompleteCommand.RunWithReporter(GetArguments($"dotnet add package {knownPackage} --version {knownVersion}$"), reporter).Should().Be(0);
                 reporter.Lines.Should().Contain(expectedVersions);
@@ -401,14 +412,17 @@ namespace Microsoft.DotNet.Tests.Commands
             finally
             {
                 Directory.SetCurrentDirectory(currentDirectory);
+                NuGetPackageDownloader.CliCompletionsTimeout = originalTimeout;
             }
         }
 
         [TestMethod]
+        // CurrentDirectory and CliCompletionsTimeout are process-wide and are used by code that cannot participate in a resource lock.
+        [DoNotParallelize]
         public void CompletesNugetPackageVersionsWithPrereleaseVersionsWhenSpecified()
         {
-            NuGetPackageDownloader.CliCompletionsTimeout = TimeSpan.FromDays(1);
             var testAsset = TestAssetsManager.CopyTestAsset("NugetCompletion").WithSource();
+            var originalTimeout = NuGetPackageDownloader.CliCompletionsTimeout;
 
             string knownPackage = "Spectre.Console";
             string knownVersion = "0.49.1";
@@ -417,6 +431,7 @@ namespace Microsoft.DotNet.Tests.Commands
             var currentDirectory = Directory.GetCurrentDirectory();
             try
             {
+                NuGetPackageDownloader.CliCompletionsTimeout = TimeSpan.FromDays(1);
                 Directory.SetCurrentDirectory(testAsset.Path);
                 CompleteCommand.RunWithReporter(GetArguments($"dotnet add package {knownPackage} --prerelease --version {knownVersion}$"), reporter).Should().Be(0);
                 reporter.Lines.Should().Equal(expectedVersions);
@@ -424,6 +439,7 @@ namespace Microsoft.DotNet.Tests.Commands
             finally
             {
                 Directory.SetCurrentDirectory(currentDirectory);
+                NuGetPackageDownloader.CliCompletionsTimeout = originalTimeout;
             }
         }
 

--- a/test/dotnet.Tests/CommandTests/MSBuild/DotnetMsbuildInProcTests.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/DotnetMsbuildInProcTests.cs
@@ -11,6 +11,8 @@ using Microsoft.DotNet.Configurer;
 namespace Microsoft.DotNet.Cli.MSBuild.Tests
 {
     [TestClass]
+    // TelemetryClient static state is process-wide and is accessed by code that cannot participate in a resource lock.
+    [DoNotParallelize]
     public class DotnetMsbuildInProcTests : SdkTest
     {
         public DotnetMsbuildInProcTests()

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetBuildInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetBuildInvocation.cs
@@ -125,11 +125,15 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         [DynamicData(nameof(TelemetryCommonPropertiesTests.LLMTelemetryTestCases), typeof(TelemetryCommonPropertiesTests))]
         public void WhenLLMIsDetectedTLLiveUpdateIsDisabled(Dictionary<string, string>? llmEnvVarsToSet, string? expectedLLMName)
         {
             CommandDirectoryContext.PerformActionWithBasePath(WorkingDirectory, () =>
             {
+                var originalValues = llmEnvVarsToSet?
+                    .ToDictionary(pair => pair.Key, pair => Environment.GetEnvironmentVariable(pair.Key));
+
                 try
                 {
                     // Set environment variables to simulate LLM environment
@@ -154,12 +158,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 }
                 finally
                 {
-                    // Clear the environment variables after the test
-                    if (llmEnvVarsToSet is not null)
+                    if (originalValues is not null)
                     {
-                        foreach (var (key, value) in llmEnvVarsToSet)
+                        foreach (var (key, value) in originalValues)
                         {
-                            Environment.SetEnvironmentVariable(key, null);
+                            Environment.SetEnvironmentVariable(key, value);
                         }
                     }
                 }
@@ -167,4 +170,3 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
     }
 }
-

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRunInvocation.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetRunInvocation.cs
@@ -16,6 +16,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         private static readonly string NuGetDisabledProperty = "--property:NuGetInteractive=false";
 
         [TestMethod]
+        // CurrentDirectory is process-wide and is read by code throughout this project that cannot participate in a resource lock.
+        [DoNotParallelize]
         [DataRow(new string[] { "-p:prop1=true" }, new string[] { "--property:prop1=true" })]
         [DataRow(new string[] { "--property:prop1=true" }, new string[] { "--property:prop1=true" })]
         [DataRow(new string[] { "--property", "prop1=true" }, new string[] { "--property:prop1=true" })]
@@ -62,4 +64,3 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
     }
 }
-

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetVsTestForwardingApp.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetVsTestForwardingApp.cs
@@ -16,7 +16,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [TestMethod]
-        [ResourceLock(WellKnownResources.EnvironmentVariables)]
+        [DoNotParallelize] // Concurrent dotnet test processes inherit VSTEST_CONSOLE_PATH without acquiring an environment lock.
         public void ItCanUseEnvironmentVariableToForceCustomPathToVsTestApp()
         {
             string vsTestConsolePath = "VSTEST_CONSOLE_PATH";

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetVsTestForwardingApp.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenDotnetVsTestForwardingApp.cs
@@ -16,10 +16,12 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void ItCanUseEnvironmentVariableToForceCustomPathToVsTestApp()
         {
             string vsTestConsolePath = "VSTEST_CONSOLE_PATH";
             string dummyPath = Path.Join(Path.GetTempPath(), "vstest.custom.console.dll");
+            string? originalVsTestConsolePath = Environment.GetEnvironmentVariable(vsTestConsolePath);
 
             try
             {
@@ -29,9 +31,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(vsTestConsolePath, null);
+                Environment.SetEnvironmentVariable(vsTestConsolePath, originalVsTestConsolePath);
             }
         }
     }
 }
-

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
@@ -268,6 +268,8 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [TestMethod]
+        // ActivitySource listeners are process-wide and can observe activities from tests that do not use a matching resource lock.
+        [DoNotParallelize]
         public void ItCreatesAnInternalActivityForEachBuild()
         {
             ActivitySource activitySource = Activities.Source;
@@ -304,6 +306,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [TestMethod]
+        // ActivitySource listeners are process-wide and can observe activities from tests that do not use a matching resource lock.
         [DoNotParallelize]
         public void ItUsesTheCurrentParentContextForEachServerBuild()
         {

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMsbuildForwardingApp.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMsbuildForwardingApp.cs
@@ -109,6 +109,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [TestMethod]
+        // TelemetryClient static state is process-wide and is accessed by code that cannot participate in a resource lock.
         [DoNotParallelize]
         public void ItUsesSeededTelemetrySessionId()
         {
@@ -166,7 +167,7 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
         }
 
         [TestMethod]
-        [DoNotParallelize]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         [DataRow(null, "0")]
         [DataRow("", "0")]
         [DataRow("0", "0")]

--- a/test/dotnet.Tests/CommandTests/New/SdkInfoProviderTests.cs
+++ b/test/dotnet.Tests/CommandTests/New/SdkInfoProviderTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.DotNet.Cli.New.Tests
         public TestContext TestContext { get; set; } = null!;
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public async Task GetInstalledVersionsAsync_ShouldContainCurrentVersion()
         {
             string? dotnetRootUnderTest = SdkTestContext.Current.ToolsetUnderTest?.DotNetRoot;

--- a/test/dotnet.Tests/CommandTests/Pack/ReleasePropertyProjectLocatorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Pack/ReleasePropertyProjectLocatorTests.cs
@@ -6,7 +6,7 @@ using Microsoft.DotNet.Cli;
 namespace Microsoft.DotNet.Pack.Tests;
 
 [TestClass]
-[DoNotParallelize]
+[ResourceLock(WellKnownResources.EnvironmentVariables)]
 public class ReleasePropertyProjectLocatorTests : SdkTest
 {
     private string? _disablePublishAndPackRelease;

--- a/test/dotnet.Tests/CommandTests/Reference/Add/GivenDotnetAddReference.cs
+++ b/test/dotnet.Tests/CommandTests/Reference/Add/GivenDotnetAddReference.cs
@@ -134,12 +134,12 @@ Commands:
         [TestMethod]
         public void WhenTooManyArgumentsArePassedItPrintsError()
         {
-            if (!File.Exists("proj.csproj"))
-            {
-                File.Create("proj.csproj");
-            }
+            var testDirectory = TestAssetsManager.CreateTestDirectory().Path;
+            File.WriteAllText(Path.Combine(testDirectory, "proj.csproj"), string.Empty);
+
             var cmd = new DotnetCommand(Log, "add", "one", "two", "three", "reference")
-                    .Execute("proj.csproj");
+                .WithWorkingDirectory(testDirectory)
+                .Execute("proj.csproj");
             cmd.ExitCode.Should().NotBe(0);
             cmd.StdErr.Should().BeVisuallyEquivalentTo($@"{string.Format(CliStrings.UnrecognizedCommandOrArgument, "two")}
 {string.Format(CliStrings.UnrecognizedCommandOrArgument, "three")}");

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTestFixture.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTestFixture.cs
@@ -32,10 +32,9 @@ public sealed class RunFileTestFixture
             }
 
             RunFileTestBase.CopyNuGetConfigToRunfileDirectory();
-            string runFileDirectory = VirtualProjectBuilder.GetTempSubdirectory();
 
             new DotnetCommand(log, "run", "-")
-                .WithWorkingDirectory(runFileDirectory)
+                .WithWorkingDirectory(RunFileTestBase.OutOfTreeBaseDirectory)
                 .WithStandardInput("""
                     Console.WriteLine("Hello");
                     """)

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTestFixture.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTestFixture.cs
@@ -32,8 +32,10 @@ public sealed class RunFileTestFixture
             }
 
             RunFileTestBase.CopyNuGetConfigToRunfileDirectory();
+            string runFileDirectory = VirtualProjectBuilder.GetTempSubdirectory();
 
             new DotnetCommand(log, "run", "-")
+                .WithWorkingDirectory(runFileDirectory)
                 .WithStandardInput("""
                     Console.WriteLine("Hello");
                     """)

--- a/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
@@ -7,6 +7,8 @@ using Microsoft.NET.TestFramework;
 namespace Microsoft.DotNet.Tests.ParserTests
 {
     [TestClass]
+    // CurrentDirectory is process-wide and is read by code throughout this project that cannot participate in a resource lock.
+    [DoNotParallelize]
     public class RunParserTests : IDisposable
     {
         private readonly string _previousWorkingDirectory;

--- a/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestCommandParserTests.cs
@@ -125,6 +125,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void MTPCommandHonorsDotnetNoLogoEnvironmentVariable()
         {
             string? previousValue = Environment.GetEnvironmentVariable("DOTNET_NOLOGO");
@@ -280,6 +281,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         [DataRow("--collect-test-map")]
         [DataRow("--affected-tests")]
         public void MTPCommandAcceptsAffectedTestOptions(string option)
@@ -298,6 +300,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void MTPCommandRejectsAffectedTestOptionsTogether()
         {
             WithAffectedTestsFeature(enabled: true, () =>
@@ -311,6 +314,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         [DataRow("--collect-test-map")]
         [DataRow("--affected-tests")]
         public void MTPCommandRejectsAffectedTestOptionsWhenFeatureIsDisabled(string option)
@@ -328,6 +332,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void MTPCommandRejectsCollectTestMapWithParallelModules()
         {
             WithAffectedTestsFeature(enabled: true, () =>
@@ -606,6 +611,7 @@ namespace Microsoft.DotNet.Cli.Test.Tests
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void MTPCommandRejectsCollectTestMapWithMinimumExpectedTests()
         {
             WithAffectedTestsFeature(enabled: true, () =>

--- a/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Tool/Install/ToolInstallCommandTests.cs
@@ -36,6 +36,8 @@ namespace Microsoft.DotNet.Tests.Commands.Tool
 
         [TestMethod]
         [Ignore("https://github.com/dotnet/sdk/issues/42346")]
+        // CurrentDirectory is process-wide and is read by code throughout this project that cannot participate in a resource lock.
+        [DoNotParallelize]
         public void WhenRunWithRoot()
         {
             Directory.CreateDirectory("/tmp/folder/sub");

--- a/test/dotnet.Tests/ConfigurerTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
+++ b/test/dotnet.Tests/ConfigurerTests/GivenADotnetFirstTimeUseConfigurerWIthStateSetup.cs
@@ -11,6 +11,8 @@ using static Microsoft.DotNet.Configurer.UnitTests.GivenADotnetFirstTimeUseConfi
 namespace Microsoft.DotNet.Configurer.UnitTests
 {
     [TestClass]
+    // TelemetryClient static state is process-wide and is accessed by code that cannot participate in a resource lock.
+    [DoNotParallelize]
     public class GivenADotnetFirstTimeUseConfigurerWithStateSetup
     {
         private MockBasicSentinel _firstTimeUseNoticeSentinelMock;

--- a/test/dotnet.Tests/GivenParserDirectives.cs
+++ b/test/dotnet.Tests/GivenParserDirectives.cs
@@ -13,9 +13,11 @@ namespace Microsoft.DotNet.Tests
         [TestMethod]
         public void ItCanAcceptResponseFiles()
         {
-            File.WriteAllText(Path.Combine(Directory.GetCurrentDirectory(), "response.rsp"), "build");
+            var testDirectory = TestAssetsManager.CreateTestDirectory().Path;
+            File.WriteAllText(Path.Combine(testDirectory, "response.rsp"), "build");
             string[] args = new[] { @"@response.rsp", "-h" };
             new DotnetCommand(Log, args)
+                .WithWorkingDirectory(testDirectory)
                 .Execute()
                 .Should()
                 .Pass()

--- a/test/dotnet.Tests/ParserTests/CommonOptionsTests.cs
+++ b/test/dotnet.Tests/ParserTests/CommonOptionsTests.cs
@@ -8,10 +8,10 @@ using Microsoft.DotNet.Cli.CommandLine;
 namespace Microsoft.DotNet.Tests.ParserTests;
 
 [TestClass]
+[DoNotParallelize] // Child dotnet processes in other classes inherit Configuration without acquiring an environment lock.
 public class CommonOptionsTests
 {
     [TestMethod]
-    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public void ConfigurationDefaultsToEnvironmentVariable()
     {
         string? originalConfiguration = Environment.GetEnvironmentVariable("Configuration");
@@ -36,7 +36,6 @@ public class CommonOptionsTests
     }
 
     [TestMethod]
-    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public void ExplicitConfigurationOverridesEnvironmentVariable()
     {
         string? originalConfiguration = Environment.GetEnvironmentVariable("Configuration");
@@ -61,7 +60,6 @@ public class CommonOptionsTests
     }
 
     [TestMethod]
-    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     [DataRow("")]
     [DataRow(" ")]
     [DataRow("\t")]

--- a/test/dotnet.Tests/ParserTests/CommonOptionsTests.cs
+++ b/test/dotnet.Tests/ParserTests/CommonOptionsTests.cs
@@ -11,6 +11,7 @@ namespace Microsoft.DotNet.Tests.ParserTests;
 public class CommonOptionsTests
 {
     [TestMethod]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public void ConfigurationDefaultsToEnvironmentVariable()
     {
         string? originalConfiguration = Environment.GetEnvironmentVariable("Configuration");
@@ -35,6 +36,7 @@ public class CommonOptionsTests
     }
 
     [TestMethod]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public void ExplicitConfigurationOverridesEnvironmentVariable()
     {
         string? originalConfiguration = Environment.GetEnvironmentVariable("Configuration");
@@ -59,6 +61,7 @@ public class CommonOptionsTests
     }
 
     [TestMethod]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     [DataRow("")]
     [DataRow(" ")]
     [DataRow("\t")]

--- a/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
+++ b/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json;
 namespace Microsoft.DotNet.ProjectTools.Tests;
 
 [TestClass]
+[ResourceLock(WellKnownResources.EnvironmentVariables)]
 public class LaunchSettingsParserTests
 {
     private static readonly string s_environmentVariableName1 = $"TEST_VAR1_{GetUniqueName()}";
@@ -16,6 +17,13 @@ public class LaunchSettingsParserTests
     {
         Environment.SetEnvironmentVariable(s_environmentVariableName1, "ENV_VALUE1");
         Environment.SetEnvironmentVariable(s_environmentVariableName2, "ENV_VALUE2");
+    }
+
+    [ClassCleanup]
+    public static void RestoreEnvironmentVariables()
+    {
+        Environment.SetEnvironmentVariable(s_environmentVariableName1, null);
+        Environment.SetEnvironmentVariable(s_environmentVariableName2, null);
     }
 
     // The same syntax works on Windows and Unix ($VAR does not get expanded Unix).

--- a/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryClientTests.cs
@@ -32,6 +32,8 @@ public class TelemetryClientTests : SdkTest
     [TestMethod]
     [OSCondition(OperatingSystems.Windows)]
     [DynamicData(nameof(CommandsWithExitCode))]
+    // The build-server shutdown row affects per-user servers that tests throughout this project can use.
+    [DoNotParallelize]
     public void ItProcessesTelemetryData(string[] commandArgs, string exitCodeExpected)
     {
         var testDir = TestAssetsManager.CreateTestDirectory().Path;
@@ -75,6 +77,7 @@ public class TelemetryClientTests : SdkTest
 
     [TestMethod]
     [OSCondition(OperatingSystems.Windows)]
+    // The process-wide MSBuild server can also be used by tests that cannot participate in a resource lock.
     [DoNotParallelize]
     public void ItProcessesMSBuildTelemetryWithTheServerEnabled()
     {
@@ -146,6 +149,7 @@ public class TelemetryClientTests : SdkTest
     }
 
     [TestMethod]
+    // TelemetryClient static state is process-wide and is accessed by code that cannot participate in a resource lock.
     [DoNotParallelize]
     public void DisabledForTestsDoesNotInitializeTelemetry()
     {
@@ -167,6 +171,7 @@ public class TelemetryClientTests : SdkTest
     }
 
     [TestMethod]
+    // TelemetryClient static state is process-wide and is accessed by code that cannot participate in a resource lock.
     [DoNotParallelize]
     public void MSBuildLoggerDoesNotReinitializeDisabledTelemetry()
     {
@@ -195,6 +200,7 @@ public class TelemetryClientTests : SdkTest
     }
 
     [TestMethod]
+    // TelemetryClient static state is process-wide and is accessed by code that cannot participate in a resource lock.
     [DoNotParallelize]
     public void ItSeedsCurrentSessionIdFromEnvironmentWhenSessionIdIsNotProvided()
     {
@@ -225,6 +231,7 @@ public class TelemetryClientTests : SdkTest
     }
 
     [TestMethod]
+    // TelemetryClient static state is process-wide and is accessed by code that cannot participate in a resource lock.
     [DoNotParallelize]
     public void ItPrefersExplicitSessionIdOverEnvironmentSeed()
     {

--- a/test/dotnet.Tests/TelemetryTests/TelemetryCommonPropertiesTests.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryCommonPropertiesTests.cs
@@ -194,9 +194,14 @@ public class TelemetryCommonPropertiesTests : SdkTest
     }
 
     [TestMethod]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     [DynamicData(nameof(CITelemetryTestCases))]
     public void CanDetectCIStatusForEnvVars(Dictionary<string, string> envVars, bool expected)
     {
+        var originalValues = envVars.ToDictionary(
+            pair => pair.Key,
+            pair => Environment.GetEnvironmentVariable(pair.Key));
+
         try
         {
             foreach (var (key, value) in envVars)
@@ -207,9 +212,9 @@ public class TelemetryCommonPropertiesTests : SdkTest
         }
         finally
         {
-            foreach (var (key, value) in envVars)
+            foreach (var (key, value) in originalValues)
             {
-                Environment.SetEnvironmentVariable(key, null);
+                Environment.SetEnvironmentVariable(key, value);
             }
         }
     }
@@ -242,6 +247,7 @@ public class TelemetryCommonPropertiesTests : SdkTest
     ];
 
     [TestMethod]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     [DynamicData(nameof(LLMTelemetryTestCases))]
     public void CanDetectLLMStatusForEnvVars(Dictionary<string, string>? envVars, string? expected)
     {

--- a/test/dotnet.Tests/TelemetryTests/TelemetryHostMatrixTests.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryHostMatrixTests.cs
@@ -6,6 +6,8 @@ using Microsoft.DotNet.Cli.Utils;
 namespace Microsoft.DotNet.Tests.TelemetryTests;
 
 [TestClass]
+// The matrix starts and stops per-user build servers that tests throughout this project can use.
+[DoNotParallelize]
 public class TelemetryHostMatrixTests : SdkTest
 {
     [TestMethod]
@@ -151,8 +153,7 @@ public class TelemetryHostMatrixTests : SdkTest
 
     private void ShutdownBuildServers()
     {
-        // This project runs serially, and every row shuts down the per-user server before
-        // and after its trial so the cold/hot state belongs to this test.
+        // Every row shuts down the per-user server before and after its trial so the cold/hot state belongs to this test.
         new DotnetCommand(Log, "build-server", "shutdown")
             .WithEnvironmentVariable("DOTNET_CLI_TELEMETRY_OPTOUT", "1")
             .Execute()

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -11,8 +11,8 @@
     <OutputPath>$(TestHostFolder)</OutputPath>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Tests rely on global process state, so run serially. None makes MSTest.Sdk emit [assembly: DoNotParallelize]. -->
-    <MSTestParallelizeScope>None</MSTestParallelizeScope>
+    <!-- Methods within a fixture share test state. Cross-fixture process state is isolated with ResourceLock or DoNotParallelize. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/msbuild.Integration.Tests/msbuild.Integration.Tests.csproj
+++ b/test/msbuild.Integration.Tests/msbuild.Integration.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <!-- Each test uses a caller- and data-row-specific asset directory and only mutates child-process state. -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/sdk-tasks.Tests/sdk-tasks.Tests.csproj
+++ b/test/sdk-tasks.Tests/sdk-tasks.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
   </PropertyGroup>
 

--- a/test/trustedroots.Tests/trustedroots.Tests.csproj
+++ b/test/trustedroots.Tests/trustedroots.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <CanRunTestAsTool>false</CanRunTestAsTool>
     <OutputPath>$(TestHostFolder)</OutputPath>
+    <!-- Tests only read immutable SDK files; shared certificate sets use thread-safe lazy initialization. -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
> [!NOTE]
> This combined draft has been superseded by smaller, independent PRs aligned with CODEOWNERS. Please review the replacement PR for the relevant area instead.

## Replacement PRs

| Area / owner | Replacement |
| --- | --- |
| Core SDK and CLI tests | #56036 |
| Pack and restore (`@dotnet/nuget-team`) | #56027 |
| TemplateEngine (`@dotnet/templating-engine-maintainers`) | #56032 |
| Compatibility tools (`@dotnet/area-infrastructure-libraries`) | #56030 |
| Containers (`@dotnet/sdk-container-builds-maintainers`) | #56033 |
| Blazor and static web assets (`@dotnet/aspnet-blazor-eng`) | #56029 |
| Razor (`@dotnet/razor-tooling`) | #56035 |
| Web SDK publish tasks (`@vijayrkn`) | #56037 |
| Run-file (`@dotnet/run-file`) | #56038 |
| `dotnet test` parser (`@dotnet/dotnet-testing`) | #56031 |
| Workload manifest reader (`@dotnet/net-sdk-workload-contributors`) | #56034 |
| ILLink (`@dotnet/illink`) | #56026 |
| NetAnalyzers (`@dotnet/dotnet-analyzers`) | #56028 |

Performance/setup work remains separately tracked by standalone PR #56016.

## Validation context

The combined branch was audited across process globals, environment/current-directory/console state, static caches, shared paths, ports/daemons, and fixtures/data rows. Its final-scope Razor-fixed iteration completed in **5,426.805s** versus **14,445.996s** at baseline (**62.43% faster**), with the same expected 10 failing projects, 0 timeouts, and 116 primary-runner failures. Each replacement remains draft while its area-specific validation and review are completed.
