### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    groups:
+      github-actions:
+        patterns: ["*"]
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: "nuget"
     directory: "/eng/dependabot"
     open-pull-requests-limit: 10

--- a/.github/memory/CONVENTIONS.md
+++ b/.github/memory/CONVENTIONS.md
@@ -53,6 +53,10 @@ Repository policy:
   hand-edit generated `eng/Version.Details.props`.
 - Treat `NU19xx` audit findings as actionable: update or remove the package rather than
   suppressing the warning or weakening audit settings.
+- Pin external GitHub Actions and reusable workflows in runtime workflow YAML to full
+  40-character commit SHAs, with the tag or branch in a trailing comment. Dependabot
+  maintains these pins through [`.github/dependabot.yml`](../dependabot.yml); do not
+  hand-edit generated `*.lock.yml` workflows.
 
 ## Canonical Convention Owners
 

--- a/.github/workflows/add-lockdown-label.yml
+++ b/.github/workflows/add-lockdown-label.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@0717577d45739eb3c851188b29f50ed6c0b2194e # v2
         with:
           persist-credentials: false
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   backport:
-    uses: dotnet/arcade/.github/workflows/backport-base.yml@main
+    uses: dotnet/arcade/.github/workflows/backport-base.yml@306225d7029934938d109e18df390f04e366a68d # main
     with:
         pr_labels: backport
         pr_description_template: |

--- a/.github/workflows/check-vendored-files.yml
+++ b/.github/workflows/check-vendored-files.yml
@@ -42,8 +42,8 @@ jobs:
     name: Validate manifest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - name: Validate vendored-files.json
@@ -55,8 +55,8 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.12'
       - name: Check vendored files

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -38,7 +38,7 @@ jobs:
 
       # For MCP servers like nuget's
       - name: Install .NET 10.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: |
             10.x
@@ -46,7 +46,7 @@ jobs:
 
       # for MCP servers
       - name: Install .NET 8.x
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: |
             8.x

--- a/.github/workflows/inter-branch-merge-flow.yml
+++ b/.github/workflows/inter-branch-merge-flow.yml
@@ -14,4 +14,4 @@ env:
 
 jobs:
   Merge:
-    uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@main
+    uses: dotnet/arcade/.github/workflows/inter-branch-merge-base.yml@306225d7029934938d109e18df390f04e366a68d # main

--- a/.github/workflows/remove-lockdown-label.yml
+++ b/.github/workflows/remove-lockdown-label.yml
@@ -23,7 +23,7 @@ jobs:
         steps:
         -   name: PR's only change is <VersionFeature> in eng/Versions.props
             id: only_version_feature_changed
-            uses: actions/github-script@v4
+            uses: actions/github-script@10b53a9ec6c222bb4ce97aa6bd2b5f739696b536 # v4
             with:
                 script: |
                     const otherChangesMessage = "❌ Changes in eng/Versions.props other than <VersionFeature> found";
@@ -55,7 +55,7 @@ jobs:
 
         -   name: Remove Branch Lockdown label from other PRs targeting this branch
             if: steps.only_version_feature_changed.outputs.only_version_feature_changed == 'true'
-            uses: actions/github-script@v4
+            uses: actions/github-script@10b53a9ec6c222bb4ce97aa6bd2b5f739696b536 # v4
             with:
                 script: |
                     const prs = await github.pulls.list({

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -21,7 +21,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9 # https://github.com/actions/stale/blob/v9/README.md
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           ascending: true # Process the oldest issues first
           stale-issue-message: "Due to lack of recent activity, this issue has been labeled as 'Stale'. It will be closed if no further activity occurs within 14 more days. Any new comment will remove the label."
@@ -40,7 +40,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const CLOSE_KBE_AFTER_DAYS = 7;

--- a/.github/workflows/update-man-pages.yml
+++ b/.github/workflows/update-man-pages.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           ref: release/10.0.1xx
           persist-credentials: false

--- a/.github/workflows/update-static-web-assets-baselines.yml
+++ b/.github/workflows/update-static-web-assets-baselines.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Load pull request details
         id: info
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           PR_NUMBER: ${{ github.event.inputs.pr_number }}
         with:
@@ -89,7 +89,7 @@ jobs:
         working-directory: pr
     steps:
       - name: Checkout PR head
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           token: ${{ github.token }}
           fetch-depth: 0
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload baseline artifacts
         if: steps.evaluate.outputs.status == 'success' && steps.check.outputs.changes == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: static-web-assets-baselines
           path: pr/__artifacts
@@ -197,7 +197,7 @@ jobs:
 
       - name: Upload failure diagnostics
         if: steps.evaluate.outputs.status == 'failed'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: static-web-assets-baselines-failure
           path: pr/__failure
@@ -219,7 +219,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout PR branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           token: ${{ github.token }}
           fetch-depth: 0
@@ -231,14 +231,14 @@ jobs:
 
       - name: Download baseline artifacts
         if: needs.generate.outputs.changes == 'true'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: static-web-assets-baselines
           path: artifact
 
       - name: Checkout trusted validation script
         if: needs.generate.outputs.changes == 'true'
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           # Always use the canonical validator from the repository's default branch (main), never the PR's copy and
           # never a release branch's copy when this workflow is dispatched from one.
@@ -346,7 +346,7 @@ jobs:
 
       - name: Comment on PR - Success
         if: steps.commit.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           COMMENT_BODY: |
             ✅ Static web assets baselines were updated and pushed to this pull request. Review [the workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
@@ -364,7 +364,7 @@ jobs:
 
       - name: Comment on PR - No changes
         if: needs.generate.outputs.changes != 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           COMMENT_BODY: |
             ℹ️ No static web assets baselines needed updating. Review [the workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
@@ -389,7 +389,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Download failure diagnostics
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: static-web-assets-baselines-failure
           path: diagnostics
@@ -426,7 +426,7 @@ jobs:
           printf 'body<<EOF\n%s\nEOF\n' "$message" >> "$GITHUB_OUTPUT"
 
       - name: Comment on PR - Failure
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           COMMENT_BODY: ${{ steps.failure-comment.outputs.body }}
           ISSUE_NUMBER: ${{ needs.metadata.outputs.pr_number }}


### PR DESCRIPTION
🤖 GitHub Action tags and branches are mutable, which leaves workflow execution exposed to upstream ref changes. This pins every external action and reusable workflow used by runtime YAML to its verified full commit SHA while retaining readable version comments.

Dependabot now groups GitHub Actions updates on a weekly schedule with a seven-day cooldown, so the immutable pins remain maintainable. Generated gh-aw lock workflows were left untouched because they are already compiler-pinned, and the repository convention is documented for future workflow changes.

Fixes: #55866