### PR TITLE
Parallelize TemplateEngine tests

### DIFF
--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ExportCommandFailureTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/ExportCommandFailureTests.cs
@@ -10,6 +10,8 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
     [TestClass]
     public class ExportCommandFailureTests : IDisposable
     {
+        private readonly CultureInfo _originalCurrentCulture;
+        private readonly CultureInfo _originalCurrentUICulture;
         private readonly string _workingDirectory;
 
         public TestContext TestContext { get; set; } = null!;
@@ -18,6 +20,8 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 
         public ExportCommandFailureTests()
         {
+            _originalCurrentCulture = CultureInfo.CurrentCulture;
+            _originalCurrentUICulture = CultureInfo.CurrentUICulture;
             CultureInfo.CurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.CurrentUICulture = CultureInfo.InvariantCulture;
 
@@ -27,7 +31,15 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
 
         public void Dispose()
         {
-            Directory.Delete(_workingDirectory, true);
+            try
+            {
+                Directory.Delete(_workingDirectory, true);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = _originalCurrentCulture;
+                CultureInfo.CurrentUICulture = _originalCurrentUICulture;
+            }
         }
 
         [TestMethod]

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/Microsoft.TemplateEngine.Authoring.CLI.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.UnitTests/Microsoft.TemplateEngine.Authoring.CLI.UnitTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests/Microsoft.TemplateEngine.Authoring.Tasks.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
   </PropertyGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <Import Project="Microsoft.TemplateEngine.Authoring.TemplateVerifier.IntegrationTests.Shared.props" />
 
   <PropertyGroup>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests/Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests.csproj
@@ -3,6 +3,7 @@
   <Import Project="Microsoft.TemplateEngine.Authoring.TemplateVerifier.UnitTests.Shared.props" />
 
   <PropertyGroup>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests/Microsoft.TemplateEngine.Authoring.Templates.IntegrationTests.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="MSTest.Sdk">
 
   <PropertyGroup>
+    <MSTestParallelizeScope>MethodLevel</MSTestParallelizeScope>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/Microsoft.TemplateEngine.Edge.UnitTests.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
+    <!-- Test classes use isolated settings helpers, while methods within several classes share
+         mutable package providers, package-manager state, and culture-sensitive fixtures. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests/Microsoft.TemplateEngine.TemplateLocalizer.Core.UnitTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsTestProject>true</IsTestProject>
+    <!-- Test classes have independent inputs and working directories. Preserve method isolation
+         so each StringUpdaterTests instance exclusively owns its temporary directory. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Utils.UnitTests/Microsoft.TemplateEngine.Utils.UnitTests.csproj
@@ -4,6 +4,9 @@
     <TargetFrameworks>$(NetCurrent);$(NetFrameworkCurrent)</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Test classes have isolated fixtures, but methods in environment-backed classes share
+         class-scoped EnvironmentSettingsHelper instances. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateSearch.Common.UnitTests/Microsoft.TemplateSearch.Common.UnitTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <IsTestProject>true</IsTestProject>
+    <!-- Test classes use separate virtualized environments, while methods within each class share
+         an EnvironmentSettingsHelper and, in some cases, mutable search-provider fixtures. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TemplateEngine/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests.csproj
+++ b/test/TemplateEngine/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests/Microsoft.TemplateSearch.TemplateDiscovery.IntegrationTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>$(NetCurrent)</TargetFramework>
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
+    <!-- Keep each integration-test class serial because TemplateDiscoveryTests methods pack into
+         shared package output locations and invoke tools against class-local hives. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Opt TemplateEngine test assemblies into audited MSTest parallel execution, using `ClassLevel` where methods share class-scoped state and `MethodLevel` where methods are independently isolated.
- Keep export failure tests isolated with a randomized per-instance working directory and restore the original current cultures during cleanup.
- Ownership: @dotnet/templating-engine-maintainers.

This is the independent replacement for the `templates` slice of #56015, extracted as 12 files from source `84e283b69ce8f087114b5adba1016c8ce1f0e5d0` onto base `198ec8f3f13efc148f464688a6523341f856e03c`.


## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

The short TemplateEngine project medians generally regressed by 2–13 seconds under the complete benchmark; the aggregate fleet still improved because savings in long-running projects dominated. The largest TemplateEngine median regressions were Authoring Tasks integration (**+13.324s**) and TemplateVerifier integration (**+11.384s**).
