### PR TITLE
Parallelize container integration tests

### DIFF
--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateImageIndexTests.cs
@@ -12,6 +12,7 @@ using Task = System.Threading.Tasks.Task;
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
 [TestClass]
+[ResourceLock(TestSettings.DockerDaemonResource)]
 public class CreateImageIndexTests : SdkTest
 {
     [TestMethod]
@@ -21,7 +22,7 @@ public class CreateImageIndexTests : SdkTest
         DirectoryInfo newProjectDir = CreateNewProject();
         (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
         string outputRegistry = DockerRegistryManager.LocalRegistry;
-        string repository = "dotnet/create-image-index-baseline";
+        string repository = $"dotnet/create-image-index-baseline-{TestSettings.TestRunId}";
         string[] tags = new[] { "tag1", "tag2" };
 
         // Create images for 2 rids
@@ -159,4 +160,3 @@ public class CreateImageIndexTests : SdkTest
 
     private static string FormatBuildMessages(List<string?> messages) => string.Join("\r\n", messages);
 }
-

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/CreateNewImageTests.cs
@@ -10,6 +10,7 @@ using Microsoft.NET.Build.Containers.IntegrationTests;
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
 [TestClass]
+[ResourceLock(TestSettings.DockerDaemonResource)]
 public class CreateNewImageTests : SdkTest
 {
     [TestMethod]
@@ -47,7 +48,7 @@ public class CreateNewImageTests : SdkTest
         task.OutputRegistry = "localhost:5010";
         task.LocalRegistry = DockerUnavailableCondition.LocalRegistry;
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-arm64", "publish");
-        task.Repository = "dotnet/create-new-image-baseline";
+        task.Repository = $"dotnet/create-new-image-baseline-{TestSettings.TestRunId}";
         task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";
         task.ContainerRuntimeIdentifier = "linux-arm64";
@@ -90,10 +91,11 @@ public class CreateNewImageTests : SdkTest
         ParseContainerProperties pcp = new();
         (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
         pcp.BuildEngine = buildEngine;
+        string repository = $"dotnet/testimage-{TestSettings.TestRunId}";
 
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:7.0";
         pcp.ContainerRegistry = "localhost:5010";
-        pcp.ContainerRepository = "dotnet/testimage";
+        pcp.ContainerRepository = repository;
         pcp.ContainerImageTags = new[] { "5.0", "latest" };
 
         Assert.IsTrue(pcp.Execute(), FormatBuildMessages(errors));
@@ -101,7 +103,7 @@ public class CreateNewImageTests : SdkTest
         Assert.AreEqual("dotnet/runtime", pcp.ParsedContainerImage);
         Assert.AreEqual("7.0", pcp.ParsedContainerTag);
 
-        Assert.AreEqual("dotnet/testimage", pcp.NewContainerRepository);
+        Assert.AreEqual(repository, pcp.NewContainerRepository);
         pcp.NewContainerTags.Should().BeEquivalentTo(new[] { "5.0", "latest" });
 
         CreateNewImage cni = new();
@@ -159,10 +161,11 @@ public class CreateNewImageTests : SdkTest
         ParseContainerProperties pcp = new();
         (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
         pcp.BuildEngine = buildEngine;
+        string repository = $"dotnet/envvarvalidation-{TestSettings.TestRunId}";
 
         pcp.FullyQualifiedBaseImageName = $"mcr.microsoft.com/{DockerRegistryManager.RuntimeBaseImage}:{DockerRegistryManager.Net9ImageTag}";
         pcp.ContainerRegistry = "";
-        pcp.ContainerRepository = "dotnet/envvarvalidation";
+        pcp.ContainerRepository = repository;
         pcp.ContainerImageTag = "latest";
 
         Dictionary<string, string> dict = new();
@@ -177,7 +180,7 @@ public class CreateNewImageTests : SdkTest
         Assert.ContainsSingle(pcp.NewContainerEnvironmentVariables);
         Assert.AreEqual("Foo", pcp.NewContainerEnvironmentVariables[0].GetMetadata("Value"));
 
-        Assert.AreEqual("dotnet/envvarvalidation", pcp.NewContainerRepository);
+        Assert.AreEqual(repository, pcp.NewContainerRepository);
         Assert.AreEqual("latest", pcp.NewContainerTags[0]);
 
         CreateNewImage cni = new();
@@ -218,8 +221,8 @@ public class CreateNewImageTests : SdkTest
     [Ignore("https://github.com/dotnet/sdk/issues/49300")]
     public async System.Threading.Tasks.Task CreateNewImage_RootlessBaseImage()
     {
-        const string RootlessBase = "dotnet/rootlessbase";
-        const string AppImage = "dotnet/testimagerootless";
+        string rootlessBase = $"dotnet/rootlessbase-{TestSettings.TestRunId}";
+        string appImage = $"dotnet/testimagerootless-{TestSettings.TestRunId}";
         const string RootlessUser = "1654";
         var loggerFactory = new TestLoggerFactory(Log);
         var logger = loggerFactory.CreateLogger(nameof(CreateNewImage_RootlessBaseImage));
@@ -240,7 +243,7 @@ public class CreateNewImageTests : SdkTest
         BuiltImage builtImage = imageBuilder.Build();
 
         var sourceReference = new SourceImageReference(registry, DockerRegistryManager.RuntimeBaseImage, DockerRegistryManager.Net8ImageTag, null);
-        var destinationReference = new DestinationImageReference(registry, RootlessBase, new[] { "latest" });
+        var destinationReference = new DestinationImageReference(registry, rootlessBase, new[] { "latest" });
 
         await registry.PushAsync(builtImage, sourceReference, destinationReference, cancellationToken: default).ConfigureAwait(false);
 
@@ -269,12 +272,12 @@ public class CreateNewImageTests : SdkTest
         var (buildEngine, errors) = SetupBuildEngine();
         task.BuildEngine = buildEngine;
         task.BaseRegistry = "localhost:5010";
-        task.BaseImageName = RootlessBase;
+        task.BaseImageName = rootlessBase;
         task.BaseImageTag = "latest";
 
         task.OutputRegistry = "localhost:5010";
         task.PublishDirectory = Path.Combine(newProjectDir.FullName, "bin", "Release", ToolsetInfo.CurrentTargetFramework, "linux-x64", "publish");
-        task.Repository = AppImage;
+        task.Repository = appImage;
         task.ImageTags = new[] { "latest" };
         task.WorkingDirectory = "app/";
         task.ContainerRuntimeIdentifier = "linux-x64";
@@ -286,7 +289,7 @@ public class CreateNewImageTests : SdkTest
 
         // Verify the application image uses the non-root user from the base image.
         imageBuilder = await registry.GetImageManifestAsync(
-            AppImage,
+            appImage,
             "latest",
             "linux-x64",
             ToolsetUtils.RidGraphManifestPicker,
@@ -323,10 +326,11 @@ public class CreateNewImageTests : SdkTest
         ParseContainerProperties pcp = new();
         (IBuildEngine buildEngine, List<string?> errors) = SetupBuildEngine();
         pcp.BuildEngine = buildEngine;
+        string repository = $"dotnet/testimage-{TestSettings.TestRunId}";
 
         pcp.FullyQualifiedBaseImageName = "mcr.microsoft.com/dotnet/runtime:9.0";
         pcp.ContainerRegistry = "localhost:5010";
-        pcp.ContainerRepository = "dotnet/testimage";
+        pcp.ContainerRepository = repository;
         pcp.ContainerImageTags = new[] { "5.0", "latest" };
 
         Assert.IsTrue(pcp.Execute(), FormatBuildMessages(errors));
@@ -334,7 +338,7 @@ public class CreateNewImageTests : SdkTest
         Assert.AreEqual("dotnet/runtime", pcp.ParsedContainerImage);
         Assert.AreEqual("9.0", pcp.ParsedContainerTag);
 
-        Assert.AreEqual("dotnet/testimage", pcp.NewContainerRepository);
+        Assert.AreEqual(repository, pcp.NewContainerRepository);
         pcp.NewContainerTags.Should().BeEquivalentTo(new[] { "5.0", "latest" });
 
         CreateNewImage cni = new();

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/DockerRegistryTests.cs
@@ -5,6 +5,7 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 [TestClass]
+[ResourceLock(TestSettings.DockerDaemonResource)]
 public class DockerRegistryTests : SdkTest
 {
     private TestLoggerFactory? _loggerFactory;
@@ -40,6 +41,7 @@ public class DockerRegistryTests : SdkTest
         var registryAuthDir = new DirectoryInfo(Path.Combine(registryDir.FullName, "auth"));
         var registryCertsDir = new DirectoryInfo(Path.Combine(registryDir.FullName, "certs"));
         var registryName = "localhost:5555";
+        var registryContainerName = $"auth-registry-{TestSettings.TestRunId}";
         try
         {
             if (!registryCertsDir.Exists)
@@ -54,7 +56,7 @@ public class DockerRegistryTests : SdkTest
             // start up an authenticated registry using that dev cert
             ContainerCli.RunCommand(Log,
                 "-d", "--rm",
-                "--name", "auth-registry",
+                "--name", registryContainerName,
                 "-p", "5555:5000",
                 "-e", "REGISTRY_AUTH=htpasswd",
                 "-e", "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm",
@@ -66,7 +68,7 @@ public class DockerRegistryTests : SdkTest
                 "registry:2")
             .WithWorkingDirectory(registryDir.FullName).Execute().Should().Pass();
             // verify that the registry container started successfully
-            ContainerCli.InspectCommand(Log, "auth-registry").Execute().Should().Pass();
+            ContainerCli.InspectCommand(Log, registryContainerName).Execute().Should().Pass();
             // login to that registry
             ContainerCli.LoginCommand(Log, "--username", "testuser", "--password", "testpassword", registryName).Execute().Should().Pass();
             // push an image to that registry using username/password
@@ -88,7 +90,7 @@ public class DockerRegistryTests : SdkTest
         finally
         {
             //stop the registry
-            ContainerCli.StopCommand(Log, "auth-registry").WithWorkingDirectory(registryDir.FullName).Execute().Should().Pass();
+            ContainerCli.StopCommand(Log, registryContainerName).WithWorkingDirectory(registryDir.FullName).Execute().Should().Pass();
         }
     }
 }

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/EndToEndTests.cs
@@ -14,6 +14,7 @@ using ILogger = Microsoft.Extensions.Logging.ILogger;
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 [TestClass]
+[ResourceLock(TestSettings.DockerDaemonResource)]
 public class EndToEndTests : SdkTest, IDisposable
 {
     private TestLoggerFactory? _loggerFactory;
@@ -21,7 +22,7 @@ public class EndToEndTests : SdkTest, IDisposable
 
     public static string NewImageName([CallerMemberName] string callerMemberName = "")
     {
-        var (normalizedName, warning, error) = ContainerHelpers.NormalizeRepository(callerMemberName);
+        var (normalizedName, warning, error) = ContainerHelpers.NormalizeRepository($"{callerMemberName}-{TestSettings.TestRunId}");
         if (error is (var format, var args))
         {
             throw new ArgumentException(string.Format(Strings.ResourceManager.GetString(format)!, args));
@@ -684,7 +685,7 @@ public class EndToEndTests : SdkTest, IDisposable
             .Execute()
             .Should().Pass();
 
-        var containerName = $"test-container-1-{projectType}-{addPackageReference}";
+        var containerName = $"test-container-1-{projectType}-{addPackageReference}-{TestSettings.TestRunId}";
         CommandResult processResult = ContainerCli.RunCommand(
             Log,
             [
@@ -834,7 +835,7 @@ public class EndToEndTests : SdkTest, IDisposable
             .Execute()
             .Should().Pass();
 
-        var containerName = "test-container-2";
+        var containerName = $"test-container-2-{TestSettings.TestRunId}";
         CommandResult processResult = ContainerCli.RunCommand(
             Log,
             "--rm",
@@ -875,7 +876,7 @@ public class EndToEndTests : SdkTest, IDisposable
             Log,
             "--rm",
             "--name",
-            $"test-container-singlearch-norid",
+            $"test-container-singlearch-norid-{TestSettings.TestRunId}",
             $"{imageName}:{imageTag}")
         .Execute();
         processResultX64.Should().Pass().And.HaveStdOut("Hello, World!");
@@ -991,8 +992,8 @@ public class EndToEndTests : SdkTest, IDisposable
     {
         string[] imageNames =
         [
-            "endtoendmultiarch-localregistry",
-            "myteam/endtoendmultiarch-localregistry"
+            $"endtoendmultiarch-localregistry-{TestSettings.TestRunId}",
+            $"myteam/endtoendmultiarch-localregistry-{TestSettings.TestRunId}"
         ];
 
         string[] localRegistries = [.. MultiArchLocalRegistryTestData.AvailableRuntimes()];

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/LayerEndToEndTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/LayerEndToEndTests.cs
@@ -8,6 +8,8 @@ using System.Security.Cryptography;
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 [TestClass]
+// ContentStore.ArtifactRoot is read by product code that cannot acquire a test resource lock.
+[DoNotParallelize]
 public sealed class LayerEndToEndTests : SdkTest, IDisposable
 {
     public LayerEndToEndTests()

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/Microsoft.NET.Build.Containers.IntegrationTests.csproj
@@ -7,6 +7,7 @@
     <DisableMSBuildAssemblyCopyCheck>true</DisableMSBuildAssemblyCopyCheck>
     <StrongNameKeyId>MicrosoftShared</StrongNameKeyId>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <!-- MSTest experimental APIs (Assert.ThrowsExactly, condition attributes, etc.). -->
     <NoWarn>$(NoWarn);MSTESTEXP</NoWarn>
   </PropertyGroup>

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/ParseContainerPropertiesTests.cs
@@ -8,6 +8,7 @@ using static Microsoft.NET.Build.Containers.KnownStrings.Properties;
 namespace Microsoft.NET.Build.Containers.Tasks.IntegrationTests;
 
 [TestClass]
+[ResourceLock(TestSettings.MSBuildBuildManagerResource)]
 public class ParseContainerPropertiesTests
 {
     [TestMethod]

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/ProjectInitializer.cs
@@ -55,10 +55,10 @@ public sealed class ProjectInitializer
         props["NETCoreSdkPortableRuntimeIdentifier"] = "linux-x64";
 
 
-        var safeBinlogFileName = projectName.Replace(" ", "_").Replace(":", "_").Replace("/", "_").Replace("\\", "_").Replace("*", "_");
+        var safeBinlogFileName = $"{projectName.Replace(" ", "_").Replace(":", "_").Replace("/", "_").Replace("\\", "_").Replace("*", "_")}-{Guid.NewGuid():N}";
         var loggers = new List<ILogger>
         {
-            new global::Microsoft.Build.Logging.BinaryLogger() {CollectProjectImports = global::Microsoft.Build.Logging.BinaryLogger.ProjectImportsCollectionMode.Embed, Verbosity = LoggerVerbosity.Diagnostic, Parameters = $"LogFile={safeBinlogFileName}.binlog" },
+            new global::Microsoft.Build.Logging.BinaryLogger() {CollectProjectImports = global::Microsoft.Build.Logging.BinaryLogger.ProjectImportsCollectionMode.Embed, Verbosity = LoggerVerbosity.Diagnostic, Parameters = $"LogFile={Path.Combine(TestSettings.TestArtifactsDirectory, safeBinlogFileName)}.binlog" },
             new global::Microsoft.Build.Logging.ConsoleLogger(LoggerVerbosity.Detailed)
         };
         CapturingLogger logs = new();

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TargetsTests.cs
@@ -8,6 +8,7 @@ using static Microsoft.NET.Build.Containers.KnownStrings.Properties;
 namespace Microsoft.NET.Build.Containers.Targets.IntegrationTests;
 
 [TestClass]
+[ResourceLock(TestSettings.MSBuildBuildManagerResource)]
 public class TargetsTests
 {
     [TestMethod]

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
@@ -6,6 +6,7 @@ namespace Microsoft.NET.Build.Containers.IntegrationTests;
 internal static class TestSettings
 {
     internal const string DockerDaemonResource = "DockerDaemon";
+    internal const string MSBuildBuildManagerResource = "MSBuildBuildManager";
 
     private static readonly object _tmpLock = new();
     private static string? _testArtifactsDir;

--- a/test/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
+++ b/test/Microsoft.NET.Build.Containers.IntegrationTests/TestSettings.cs
@@ -1,14 +1,16 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Globalization;
-
 namespace Microsoft.NET.Build.Containers.IntegrationTests;
 
 internal static class TestSettings
 {
+    internal const string DockerDaemonResource = "DockerDaemon";
+
     private static readonly object _tmpLock = new();
     private static string? _testArtifactsDir;
+
+    internal static string TestRunId { get; } = Guid.NewGuid().ToString("N");
 
     /// <summary>
     /// Gets temporary location for test artifacts.
@@ -23,7 +25,7 @@ internal static class TestSettings
                 {
                     if (_testArtifactsDir == null)
                     {
-                        string tmpDir = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "ContainersTests", DateTime.Now.ToString("yyyyMMddHHmmssfff", CultureInfo.InvariantCulture));
+                        string tmpDir = Path.Combine(SdkTestContext.Current.TestExecutionDirectory, "ContainersTests", TestRunId);
                         if (!Directory.Exists(tmpDir))
                         {
                             Directory.CreateDirectory(tmpDir);


### PR DESCRIPTION
## Summary

This replacement split carries only the `containers` slice from #56015. It enables class-level execution for the container integration-test assembly while isolating registry repositories, image names, container names, test artifacts, and binlogs with per-run identifiers.

Tests that use the local Docker daemon declare the narrow shared `DockerDaemon` resource lock. `LayerEndToEndTests` remains serialized because product code reads the process-wide `ContentStore.ArtifactRoot` state and cannot participate in a test resource lock.

## Ownership

@dotnet/sdk-container-builds-maintainers


## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

The container integration project median changed from **127.982s** to **135.466s** (**7.484s / 5.85% slower**) in the complete benchmark; its baseline and changed runs both retained the same expected local Docker-prerequisite failure status.
## CI regression fix validation

The first Helix run exposed a process-wide in-process MSBuild collision between `ParseContainerPropertiesTests` and `TargetsTests`: concurrent `ProjectInstance.Build` calls failed with “a build is already in progress.” Commit `f0edffc32aa72f566ffef5efe3dc8880f351b330` adds a narrow shared `MSBuildBuildManager` resource lock only to those two classes.

A focused run of both classes passed **117/117 tests** with 0 failures and 0 skips in 13.857s. Replacement CI build 1575621 confirmed the container work items no longer fail; its only red work item was unrelated `dotnet-new.IntegrationTests.dll.1` on Linux (exit 7).

