### PR TITLE
Parallelize workload manifest reader tests

### DIFF
--- a/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.WorkloadManifestReader.Tests/Microsoft.NET.Sdk.WorkloadManifestReader.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFrameworks>net472;$(SdkTargetFramework)</TargetFrameworks>
     <TargetFrameworks Condition=" '$([MSBuild]::IsOSPlatform(`Windows`))' == 'false' ">$(SdkTargetFramework)</TargetFrameworks>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <!-- Test classes either use immutable inputs or isolated TestAssetsManager directories. -->
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
 
     <!-- By default test projects don't append TargetFramework to output path, but for multi-targeted tests
          we need to -->


### PR DESCRIPTION
## Summary

Opts `Microsoft.NET.Sdk.WorkloadManifestReader.Tests` into MSTest `ClassLevel` parallelization after auditing the assembly's isolation model. Test classes use immutable inputs or isolated `TestAssetsManager` directories, so no shared mutable resource was identified that requires serialization.

**Ownership:** @dotnet/net-sdk-workload-contributors


## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

The workload manifest reader project median changed from **10.882s** to **14.672s** (**3.790s slower**) in the complete benchmark.
