### PR TITLE
Parallelize NetAnalyzers unit tests

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/AGENTS.md
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/AGENTS.md
@@ -71,8 +71,9 @@ the driver already implies them and the combination fails. To regenerate `.xlf` 
   upstream `dotnet/roslyn-analyzers` tests use xUnit and must be translated when ported.
   `tests/Test.Utilities/TheoryData.cs` is an MSTest-friendly shim for xUnit's `TheoryData`,
   consumable from `[DynamicData]`.
-- The unit-test assembly uses method-level parallelization. Keep new fixtures, data sources,
-  process-global state, and filesystem paths safe for concurrent test methods.
+- `Microsoft.CodeAnalysis.NetAnalyzers.UnitTests` sets
+  `MSTestParallelizeScope=MethodLevel`. Keep new fixtures, data sources, process-global
+  state, and filesystem paths safe for concurrent test methods.
 - Embedded C# test sources default to `LanguageVersion.CSharp7_3`; set `LanguageVersion`
   explicitly when the source uses newer syntax.
 - `test/ConditionalTests.props` registers a `NetAnalyzers` scope, so PR validation can skip

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/AGENTS.md
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/AGENTS.md
@@ -71,6 +71,8 @@ the driver already implies them and the combination fails. To regenerate `.xlf` 
   upstream `dotnet/roslyn-analyzers` tests use xUnit and must be translated when ported.
   `tests/Test.Utilities/TheoryData.cs` is an MSTest-friendly shim for xUnit's `TheoryData`,
   consumable from `[DynamicData]`.
+- The unit-test assembly uses method-level parallelization. Keep new fixtures, data sources,
+  process-global state, and filesystem paths safe for concurrent test methods.
 - Embedded C# test sources default to `LanguageVersion.CSharp7_3`; set `LanguageVersion`
   explicitly when the source uses newer syntax.
 - `test/ConditionalTests.props` registers a `NetAnalyzers` scope, so PR validation can skip

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
@@ -8,9 +8,8 @@
          isolated: every test is a self-contained Roslyn compilation built by a fresh verifier
          instance, there are no [AssemblyInitialize]/[ClassInitialize]/[TestInitialize] fixtures,
          and the only shared state is init-once immutable data (Test.Utilities'
-         AdditionalMetadataReferences and the [DynamicData] providers). The package cache under
-         %TEMP%\test-packages is reached only through ReferenceAssemblies.ResolveAsync, which
-         serializes restores behind its own cross-process semaphore. -->
+         AdditionalMetadataReferences and the [DynamicData] providers). Package resolution is
+         reached only through ReferenceAssemblies.ResolveAsync. -->
     <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <!-- RS1024: Compare symbols correctly https://github.com/dotnet/roslyn-analyzers/issues/6381 -->

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <Nullable>disable</Nullable>
+    <!-- Overrides the repo-wide 'None' default from test/Directory.Build.props. These tests are
+         isolated: every test is a self-contained Roslyn compilation built by a fresh verifier
+         instance, there are no [AssemblyInitialize]/[ClassInitialize]/[TestInitialize] fixtures,
+         and the only shared state is init-once immutable data (Test.Utilities'
+         AdditionalMetadataReferences and the [DynamicData] providers). The package cache under
+         %TEMP%\test-packages is reached only through ReferenceAssemblies.ResolveAsync, which
+         serializes restores behind its own cross-process semaphore. -->
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
     <!-- RS1024: Compare symbols correctly https://github.com/dotnet/roslyn-analyzers/issues/6381 -->
     <NoWarn>$(NoWarn);RS1024</NoWarn>


### PR DESCRIPTION
## Summary

This is the independent `net-analyzers` replacement slice of #56015.

- Enable MSTest `MethodLevel` parallelization for the NetAnalyzers unit-test assembly.
- Document the concurrency requirement in the area-owned `src/Microsoft.CodeAnalysis.NetAnalyzers/AGENTS.md` guidance.

## Ownership

@dotnet/dotnet-analyzers owns this NetAnalyzers test area, with agent and contributor guidance maintained in `src/Microsoft.CodeAnalysis.NetAnalyzers/AGENTS.md`.

## Isolation rationale

Each test creates a self-contained Roslyn compilation through a fresh verifier instance. The assembly has no assembly-, class-, or test-initialization fixtures, and its shared state is limited to init-once immutable metadata references and dynamic-data providers. `ReferenceAssemblies.ResolveAsync` protects the shared package cache with its cross-process semaphore.

The added AGENTS guidance requires future fixtures, data sources, process-global state, and filesystem paths to remain safe for concurrent test methods.


## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

A separate 10-run NetAnalyzers measurement completed with exit code 0 on every run and no failures or timeouts.

| NetAnalyzers statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 402.691s | 122.301s | 69.63% |
| Median | 364.287s | 121.878s | 66.54% |
| Min | 354.850s | 114.518s | — |
| Max | 760.757s | 138.448s | — |

Raw baseline seconds: `760.757, 370.872, 367.239, 370.873, 356.237, 360.802, 362.482, 356.704, 366.091, 354.850`.

Raw changed seconds: `138.448, 125.842, 126.657, 124.467, 123.759, 117.878, 116.751, 114.518, 114.689, 119.998`.
