### PR TITLE
Parallelize ILLink tests by class

### DIFF
--- a/test/Microsoft.NET.ILLink.Tests/Microsoft.NET.ILLink.Tests.csproj
+++ b/test/Microsoft.NET.ILLink.Tests/Microsoft.NET.ILLink.Tests.csproj
@@ -6,6 +6,7 @@
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
     <PackageId>testSdkILLink</PackageId>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Opt `Microsoft.NET.ILLink.Tests` into MSTest `ClassLevel` parallelization after auditing the assembly for shared test resources.
- Ownership: @dotnet/illink.


## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

Project median: `Microsoft.NET.ILLink.Tests` improved from **2,509.241s** to **757.878s** (**69.80%**).
