### PR TITLE
Restore the SDL source analysis pool for the official pipeline

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -74,6 +74,12 @@ extends:
         env:
           ROOTFS_DIR: /crossrootfs/arm64
 
+    sdl:
+      sourceAnalysisPool:
+        name: $(DncEngInternalBuildPool)
+        image: 1es-windows-2022
+        os: windows
+
     stages:
     ############### BUILD STAGE ###############
     # Run build jobs for non-check-in runs.


### PR DESCRIPTION
## Problem

**Error or behavior:** Azure DevOps rejects the expanded official pipeline YAML because the template-generated `SDLSources` stage has no Windows pool.

**Root cause:** [PR #55779](https://github.com/dotnet/sdk/pull/55779) moved weekly SDL checks to `.vsts-sdl.yml` and removed the entire `sdl` configuration from `.vsts-ci.yml`, including the pool still required by the 1ES official template.

## Description

**Fix:** Restore only `sdl.sourceAnalysisPool` in `.vsts-ci.yml`. Full SDL check configuration remains isolated in the dedicated weekly pipeline.