### PR TITLE
Parallelize compatibility tool tests

### DIFF
--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tests/Microsoft.DotNet.ApiCompat.Tests.csproj
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.ApiCompat.Tests/Microsoft.DotNet.ApiCompat.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/Microsoft.DotNet.PackageValidation.Tests.csproj
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/Microsoft.DotNet.PackageValidation.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
@@ -182,6 +182,7 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
         }
 
         [TestMethod]
+        [DoNotParallelize] // Concurrent pack/restore child processes can emit shared-cache diagnostics to stderr.
         public void ValidateReferencesAreRespectedForPlatformSpecificTFMs()
         {
             TestProject testProject = CreateTestProject("public class MyType { }", $"netstandard2.0;{ToolsetInfo.CurrentTargetFramework}-windows");

--- a/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
+++ b/test/Compatibility/ApiCompat/Microsoft.DotNet.PackageValidation.Tests/ValidatePackageInProcessTests.cs
@@ -15,6 +15,7 @@ using NuGet.Frameworks;
 namespace Microsoft.DotNet.PackageValidation.Tests
 {
     [TestClass]
+    [DoNotParallelize] // Concurrent pack/restore child processes can emit shared-cache diagnostics to stderr.
     public class ValidatePackageInProcessTests : SdkTest
     {
 
@@ -182,7 +183,6 @@ namespace PackageValidationTests { public class MyForwardedType : ISomeInterface
         }
 
         [TestMethod]
-        [DoNotParallelize] // Concurrent pack/restore child processes can emit shared-cache diagnostics to stderr.
         public void ValidateReferencesAreRespectedForPlatformSpecificTFMs()
         {
             TestProject testProject = CreateTestProject("public class MyType { }", $"netstandard2.0;{ToolsetInfo.CurrentTargetFramework}-windows");

--- a/test/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.IntegrationTests/Microsoft.DotNet.ApiDiff.IntegrationTests.csproj
+++ b/test/Compatibility/ApiDiff/Microsoft.DotNet.ApiDiff.IntegrationTests/Microsoft.DotNet.ApiDiff.IntegrationTests.csproj
@@ -5,6 +5,7 @@
          path that needs to be exercised from desktop MSBuild. Single-target the netcore TFM. -->
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.IntegrationTests/Microsoft.DotNet.GenAPI.IntegrationTests.csproj
+++ b/test/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.IntegrationTests/Microsoft.DotNet.GenAPI.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>$(SdkTargetFramework);$(NetFrameworkToolCurrent)</TargetFrameworks>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
+++ b/test/Compatibility/GenAPI/Microsoft.DotNet.GenAPI.Tests/Microsoft.DotNet.GenAPI.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Compatibility/Microsoft.DotNet.ApiSymbolExtensions.Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj
+++ b/test/Compatibility/Microsoft.DotNet.ApiSymbolExtensions.Tests/Microsoft.DotNet.ApiSymbolExtensions.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>$(SdkTargetFramework)</TargetFramework>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

This is the independent replacement for the `compatibility` partition of #56015, split according to the `@dotnet/area-infrastructure-libraries` CODEOWNERS boundary.

- Enable MSTest assembly parallelization for the ApiCompat, PackageValidation, ApiDiff, GenAPI, and ApiSymbolExtensions test projects.
- Keep the stderr-sensitive `ValidatePackageInProcessTests` PackageValidation class in MSTest's serial tail because each method runs pack/restore child processes and asserts on stderr, which can include concurrent shared-cache diagnostics.

## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

Representative project medians: PackageValidation improved **66.63%**, GenAPI integration improved **29.62%**, GenAPI unit tests improved **19.19%**, and ApiDiff improved **11.18%**; ApiCompat and ApiSymbolExtensions, both short-running projects, regressed by 1.892s and 7.701s respectively.
