### PR TITLE
Pin run-file warmup working directory

### DIFF
--- a/test/dotnet.Tests/CommandTests/Run/RunFileTestFixture.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTestFixture.cs
@@ -33,6 +33,9 @@ public sealed class RunFileTestFixture
 
             RunFileTestBase.CopyNuGetConfigToRunfileDirectory();
 
+            // `dotnet run -` falls back to project-based run when the working directory contains a project.
+            // Use a stable project-free directory because other tests can temporarily change the
+            // process-wide current directory.
             new DotnetCommand(log, "run", "-")
                 .WithWorkingDirectory(RunFileTestBase.OutOfTreeBaseDirectory)
                 .WithStandardInput("""

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTestFixture.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTestFixture.cs
@@ -34,6 +34,7 @@ public sealed class RunFileTestFixture
             RunFileTestBase.CopyNuGetConfigToRunfileDirectory();
 
             new DotnetCommand(log, "run", "-")
+                .WithWorkingDirectory(RunFileTestBase.OutOfTreeBaseDirectory)
                 .WithStandardInput("""
                     Console.WriteLine("Hello");
                     """)

--- a/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
@@ -7,9 +7,6 @@ using Microsoft.NET.TestFramework;
 namespace Microsoft.DotNet.Tests.ParserTests
 {
     [TestClass]
-    // These tests mutate process-wide CurrentDirectory, which production code can read indirectly from other parallel tests.
-    // A resource lock cannot serialize those indirect readers.
-    [DoNotParallelize]
     public class RunParserTests : IDisposable
     {
         private readonly string _previousWorkingDirectory;

--- a/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
@@ -7,6 +7,8 @@ using Microsoft.NET.TestFramework;
 namespace Microsoft.DotNet.Tests.ParserTests
 {
     [TestClass]
+    // CurrentDirectory is process-wide and is read by code throughout this project that cannot participate in a resource lock.
+    [DoNotParallelize]
     public class RunParserTests : IDisposable
     {
         private readonly string _previousWorkingDirectory;

--- a/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunParserTests.cs
@@ -7,7 +7,8 @@ using Microsoft.NET.TestFramework;
 namespace Microsoft.DotNet.Tests.ParserTests
 {
     [TestClass]
-    // CurrentDirectory is process-wide and is read by code throughout this project that cannot participate in a resource lock.
+    // These tests mutate process-wide CurrentDirectory, which production code can read indirectly from other parallel tests.
+    // A resource lock cannot serialize those indirect readers.
     [DoNotParallelize]
     public class RunParserTests : IDisposable
     {


### PR DESCRIPTION
## Summary

- Pin the stdin run-file warmup to `RunFileTestBase.OutOfTreeBaseDirectory` after failures caused by inheriting another test's current working directory.

## Ownership

Owned by @dotnet/run-file.

## 10× benchmark results

The combined Razor-fixed branch was measured on the same machine under an exclusive benchmark lock. Each iteration ran the identical 54 affected projects sequentially through `scripts/RunTests.cs`, with the same 90-minute per-project timeout and the same exclusion for the pre-existing hanging interruption test.

| Fleet statistic | Baseline | Changed | Improvement |
| --- | ---: | ---: | ---: |
| Mean | 14,773.837s | 7,341.516s | 50.31% |
| Median | 14,276.260s | 6,742.966s | 52.77% |
| Min | 14,193.833s | 5,426.805s | — |
| Max | 18,277.595s | 10,443.242s | — |

All 10 changed iterations completed with zero timeouts and retained exactly the same 10-project local-environment/prerequisite failure set as all 10 baseline iterations; there were no new or resolved failing projects. These combined-branch measurements provide performance and stability context, not isolated attribution or a per-slice tests-passed claim.

The run-file tests execute within `dotnet.Tests`, whose complete-project median improved from **5,400.162s** to **1,611.950s** (**70.15%**); that assembly-level number is context rather than isolated attribution to this slice.