### PR TITLE
Enable safe Razor tool test parallelization

### DIFF
--- a/test/Microsoft.NET.Sdk.Razor.Tests/Microsoft.NET.Sdk.Razor.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Razor.Tests/Microsoft.NET.Sdk.Razor.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
+    <!-- Integration tests share the Razor build server, which can cross-contaminate concurrent project builds. -->
+    <MSTestParallelizeScope>None</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Sdk.Razor.Tool.Tests/Microsoft.NET.Sdk.Razor.Tool.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Razor.Tool.Tests/Microsoft.NET.Sdk.Razor.Tool.Tests.csproj
@@ -4,6 +4,7 @@
     <EnableDefaultItems>false</EnableDefaultItems>
     <OutDirName>Tests\$(MSBuildProjectName)</OutDirName>
     <StrongNameKeyId>MicrosoftAspNetCore</StrongNameKeyId>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerCommandTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerCommandTest.cs
@@ -6,6 +6,7 @@
 using System.Diagnostics;
 using System.Globalization;
 using Microsoft.CodeAnalysis;
+using Microsoft.NET.TestFramework;
 using Moq;
 
 namespace Microsoft.NET.Sdk.Razor.Tool
@@ -56,6 +57,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void GetPidFilePath_ReturnsCorrectDefaultPath()
         {
             // Arrange
@@ -69,10 +71,12 @@ namespace Microsoft.NET.Sdk.Razor.Tool
         }
 
         [TestMethod]
+        [ResourceLock(WellKnownResources.EnvironmentVariables)]
         public void GetPidFilePath_UsesEnvironmentVariablePathIfSpecified()
         {
             // Arrange
             var expectedPath = "/Some/directory/path/";
+            var previousPath = Environment.GetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY");
             Environment.SetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY", expectedPath);
             try
             {
@@ -84,7 +88,7 @@ namespace Microsoft.NET.Sdk.Razor.Tool
             }
             finally
             {
-                Environment.SetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY", "");
+                Environment.SetEnvironmentVariable("DOTNET_BUILD_PIDFILE_DIRECTORY", previousPath);
             }
         }
 

--- a/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerLifecycleTest.cs
+++ b/test/Microsoft.NET.Sdk.Razor.Tool.Tests/ServerLifecycleTest.cs
@@ -10,6 +10,7 @@ using Microsoft.NET.TestFramework;
 namespace Microsoft.NET.Sdk.Razor.Tool.Tests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public class ServerLifecycleTest
     {
         public TestContext TestContext { get; set; }


### PR DESCRIPTION
## Summary

This independent replacement contains the Razor-owned slice of #56015.

- Enables class-level parallelization for `Microsoft.NET.Sdk.Razor.Tool.Tests`.
- Isolates tests that mutate `DOTNET_BUILD_PIDFILE_DIRECTORY` with the shared environment-variable resource lock and restores the previous value.
- Keeps `Microsoft.NET.Sdk.Razor.Tests` at `None` intentionally: empirical validation exposed cross-project contamination through the shared Razor build server.

Ownership: @dotnet/razor-tooling


## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

Razor integration intentionally remained serialized after detecting build-server contamination; its median changed from **357.586s** to **376.514s**. Razor Tool tests changed from **19.128s** to **22.450s**.
