### PR TITLE
Expand MSBuild properties in launch profile arguments

### DIFF
--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -7,6 +7,7 @@ using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
@@ -26,6 +27,8 @@ namespace Microsoft.DotNet.Cli.Commands.Run;
 [RequiresDynamicCode("Uses MSBuild Object Model types, which are not AOT-safe")]
 public class RunCommand
 {
+    private static readonly Regex s_msBuildPropertyRegex = new(@"\$\((?<token>[^\)]+)\)", RegexOptions.IgnoreCase);
+
     public bool NoBuild { get; }
 
     /// <summary>
@@ -571,7 +574,10 @@ public class RunCommand
 
         if (!NoLaunchProfileArguments && string.IsNullOrEmpty(command.CommandArgs) && launchSettings?.CommandLineArgs != null)
         {
-            command.SetCommandArgs(project?.ExpandString(launchSettings.CommandLineArgs) ?? launchSettings.CommandLineArgs);
+            command.SetCommandArgs(
+                project is null
+                    ? launchSettings.CommandLineArgs
+                    : s_msBuildPropertyRegex.Replace(launchSettings.CommandLineArgs, match => project.ExpandString(match.Value)));
         }
 
         return command;

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Cli.Commands.Run;
 [RequiresDynamicCode("Uses MSBuild Object Model types, which are not AOT-safe")]
 public class RunCommand
 {
-    private static readonly Regex s_msBuildPropertyRegex = new(@"\$\((?<token>[^\)]+)\)", RegexOptions.IgnoreCase);
+    private static readonly Regex s_msBuildPropertyRegex = new(@"\$\((?!\[)(?<token>[^\)]+)\)", RegexOptions.IgnoreCase);
 
     public bool NoBuild { get; }
 

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -520,6 +520,7 @@ public class RunCommand
     private ICommand GetTargetCommandForProject(ProjectLaunchProfile? launchSettings, Func<ProjectCollection, ProjectInstance>? projectFactory, RunProperties? cachedRunProperties, bool runPropertiesFromEvaluation, FacadeLogger? logger)
     {
         ICommand command;
+        ProjectInstance? project = null;
         IReadOnlyDictionary<string, string> runtimeEnvironmentVariables = EnvironmentVariables;
         if (cachedRunProperties != null)
         {
@@ -540,7 +541,6 @@ public class RunCommand
         {
             Reporter.Verbose.WriteLine("Getting target command: evaluating project.");
 
-            ProjectInstance project;
             bool hasRuntimeEnvironmentVariableSupport;
             try
             {
@@ -571,7 +571,7 @@ public class RunCommand
 
         if (!NoLaunchProfileArguments && string.IsNullOrEmpty(command.CommandArgs) && launchSettings?.CommandLineArgs != null)
         {
-            command.SetCommandArgs(launchSettings.CommandLineArgs);
+            command.SetCommandArgs(project?.ExpandString(launchSettings.CommandLineArgs) ?? launchSettings.CommandLineArgs);
         }
 
         return command;

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
@@ -32,8 +32,6 @@ internal abstract class LaunchProfileParser
         return builder.ToImmutable();
     }
 
-    // TODO: Expand MSBuild variables $(...): https://github.com/dotnet/sdk/issues/50157
-    // See https://github.com/dotnet/project-system/blob/main/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/Debug/DebugTokenReplacer.cs#L35-L57
     protected static string ExpandVariables(string value)
         => Environment.ExpandEnvironmentVariables(value);
 }

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -88,7 +88,7 @@ public sealed class RunCommandTests : SdkTest
               "profiles": {
                 "First": {
                   "commandName": "Project",
-                  "commandLineArgs": "\"$(MSBuildProjectDirectory)\""
+                  "commandLineArgs": "\"$(MSBuildProjectDirectory)\" \"$([System.String]::Copy('function'))\" \"@(Items)\" \"%(Identity)\""
                 }
               }
             }
@@ -98,7 +98,7 @@ public sealed class RunCommandTests : SdkTest
             .WithWorkingDirectory(testProjectDirectory)
             .Execute()
             .Should().Pass()
-            .And.HaveStdOutContaining($"ARGS={testProjectDirectory}");
+            .And.HaveStdOutContaining($"ARGS={testProjectDirectory},$([System.String]::Copy('function')),@(Items),%(Identity)");
     }
 
     [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -74,6 +74,34 @@ public sealed class RunCommandTests : SdkTest
     }
 
     [TestMethod]
+    public void MSBuildPropertyExpansion_Project()
+    {
+        var testAppName = "AppThatOutputsDotnetLaunchProfile";
+        var testInstance = TestAssetsManager.CopyTestAsset(testAppName)
+            .WithSource();
+
+        var testProjectDirectory = testInstance.Path;
+        var launchSettingsPath = Path.Combine(testProjectDirectory, "Properties", "launchSettings.json");
+
+        File.WriteAllText(launchSettingsPath, """
+            {
+              "profiles": {
+                "First": {
+                  "commandName": "Project",
+                  "commandLineArgs": "\"$(MSBuildProjectDirectory)\""
+                }
+              }
+            }
+            """);
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(testProjectDirectory)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOutContaining($"ARGS={testProjectDirectory}");
+    }
+
+    [TestMethod]
     public void Executable_DefaultWorkingDirectory()
     {
         var root = TestAssetsManager.CreateTestDirectory().Path;

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -88,7 +88,7 @@ public sealed class RunCommandTests : SdkTest
               "profiles": {
                 "First": {
                   "commandName": "Project",
-                  "commandLineArgs": "\"$(MSBuildProjectDirectory)\" \"$([System.String]::Copy('function'))\" \"@(Items)\" \"%(Identity)\""
+                  "commandLineArgs": "\"$(MSBuildProjectDirectory)\" \"$([System.IO.Path]::DirectorySeparatorChar)\" \"@(Items)\" \"%(Identity)\""
                 }
               }
             }
@@ -98,7 +98,7 @@ public sealed class RunCommandTests : SdkTest
             .WithWorkingDirectory(testProjectDirectory)
             .Execute()
             .Should().Pass()
-            .And.HaveStdOutContaining($"ARGS={testProjectDirectory},$([System.String]::Copy('function')),@(Items),%(Identity)");
+            .And.HaveStdOutContaining($"ARGS={testProjectDirectory},$([System.IO.Path]::DirectorySeparatorChar),@(Items),%(Identity)");
     }
 
     [TestMethod]


### PR DESCRIPTION
Expands MSBuild properties in project launch profile `commandLineArgs` using the evaluated project, matching the behavior supported by Visual Studio and Dev Kit.

Fixes #50157.

> [!NOTE]
> This pull request was drafted with GitHub Copilot.