### PR TITLE
Parallelize SDK pack and restore tests

### DIFF
--- a/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
+++ b/test/Microsoft.NET.Pack.Tests/GivenThatWeWantToPackAHelloWorldProject.cs
@@ -102,7 +102,7 @@ namespace Microsoft.NET.Pack.Tests
         public void It_packs_with_release_if_PackRelease_property_set_in_csproj(string valueOfPackRelease)
         {
             var helloWorldAsset = TestAssetsManager
-               .CopyTestAsset("HelloWorld")
+               .CopyTestAsset("HelloWorld", identifier: valueOfPackRelease)
                .WithSource()
                .WithProjectChanges(project =>
                {

--- a/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
+++ b/test/Microsoft.NET.Pack.Tests/Microsoft.NET.Pack.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages.cs
@@ -6,6 +6,7 @@
 namespace Microsoft.NET.Restore.Tests
 {
     [TestClass]
+    [ResourceLock(RestoreTestResources.NuGetCache)]
     public class GivenThatWeWantToIgnoreObsoleteDotNetCliToolPackages : SdkTest
     {
         [TestMethod]

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreDotNetCliToolReference.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreDotNetCliToolReference.cs
@@ -10,6 +10,7 @@ using NuGet.ProjectModel;
 namespace Microsoft.NET.Restore.Tests
 {
     [TestClass]
+    [ResourceLock(RestoreTestResources.NuGetCache)]
     public class GivenThatWeWantToRestoreDotNetCliToolReference : SdkTest
     {
         private const string ProjectToolVersion = "1.0.0";

--- a/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
+++ b/test/Microsoft.NET.Restore.Tests/GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties.cs
@@ -11,6 +11,7 @@ using NuGet.Packaging.Signing;
 namespace Microsoft.NET.Restore.Tests
 {
     [TestClass]
+    [ResourceLock(RestoreTestResources.NuGetCache)]
     public class GivenThatWeWantToRestoreProjectsUsingNuGetConfigProperties : SdkTest
     {
         [TestMethod]

--- a/test/Microsoft.NET.Restore.Tests/Microsoft.NET.Restore.Tests.csproj
+++ b/test/Microsoft.NET.Restore.Tests/Microsoft.NET.Restore.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Restore.Tests/RestoreTestResources.cs
+++ b/test/Microsoft.NET.Restore.Tests/RestoreTestResources.cs
@@ -1,0 +1,9 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.NET.Restore.Tests;
+
+internal static class RestoreTestResources
+{
+    public const string NuGetCache = "Restore.NuGetCache";
+}

--- a/test/dotnet.Tests/CommandTests/Pack/ReleasePropertyProjectLocatorTests.cs
+++ b/test/dotnet.Tests/CommandTests/Pack/ReleasePropertyProjectLocatorTests.cs
@@ -6,7 +6,7 @@ using Microsoft.DotNet.Cli;
 namespace Microsoft.DotNet.Pack.Tests;
 
 [TestClass]
-[DoNotParallelize]
+[ResourceLock(WellKnownResources.EnvironmentVariables)]
 public class ReleasePropertyProjectLocatorTests : SdkTest
 {
     private string? _disablePublishAndPackRelease;


### PR DESCRIPTION
## Summary

NuGet-owned test parallelization slice extracted from #56015 for review by @dotnet/nuget-team.

- enables method-level parallelism for SDK pack tests and gives the parameterized `PackRelease` DataRow cases isolated test-asset paths
- enables class-level parallelism for SDK restore tests while serializing the classes that share the NuGet cache through a named resource lock
- narrows the `dotnet pack` release-property tests from assembly-wide serialization to the environment-variable resource, while preserving explicit save-and-restore behavior for the process environment


## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

Project medians: `Microsoft.NET.Pack.Tests` improved from **127.059s** to **23.710s** (**81.34%**), and `Microsoft.NET.Restore.Tests` improved from **135.892s** to **110.296s** (**18.84%**).
