### PR TITLE
Fix spurious CA1416 warnings in guard members and in nameof

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1342,6 +1342,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                 return;
             }
 
+            // A 'nameof' expression only captures the name of the member at compile time, the member itself is never accessed
+            if (operation.GetAncestor<INameOfOperation>(OperationKind.NameOf) != null)
+            {
+                return;
+            }
+
             var symbol = GetOperationSymbol(operation);
 
             if (symbol == null || symbol is ITypeSymbol type && type.SpecialType != SpecialType.None)
@@ -1415,6 +1421,13 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         containingSymbol = method.AssociatedSymbol!;
                     }
 
+                    // A guard member has no platform requirements of its own so that it can be called from any call site,
+                    // but its body still runs within the platform context established by the containing type or assembly
+                    if (HasGuardAttribute(containingSymbol))
+                    {
+                        containingSymbol = containingSymbol.ContainingSymbol;
+                    }
+
                     if (TryGetOrCreatePlatformAttributes(containingSymbol, true, crossPlatform, platformSpecificMembers, relatedPlatforms, out var callSiteAttributes))
                     {
                         if (callSiteAttributes.Callsite != Callsite.Empty &&
@@ -1435,6 +1448,19 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
 
         private static bool OperationHasOnlyAssemblyAttributesAndCalledFromSameAssembly(PlatformAttributes operationAttributes, ISymbol symbol, ISymbol containingSymbol) =>
             operationAttributes.IsAssemblyAttribute && containingSymbol.ContainingAssembly == symbol.ContainingAssembly;
+
+        private static bool HasGuardAttribute(ISymbol symbol)
+        {
+            foreach (AttributeData attribute in symbol.GetAttributes())
+            {
+                if (attribute.AttributeClass?.Name is SupportedOSPlatformGuardAttribute or UnsupportedOSPlatformGuardAttribute)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
 
         private static bool UsedInCreatingNotSupportedException(IArgumentOperation operation, ITypeSymbol? notSupportedExceptionType)
         {

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.cs
@@ -1421,11 +1421,12 @@ namespace Microsoft.NetCore.Analyzers.InteropServices
                         containingSymbol = method.AssociatedSymbol!;
                     }
 
-                    // A guard member has no platform requirements of its own so that it can be called from any call site,
-                    // but its body still runs within the platform context established by the containing type or assembly
-                    if (HasGuardAttribute(containingSymbol))
+                    // A guard member sheds the platform requirements of its containing type so that it can be referenced
+                    // from any call site, therefore its body cannot rely on them either. The assembly wide requirements
+                    // still hold though, as every call site within the assembly is bound by them
+                    if (HasGuardAttribute(containingSymbol) && containingSymbol.ContainingAssembly is { } containingAssembly)
                     {
-                        containingSymbol = containingSymbol.ContainingSymbol;
+                        containingSymbol = containingAssembly;
                     }
 
                     if (TryGetOrCreatePlatformAttributes(containingSymbol, true, crossPlatform, platformSpecificMembers, relatedPlatforms, out var callSiteAttributes))

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.ObsoletedOSPlatformTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzer.ObsoletedOSPlatformTests.cs
@@ -73,6 +73,31 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
                 .WithArguments("Public Sub ObsoletedOnLinux()", "'Linux' 4.1 and later", "'Linux'"));
         }
 
+        [TestMethod, Test.Utilities.WorkItem(54066, "https://github.com/dotnet/sdk/issues/54066")]
+        public async Task NameOfObsoletedMemberNotWarn()
+        {
+            var csSource = """
+                using System;
+                using System.Runtime.Versioning;
+                using Mock;
+
+                public class Test
+                {
+                    [SupportedOSPlatform("Linux")]
+                    public void M1()
+                    {
+                        Console.WriteLine(nameof(ObsoletedOnLinux4)); // 'nameof' does not read the property
+                        Console.WriteLine({|CA1422:ObsoletedOnLinux4|}); // This call site is reachable on: 'Linux'. 'Test.ObsoletedOnLinux4' is obsoleted on: 'Linux' 4.1 and later.
+                    }
+
+                    [Mock.ObsoletedOSPlatform("Linux4.1")]
+                    public string ObsoletedOnLinux4 => string.Empty;
+                }
+                """ + MockObsoletedAttributeCS;
+
+            await VerifyAnalyzerCSAsync(csSource);
+        }
+
         [TestMethod]
         public async Task ObsoletedAndSupportedMixedDiagnostics()
         {

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4367,7 +4367,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
         }
 
         [TestMethod, WorkItem(54066, "https://github.com/dotnet/sdk/issues/54066")]
-        public async Task GuardMemberBodyKeepsPlatformContextOfContainerAsync()
+        public async Task GuardMemberBodyKeepsAssemblyPlatformContextAsync()
         {
             var source = """
                 using System.Runtime.Versioning;
@@ -4377,7 +4377,11 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
                 class Test
                 {
                     [SupportedOSPlatformGuard("windows10.0.20348.0")]
-                    private static bool IsWindows20348OrNewerMethod() => SupportedOnWindows10240(); // call site is still reachable on 'windows' 10.0.18362.0 and later
+                    private static bool IsWindows20348OrNewerMethod()
+                    {
+                        SupportedOnWindows10240(); // Covered by the assembly wide minimum version, no warning
+                        return [|SupportedOnWindows20348()|]; // This call site is reachable on: 'windows' 10.0.18362.0 and later. 'Test.SupportedOnWindows20348()' is only supported on: 'windows' 10.0.20348.0 and later.
+                    }
 
                     [SupportedOSPlatformGuard("windows10.0.20348.0")]
                     private static bool IsWindows20348OrNewerProperty => SupportedOnWindows10240();
@@ -4387,6 +4391,9 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
 
                     [SupportedOSPlatform("windows10.0.10240.0")]
                     private static bool SupportedOnWindows10240() => true;
+
+                    [SupportedOSPlatform("windows10.0.20348.0")]
+                    private static bool SupportedOnWindows20348() => true;
                 }
                 """;
 
@@ -4394,33 +4401,25 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
         }
 
         [TestMethod, WorkItem(54066, "https://github.com/dotnet/sdk/issues/54066")]
-        public async Task GuardMemberBodyStillWarnsForApiOutsideOfPlatformContextAsync()
+        public async Task GuardMemberBodyDoesNotInheritContainingTypeAttributesAsync()
         {
             var source = """
                 using System.Runtime.Versioning;
 
-                [SupportedOSPlatform("windows10.0.18362.0")]
                 class Test
                 {
-                    private static void NotAGuard()
-                    {
-                        SupportedOnWindows10240();
-                        [|SupportedOnWindows20348()|]; // This call site is reachable on: 'windows' 10.0.18362.0 and later. 'Test.SupportedOnWindows20348()' is only supported on: 'windows' 10.0.20348.0 and later.
-                    }
+                    private static bool CrossPlatformCallSite() => WindowsOnlyType.IsSupported; // Referencing the guard is allowed from any call site
+                }
 
+                [SupportedOSPlatform("windows")]
+                class WindowsOnlyType
+                {
+                    // The guard is referenceable from call sites which are not reachable on 'windows', so its body cannot rely on the type being windows only
                     [SupportedOSPlatformGuard("windows10.0.20348.0")]
-                    private static bool IsWindows20348OrNewer()
-                    {
-                        SupportedOnWindows10240();
-                        [|SupportedOnWindows20348()|]; // Same diagnostics as the method above, the guard attribute does not widen the call site
-                        return true;
-                    }
+                    internal static bool IsSupported => [|SupportedOnWindows()|]; // This call site is reachable on all platforms. 'WindowsOnlyType.SupportedOnWindows()' is only supported on: 'windows'.
 
-                    [SupportedOSPlatform("windows10.0.10240.0")]
-                    private static void SupportedOnWindows10240() { }
-
-                    [SupportedOSPlatform("windows10.0.20348.0")]
-                    private static void SupportedOnWindows20348() { }
+                    [SupportedOSPlatform("windows")]
+                    private static bool SupportedOnWindows() => true;
                 }
                 """;
 

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.GuardedCallsTests.cs
@@ -4366,6 +4366,67 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
         }
 
+        [TestMethod, WorkItem(54066, "https://github.com/dotnet/sdk/issues/54066")]
+        public async Task GuardMemberBodyKeepsPlatformContextOfContainerAsync()
+        {
+            var source = """
+                using System.Runtime.Versioning;
+
+                [assembly: SupportedOSPlatform("windows10.0.18362.0")]
+
+                class Test
+                {
+                    [SupportedOSPlatformGuard("windows10.0.20348.0")]
+                    private static bool IsWindows20348OrNewerMethod() => SupportedOnWindows10240(); // call site is still reachable on 'windows' 10.0.18362.0 and later
+
+                    [SupportedOSPlatformGuard("windows10.0.20348.0")]
+                    private static bool IsWindows20348OrNewerProperty => SupportedOnWindows10240();
+
+                    [SupportedOSPlatformGuard("windows10.0.20348.0")]
+                    private static readonly bool s_isWindows20348OrNewer = SupportedOnWindows10240();
+
+                    [SupportedOSPlatform("windows10.0.10240.0")]
+                    private static bool SupportedOnWindows10240() => true;
+                }
+                """;
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [TestMethod, WorkItem(54066, "https://github.com/dotnet/sdk/issues/54066")]
+        public async Task GuardMemberBodyStillWarnsForApiOutsideOfPlatformContextAsync()
+        {
+            var source = """
+                using System.Runtime.Versioning;
+
+                [SupportedOSPlatform("windows10.0.18362.0")]
+                class Test
+                {
+                    private static void NotAGuard()
+                    {
+                        SupportedOnWindows10240();
+                        [|SupportedOnWindows20348()|]; // This call site is reachable on: 'windows' 10.0.18362.0 and later. 'Test.SupportedOnWindows20348()' is only supported on: 'windows' 10.0.20348.0 and later.
+                    }
+
+                    [SupportedOSPlatformGuard("windows10.0.20348.0")]
+                    private static bool IsWindows20348OrNewer()
+                    {
+                        SupportedOnWindows10240();
+                        [|SupportedOnWindows20348()|]; // Same diagnostics as the method above, the guard attribute does not widen the call site
+                        return true;
+                    }
+
+                    [SupportedOSPlatform("windows10.0.10240.0")]
+                    private static void SupportedOnWindows10240() { }
+
+                    [SupportedOSPlatform("windows10.0.20348.0")]
+                    private static void SupportedOnWindows20348() { }
+                }
+                """;
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
         [TestMethod]
         public async Task GuardMembersWithSupportedGuardAttributesAsync()
         {

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/InteropServices/PlatformCompatibilityAnalyzerTests.cs
@@ -821,7 +821,7 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
                         M2(WindowsOnlyPropertySetter);
                         var name = nameof(WindowsOnlyPropertyGetter);
                         name = nameof(WindowsOnlyPropertySetter);
-                        name = nameof([|WindowsOnlyProperty|]);
+                        name = nameof(WindowsOnlyProperty); // 'nameof' does not access the property
                     }
                     public bool M2(bool option)
                     {
@@ -3706,6 +3706,61 @@ namespace Microsoft.NetCore.Analyzers.InteropServices.UnitTests
                 }
                 """;
             await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+        }
+
+        [TestMethod, WorkItem(54066, "https://github.com/dotnet/sdk/issues/54066")]
+        public async Task NameOfPlatformSpecificMemberNotWarnAsync()
+        {
+            var source = """
+                using System;
+                using System.Runtime.Versioning;
+
+                public class Test
+                {
+                    public void M1()
+                    {
+                        Console.WriteLine(nameof(WindowsOnly.Method));
+                        Console.WriteLine(nameof(WindowsOnly.Field));
+                        Console.WriteLine(nameof(WindowsOnly.Property));
+                        Console.WriteLine(nameof(WindowsOnly.Property.Length));
+                        Console.WriteLine([|WindowsOnly.Property|]); // Actually reading the property still warns
+                    }
+                }
+
+                [SupportedOSPlatform("windows")]
+                public class WindowsOnly
+                {
+                    public static string Field;
+                    public static string Property => string.Empty;
+                    public static void Method() { }
+                }
+                """;
+
+            await VerifyAnalyzerCSAsync(source, s_msBuildPlatforms);
+
+            var vbSource = """
+                Imports System
+                Imports System.Runtime.Versioning
+
+                Public Class Test
+                    Public Sub M1()
+                        Console.WriteLine(NameOf(WindowsOnly.Method))
+                        Console.WriteLine(NameOf(WindowsOnly.Field))
+                        Console.WriteLine(NameOf(WindowsOnly.Prop))
+                        Console.WriteLine([|WindowsOnly.Prop|]) ' Actually reading the property still warns
+                    End Sub
+                End Class
+
+                <SupportedOSPlatform("windows")>
+                Public Class WindowsOnly
+                    Public Shared Field As String
+                    Public Shared ReadOnly Property Prop As String
+                    Public Shared Sub Method()
+                    End Sub
+                End Class
+                """;
+
+            await VerifyAnalyzerVBAsync(vbSource, s_msBuildPlatforms);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #54066

Two things made CA1416 fire when it shouldn't.

**Guard members lost their call site platform context.** The analyzer computes the platform attributes of a symbol by walking up the containing chain and merging them, and it clears everything it found when the symbol carries a guard attribute. That is intentional, because referencing a guard member should never warn. The problem is that the same result is also used as the call site context for the symbol whose body is being analyzed, so as soon as a member was annotated with `[SupportedOSPlatformGuard]` it also lost the context coming from the assembly level `[SupportedOSPlatform]` that the SDK generates from `SupportedOSPlatformVersion`. Everything inside that member was then reported as reachable on all platforms.

The call site lookup now falls back to the assembly when the containing member is a guard. It deliberately stops there rather than using the containing type: a guard sheds its type's requirements so that callers on any platform can reference it, so its body cannot rely on them either. Assembly wide requirements are different, since every call site inside the assembly is bound by them regardless.

**`nameof` was treated as a real API reference.** A `nameof` operand is a compile time constant and never touches the member, and it is lowered out of the control flow graph, so platform guards around it did not suppress the diagnostic either. Operations under a `nameof` are now skipped.

The second part is a behavior change: `nameof(SomePlatformSpecificProperty)` used to report CA1416 and no longer does. That was already inconsistent, since the same expression did not warn when the attribute sat on the accessor rather than on the property, and `GetPropertyAccessors` already documents that `ValueUsageInfo.Name` only uses the name of the property. One existing test line was updated for this.

Both cases were reproduced as failing tests first, and each new test was confirmed to fail without the corresponding change. The full `Microsoft.CodeAnalysis.NetAnalyzers.UnitTests` suite passes.