### PR TITLE
Parallelize Web SDK publish task tests

### DIFF
--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EnvironmentHelperTests.cs
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/EnvironmentHelperTests.cs
@@ -6,6 +6,7 @@
 namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
 {
     [TestClass]
+    [ResourceLock(WellKnownResources.EnvironmentVariables)]
     public class EnvironmentHelperTests
     {
         private const string TelemetryOptout = "DOTNET_CLI_TELEMETRY_OPTOUT";
@@ -22,17 +23,20 @@ namespace Microsoft.NET.Sdk.Publish.Tasks.Tests
         {
             // Arrange
             string originalValue = Environment.GetEnvironmentVariable(TelemetryOptout);
-            Environment.SetEnvironmentVariable(TelemetryOptout, value);
+            try
+            {
+                Environment.SetEnvironmentVariable(TelemetryOptout, value);
 
-            // Act
-            bool actualOutput = EnvironmentHelper.GetEnvironmentVariableAsBool(TelemetryOptout);
+                // Act
+                bool actualOutput = EnvironmentHelper.GetEnvironmentVariableAsBool(TelemetryOptout);
 
-
-            // Assert
-            Assert.AreEqual<bool>(expectedOutput, actualOutput);
-
-            // reset the value back to the original value
-            Environment.SetEnvironmentVariable(TelemetryOptout, originalValue);
+                // Assert
+                Assert.AreEqual<bool>(expectedOutput, actualOutput);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(TelemetryOptout, originalValue);
+            }
         }
     }
 }

--- a/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
+++ b/test/Microsoft.NET.Sdk.Publish.Tasks.Tests/Microsoft.NET.Sdk.Publish.Tasks.Tests.csproj
@@ -9,6 +9,7 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">$(SdkTargetFramework)</TargetFrameworks>
 
     <AssemblyName>Microsoft.NET.Sdk.Publish.Tasks.Tests</AssemblyName>
+    <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
     <ExcludeFromSourceOnlyBuild>true</ExcludeFromSourceOnlyBuild>
     <EndToEndTestsDisabled>true</EndToEndTestsDisabled>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>


### PR DESCRIPTION
## Summary

This is the `web-sdk` CODEOWNERS split from #56015 for @vijayrkn.

- Enables `ClassLevel` parallel execution for `Microsoft.NET.Sdk.Publish.Tasks.Tests`.
- Isolates `EnvironmentHelperTests` process-wide environment-variable mutation with a resource lock and restores the original value in a `finally` block.


## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

Publish Tasks improved from **91.289s** to **60.488s** (**33.74%**). The separate Web SDK integration project changed from **76.554s** to **87.752s** in the complete benchmark.
