### PR TITLE
Re-enable dotnet sdk check lifecycle tests

### DIFF
--- a/test/dotnet.Tests/CommandTests/Sdk/Check/GivenDotnetSdkCheck.cs
+++ b/test/dotnet.Tests/CommandTests/Sdk/Check/GivenDotnetSdkCheck.cs
@@ -97,7 +97,6 @@ namespace Microsoft.DotNet.Cli.SdkCheck.Tests
         }
 
         [TestMethod]
-        [Ignore("https://github.com/dotnet/sdk/issues/29382")]
         [DataRow(new string[] { "3.1.301" }, new string[] { }, new string[] { "3.1.302" })]
         [DataRow(new string[] { "5.0.100" }, new string[] { }, new string[] { })]
         [DataRow(new string[] { }, new string[] { "3.1.3" }, new string[] { "3.1.10" })]
@@ -123,7 +122,6 @@ namespace Microsoft.DotNet.Cli.SdkCheck.Tests
         }
 
         [TestMethod]
-        [Ignore("https://github.com/dotnet/sdk/issues/29382")]
         [DataRow(new string[] { "1.0.10" }, new string[] { }, new string[] { "1.0.10" })]
         [DataRow(new string[] { "5.0.100" }, new string[] { }, new string[] { })]
         [DataRow(new string[] { }, new string[] { "1.0.1" }, new string[] { "1.0.1" })]


### PR DESCRIPTION
🤖 This is part of the weekly test issue cleanup effort.

The .NET 3.1 test fixture was updated after its lifecycle date caused these tests to fail in 2022, but the skips remained. Re-enable both `dotnet sdk check` lifecycle test methods, restoring 14 data-driven cases that cover patch-update and out-of-support reporting.

Fixes #29382