### PR TITLE
Use TagHelper components for MVC browser tools

### DIFF
--- a/src/Dotnet.Watch/AGENTS.md
+++ b/src/Dotnet.Watch/AGENTS.md
@@ -36,6 +36,15 @@ Reload).
   shared-secret WebSocket subprotocol, and include the generation identity in live
   managed-update messages. Preserve the initializer's injected-script fallback and the
   legacy hosting-startup configurator for other app models and older target frameworks.
+- **MVC and Razor Pages activate browser tools through the built-in body TagHelper.**
+  [`HostingStartup.cs`](Web.Middleware/HostingStartup.cs) registers
+  [`BrowserRefreshTagHelperComponent`](Web.Middleware/BrowserRefreshTagHelperComponent.cs)
+  only while browser tooling is active. This automatically appends the external client
+  script for pages that execute the built-in `BodyTagHelper`, without rewriting the
+  response stream. Static HTML (including hosted Blazor WASM `index.html`) and custom
+  rendering that bypasses that TagHelper pipeline require explicit activation; hosted
+  Blazor WASM retains the legacy stream-injection fallback. Do not add YARP to MVC apps
+  or introduce a build-time `index.html` rewrite for this path.
 - **`CompilationHandler` drives Roslyn** via
   `Microsoft.CodeAnalysis.ExternalAccess.HotReload`; unsupported edits fall
   back to a full rebuild + restart.

--- a/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/AbstractBrowserRefreshServer.cs
@@ -106,6 +106,7 @@ internal abstract class AbstractBrowserRefreshServer(
             middlewareAssemblyPath,
             this,
             BrowserToolsLaunchFeatures.BrowserRefresh |
+            BrowserToolsLaunchFeatures.LegacyHtmlInjection |
             (enableHotReload ? BrowserToolsLaunchFeatures.ManagedHotReload : BrowserToolsLaunchFeatures.None))
             .ConfigureLaunchEnvironment(builder);
 

--- a/src/Dotnet.Watch/HotReloadClient/Web/HostingStartupBrowserToolsLaunchConfigurator.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/HostingStartupBrowserToolsLaunchConfigurator.cs
@@ -30,6 +30,11 @@ internal sealed class HostingStartupBrowserToolsLaunchConfigurator(
             environment[MiddlewareEnvironmentVariables.DotNetModifiableAssemblies] = "debug";
         }
 
+        if (features.HasFlag(BrowserToolsLaunchFeatures.LegacyHtmlInjection))
+        {
+            environment[MiddlewareEnvironmentVariables.AspNetCoreAutoReloadUseLegacyHtmlInjection] = bool.TrueString;
+        }
+
         if (browserRefreshServer.Logger.IsEnabled(Microsoft.Extensions.Logging.LogLevel.Trace))
         {
             environment[MiddlewareEnvironmentVariables.LoggingLevel] = "Debug";

--- a/src/Dotnet.Watch/HotReloadClient/Web/IBrowserToolsLaunchConfigurator.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/IBrowserToolsLaunchConfigurator.cs
@@ -18,5 +18,6 @@ internal enum BrowserToolsLaunchFeatures
 {
     None = 0,
     BrowserRefresh = 1,
-    ManagedHotReload = 2
+    ManagedHotReload = 2,
+    LegacyHtmlInjection = 4
 }

--- a/src/Dotnet.Watch/HotReloadClient/Web/MiddlewareEnvironmentVariables.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/MiddlewareEnvironmentVariables.cs
@@ -36,6 +36,8 @@ internal static class MiddlewareEnvironmentVariables
     /// </summary>
     public const string AspNetCoreAutoReloadWSKey = "ASPNETCORE_AUTO_RELOAD_WS_KEY";
 
+    public const string AspNetCoreAutoReloadUseLegacyHtmlInjection = "ASPNETCORE_AUTO_RELOAD_USE_LEGACY_HTML_INJECTION";
+
     /// <summary>
     /// Variable used to set the logging level of the middleware logger.
     /// </summary>

--- a/src/Dotnet.Watch/Watch/AppModels/BlazorWebAssemblyHostedAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/BlazorWebAssemblyHostedAppModel.cs
@@ -21,6 +21,9 @@ internal sealed class BlazorWebAssemblyHostedAppModel(DotNetWatchContext context
 
     public override bool ManagedHotReloadRequiresBrowserRefresh => true;
 
+    protected override BrowserToolsLaunchFeatures AdditionalBrowserToolsLaunchFeatures
+        => BrowserToolsLaunchFeatures.LegacyHtmlInjection;
+
     protected override ImmutableArray<HotReloadClient> CreateManagedClients(ILogger clientLogger, ILogger agentLogger, BrowserRefreshServer? browserRefreshServer)
     {
         Debug.Assert(browserRefreshServer != null);

--- a/src/Dotnet.Watch/Watch/AppModels/WebApplicationAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/WebApplicationAppModel.cs
@@ -29,6 +29,12 @@ internal abstract class WebApplicationAppModel(DotNetWatchContext context) : Hot
 
     protected abstract ImmutableArray<HotReloadClient> CreateManagedClients(ILogger clientLogger, ILogger agentLogger, BrowserRefreshServer? browserRefreshServer);
 
+    protected virtual BrowserToolsLaunchFeatures AdditionalBrowserToolsLaunchFeatures
+        => BrowserToolsLaunchFeatures.None;
+
+    internal BrowserToolsLaunchFeatures GetBrowserToolsLaunchFeatures(BrowserToolsLaunchFeatures features)
+        => features | AdditionalBrowserToolsLaunchFeatures;
+
     public async sealed override ValueTask<HotReloadClients> CreateClientsAsync(ILogger clientLogger, ILogger agentLogger, CancellationToken cancellationToken)
     {
         var browserRefreshServer = await context.BrowserRefreshServerFactory.GetOrCreateBrowserRefreshServerAsync(LaunchingProject, this, cancellationToken);
@@ -40,8 +46,9 @@ internal abstract class WebApplicationAppModel(DotNetWatchContext context) : Hot
         var launchConfigurator = browserRefreshServer != null
             ? CreateBrowserToolsLaunchConfigurator(
                 browserRefreshServer,
-                BrowserToolsLaunchFeatures.BrowserRefresh |
-                (managedClients.IsEmpty ? BrowserToolsLaunchFeatures.None : BrowserToolsLaunchFeatures.ManagedHotReload))
+                GetBrowserToolsLaunchFeatures(
+                    BrowserToolsLaunchFeatures.BrowserRefresh |
+                    (managedClients.IsEmpty ? BrowserToolsLaunchFeatures.None : BrowserToolsLaunchFeatures.ManagedHotReload)))
             : null;
 
         return new HotReloadClients(

--- a/src/Dotnet.Watch/Web.Middleware/BrowserRefreshMiddleware.cs
+++ b/src/Dotnet.Watch/Web.Middleware/BrowserRefreshMiddleware.cs
@@ -21,15 +21,29 @@ public sealed class BrowserRefreshMiddleware
     private static readonly MediaTypeHeaderValue s_applicationJsonMediaType = new("application/json");
     private readonly RequestDelegate _next;
     private readonly ILogger<BrowserRefreshMiddleware> _logger;
+    private readonly bool _useLegacyHtmlInjection;
     private string? _dotnetModifiableAssemblies = GetNonEmptyEnvironmentVariableValue("DOTNET_MODIFIABLE_ASSEMBLIES");
     private string? _aspnetcoreBrowserTools = GetNonEmptyEnvironmentVariableValue("__ASPNETCORE_BROWSER_TOOLS");
 
     public BrowserRefreshMiddleware(RequestDelegate next, ILogger<BrowserRefreshMiddleware> logger)
+        : this(next, logger, BrowserToolsEnvironment.LegacyHtmlInjectionEnabled)
+    {
+    }
+
+    internal BrowserRefreshMiddleware(
+        RequestDelegate next,
+        ILogger<BrowserRefreshMiddleware> logger,
+        bool useLegacyHtmlInjection)
     {
         _next = next;
         _logger = logger;
+        _useLegacyHtmlInjection = useLegacyHtmlInjection;
 
-        logger.LogDebug("Middleware loaded: DOTNET_MODIFIABLE_ASSEMBLIES={ModifiableAssemblies}, __ASPNETCORE_BROWSER_TOOLS={BrowserTools}", _dotnetModifiableAssemblies, _aspnetcoreBrowserTools);
+        logger.LogDebug(
+            "Middleware loaded: DOTNET_MODIFIABLE_ASSEMBLIES={ModifiableAssemblies}, __ASPNETCORE_BROWSER_TOOLS={BrowserTools}, Legacy HTML injection={LegacyHtmlInjection}",
+            _dotnetModifiableAssemblies,
+            _aspnetcoreBrowserTools,
+            _useLegacyHtmlInjection);
     }
 
     private static string? GetNonEmptyEnvironmentVariableValue(string name)
@@ -42,7 +56,7 @@ public sealed class BrowserRefreshMiddleware
             AttachWebAssemblyHeaders(context);
             await _next(context);
         }
-        else if (IsBrowserDocumentRequest(context))
+        else if (_useLegacyHtmlInjection && IsBrowserDocumentRequest(context))
         {
             // Use a custom StreamWrapper to rewrite output on Write/WriteAsync
             using var responseStreamWrapper = new ResponseStreamWrapper(context, _logger);

--- a/src/Dotnet.Watch/Web.Middleware/BrowserRefreshTagHelperComponent.cs
+++ b/src/Dotnet.Watch/Web.Middleware/BrowserRefreshTagHelperComponent.cs
@@ -1,0 +1,30 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.Razor.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Microsoft.AspNetCore.Watch.BrowserRefresh;
+
+internal sealed class BrowserRefreshTagHelperComponent : ITagHelperComponent
+{
+    public int Order => int.MaxValue;
+
+    public void Init(TagHelperContext context)
+    {
+    }
+
+    public Task ProcessAsync(TagHelperContext context, TagHelperOutput output)
+    {
+        if (string.Equals(context.TagName, "body", StringComparison.OrdinalIgnoreCase))
+        {
+            output.PostContent.AppendHtml(ScriptInjectingStream.InjectedScript);
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/src/Dotnet.Watch/Web.Middleware/BrowserToolsEnvironment.cs
+++ b/src/Dotnet.Watch/Web.Middleware/BrowserToolsEnvironment.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#nullable enable
+
+using System;
+
+namespace Microsoft.AspNetCore.Watch.BrowserRefresh;
+
+internal static class BrowserToolsEnvironment
+{
+    public const string WebSocketEndpoint = "ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT";
+    public const string UseLegacyHtmlInjection = "ASPNETCORE_AUTO_RELOAD_USE_LEGACY_HTML_INJECTION";
+
+    public static bool IsActive
+        => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable(WebSocketEndpoint));
+
+    public static bool LegacyHtmlInjectionEnabled
+        => string.Equals(
+            Environment.GetEnvironmentVariable(UseLegacyHtmlInjection),
+            bool.TrueString,
+            StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Dotnet.Watch/Web.Middleware/HostingStartup.cs
+++ b/src/Dotnet.Watch/Web.Middleware/HostingStartup.cs
@@ -7,6 +7,7 @@ using System;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -18,7 +19,16 @@ internal sealed class HostingStartup : IHostingStartup, IStartupFilter
 {
     public void Configure(IWebHostBuilder builder)
     {
-        builder.ConfigureServices(services => services.TryAddEnumerable(ServiceDescriptor.Singleton<IStartupFilter>(this)));
+        builder.ConfigureServices(services => ConfigureServices(services, BrowserToolsEnvironment.IsActive));
+    }
+
+    internal void ConfigureServices(IServiceCollection services, bool browserToolsActive)
+    {
+        services.TryAddEnumerable(ServiceDescriptor.Singleton<IStartupFilter>(this));
+        if (browserToolsActive)
+        {
+            services.TryAddEnumerable(ServiceDescriptor.Singleton<ITagHelperComponent, BrowserRefreshTagHelperComponent>());
+        }
     }
 
     public Action<IApplicationBuilder> Configure(Action<IApplicationBuilder> next)

--- a/src/Dotnet.Watch/dotnet-watch/Watch/DotNetWatcher.cs
+++ b/src/Dotnet.Watch/dotnet-watch/Watch/DotNetWatcher.cs
@@ -73,7 +73,7 @@ internal static class DotNetWatcher
             {
                 webAppModel!.CreateBrowserToolsLaunchConfigurator(
                     browserRefreshServer,
-                    BrowserToolsLaunchFeatures.BrowserRefresh).ConfigureLaunchEnvironment(environmentBuilder);
+                    webAppModel.GetBrowserToolsLaunchFeatures(BrowserToolsLaunchFeatures.BrowserRefresh)).ConfigureLaunchEnvironment(environmentBuilder);
             }
 
             Action<OutputLine>? outputObserver = null;

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshMiddlewareTest.cs
@@ -606,7 +606,24 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
             Assert.DoesNotContain("<script src=\"/_framework/aspnetcore-browser-refresh.js\"></script>", responseContent);
         }
 
-        private async Task<string> TestBrowserRefreshMiddleware(int statusCode, string contentType, string content, bool includeHtmlWrapper = true)
+        [TestMethod]
+        public async Task InvokeAsync_DoesNotRewriteHtml_WhenLegacyInjectionIsDisabled()
+        {
+            var responseContent = await TestBrowserRefreshMiddleware(
+                StatusCodes.Status200OK,
+                "text/html",
+                "Test Content",
+                useLegacyHtmlInjection: false);
+
+            Assert.DoesNotContain("<script src=\"/_framework/aspnetcore-browser-refresh.js\"></script>", responseContent);
+        }
+
+        private async Task<string> TestBrowserRefreshMiddleware(
+            int statusCode,
+            string contentType,
+            string content,
+            bool includeHtmlWrapper = true,
+            bool useLegacyHtmlInjection = true)
         {
             // Arrange
             var stream = new MemoryStream();
@@ -642,7 +659,7 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
                 {
                     await context.Response.WriteAsync(content, TestContext.CancellationToken);
                 }
-            }, NullLogger<BrowserRefreshMiddleware>.Instance);
+            }, NullLogger<BrowserRefreshMiddleware>.Instance, useLegacyHtmlInjection);
 
             // Act
             await middleware.InvokeAsync(context);

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshTagHelperComponentTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/BrowserRefreshTagHelperComponentTest.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace Microsoft.AspNetCore.Watch.BrowserRefresh;
+
+[TestClass]
+public class BrowserRefreshTagHelperComponentTest
+{
+    [TestMethod]
+    public async Task ProcessAsync_AppendsBrowserRefreshScriptToBody()
+    {
+        var component = new BrowserRefreshTagHelperComponent();
+        var output = CreateOutput("body");
+
+        await component.ProcessAsync(CreateContext("body"), output);
+
+        Assert.AreEqual(int.MaxValue, component.Order);
+        Assert.AreEqual(
+            "<script src=\"/_framework/aspnetcore-browser-refresh.js\"></script>",
+            output.PostContent.GetContent());
+    }
+
+    [TestMethod]
+    public async Task ProcessAsync_DoesNotModifyOtherTags()
+    {
+        var component = new BrowserRefreshTagHelperComponent();
+        var output = CreateOutput("head");
+
+        await component.ProcessAsync(CreateContext("head"), output);
+
+        Assert.AreEqual(string.Empty, output.PostContent.GetContent());
+    }
+
+    private static TagHelperContext CreateContext(string tagName)
+        => new(
+            tagName,
+            new TagHelperAttributeList(),
+            new Dictionary<object, object>(),
+            uniqueId: "test");
+
+    private static TagHelperOutput CreateOutput(string tagName)
+        => new(
+            tagName,
+            new TagHelperAttributeList(),
+            static (_, _) => Task.FromResult<TagHelperContent>(new DefaultTagHelperContent()));
+}

--- a/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/HostingStartupTest.cs
+++ b/test/Microsoft.AspNetCore.Watch.BrowserRefresh.Tests/HostingStartupTest.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Razor.TagHelpers;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Microsoft.AspNetCore.Watch.BrowserRefresh
@@ -165,6 +166,33 @@ namespace Microsoft.AspNetCore.Watch.BrowserRefresh
 
             // Assert
             Assert.AreEqual(StatusCodes.Status226IMUsed, context.Response.StatusCode);
+        }
+
+        [TestMethod]
+        public void ConfigureServices_RegistersTagHelperComponent_WhenBrowserToolsAreActive()
+        {
+            var services = new ServiceCollection();
+
+            new HostingStartup().ConfigureServices(services, browserToolsActive: true);
+
+            var descriptors = services
+                .Where(static descriptor => descriptor.ServiceType == typeof(ITagHelperComponent))
+                .ToArray();
+
+            Assert.HasCount(1, descriptors);
+            Assert.AreEqual(typeof(BrowserRefreshTagHelperComponent), descriptors[0].ImplementationType);
+        }
+
+        [TestMethod]
+        public void ConfigureServices_DoesNotRegisterTagHelperComponent_WhenBrowserToolsAreInactive()
+        {
+            var services = new ServiceCollection();
+
+            new HostingStartup().ConfigureServices(services, browserToolsActive: false);
+
+            Assert.DoesNotContain(
+                static descriptor => descriptor.ServiceType == typeof(ITagHelperComponent),
+                services);
         }
 
         private static RequestDelegate GetRequestDelegate(Action<IApplicationBuilder>? configureBuilder = null)

--- a/test/dotnet-watch.Tests/Browser/BlazorWebAssemblyAppModelTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BlazorWebAssemblyAppModelTests.cs
@@ -69,6 +69,21 @@ public sealed class BlazorWebAssemblyAppModelTests : DotNetWatchTestBase
         Assert.IsInstanceOfType<HostingStartupBrowserToolsLaunchConfigurator>(configurator);
     }
 
+    [TestMethod]
+    public void GetBrowserToolsLaunchFeatures_HostedWasm_EnablesLegacyHtmlInjection()
+    {
+        var appModel = new BlazorWebAssemblyHostedAppModel(
+            context: null!,
+            clientProject: null!,
+            serverProject: null!);
+
+        var features = appModel.GetBrowserToolsLaunchFeatures(BrowserToolsLaunchFeatures.BrowserRefresh);
+
+        Assert.AreEqual(
+            BrowserToolsLaunchFeatures.BrowserRefresh | BrowserToolsLaunchFeatures.LegacyHtmlInjection,
+            features);
+    }
+
     private BlazorWebAssemblyAppModel CreateAppModel(string targetFramework)
     {
         var testAsset = TestAssets.CopyTestAsset("WatchBlazorWasm", identifier: targetFramework)

--- a/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserRefreshServerTests.cs
@@ -40,6 +40,7 @@ public class BrowserRefreshServerTests
         var expected = new List<string>()
         {
             "ASPNETCORE_AUTO_RELOAD_VDIR=/test/virt/dir",
+            "ASPNETCORE_AUTO_RELOAD_USE_LEGACY_HTML_INJECTION=True",
             "ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT=http://test.endpoint",
             "ASPNETCORE_HOSTINGSTARTUPASSEMBLIES=" + middlewareFileName,
             "DOTNET_STARTUP_HOOKS=" + middlewarePath,
@@ -83,6 +84,7 @@ public class BrowserRefreshServerTests
         Assert.IsTrue(environment.Remove("ASPNETCORE_AUTO_RELOAD_WS_KEY"));
         AssertEx.SequenceEqual(
         [
+            "ASPNETCORE_AUTO_RELOAD_USE_LEGACY_HTML_INJECTION=True",
             "ASPNETCORE_AUTO_RELOAD_VDIR=/test/virt/dir",
             "ASPNETCORE_AUTO_RELOAD_WS_ENDPOINT=http://test.endpoint",
             $"ASPNETCORE_HOSTINGSTARTUPASSEMBLIES={middlewareAssemblyName};Existing.HostingStartup",


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on and dependent on #56071. Review this PR against `javiercn-implement-gateway-hot-reload`; it contains only the incremental MVC/Razor Pages activation changes.

## Summary

- register an `ITagHelperComponent` from the existing browser-refresh hosting startup while browser tooling is active
- append the existing external browser-tools script once, at the end of rendered `<body>` content through the built-in `BodyTagHelper` pipeline
- disable generic response-stream rewriting for MVC/Razor Pages while retaining an explicit legacy fallback for hosted Blazor WebAssembly static `index.html`, including restart-only watch mode
- document that built-in MVC/Razor Pages body TagHelpers activate automatically, while custom/static HTML requires user-provided activation

The existing hosting-startup and DeltaApplier process-loading paths remain separate. This change does not add YARP to MVC applications and does not implement build-time `index.html` rewriting.

## Manual validation

Created a real Razor Pages app with the locally built .NET 11 SDK, then ran:

```powershell
$redist='C:\Users\jacalvar\source\repos\copilot-worktrees\sdk\javiercn-fictional-succotash\artifacts\bin\redist\Debug\dotnet'
$app='C:\Users\jacalvar\.copilot\session-state\5219b316-5710-4504-97ae-244a45eb681e\files\mvc-taghelper-manual\App'
$env:DOTNET_ROOT=$redist
$env:DOTNET_MULTILEVEL_LOOKUP='0'
$env:DOTNET_WATCH_SUPPRESS_LAUNCH_BROWSER='1'
$env:ASPNETCORE_URLS='http://localhost:5017'
Push-Location $app
& "$redist\dotnet.exe" watch --no-launch-profile
```

Observed in a real browser:

- Home and Privacy each rendered exactly one `/_framework/aspnetcore-browser-refresh.js` script, as the final `<body>` element; navigating layouts/pages did not duplicate it.
- The browser-tools client loaded and connected.
- Editing `Pages\Index.cshtml` updated the live heading to `TagHelper browser refresh live!`; watch logged `C# and Razor changes applied in 1573ms` and only one `Now listening` launch occurred, proving no restart.
- The watched process retained the BrowserRefresh hosting startup and the separate BrowserRefresh/DeltaApplier startup hooks. Normal Razor Pages launch did not receive `ASPNETCORE_AUTO_RELOAD_USE_LEGACY_HTML_INJECTION`.

Then ran the app without tooling:

```powershell
$env:ASPNETCORE_URLS='http://localhost:5018'
& "$redist\dotnet.exe" run --no-build --no-launch-profile
```

The page started and rendered with zero browser-refresh script tags and no browser-tools sentinel. The no-launch-profile Production run also reported an unrelated missing generated scoped-CSS development asset; that environment-only static-assets warning did not affect the activation checks. The external NuGet credential-provider workaround was not needed in this fork.

## Automated validation

- `build.cmd`
- `RunTests.cs --project test\Microsoft.AspNetCore.Watch.BrowserRefresh.Tests\Microsoft.AspNetCore.Watch.BrowserRefresh.Tests.csproj`: 115 passed
- `RunTests.cs --project test\dotnet-watch.Tests\dotnet-watch.Tests.csproj --filter "FullyQualifiedName~BrowserRefreshServerTests|FullyQualifiedName~BlazorWebAssemblyAppModelTests"`: 18 passed

## Boundaries

MVC and Razor Pages are automatic only when rendering executes the built-in body TagHelper. Static HTML, custom rendering that bypasses it, and hosted Blazor WebAssembly `index.html` are not covered by `ITagHelperComponent`; hosted Blazor WebAssembly keeps the existing stream fallback to prevent regression. Static/custom applications otherwise require explicit script activation. There is no build-time HTML rewriting in this change.

**Design deviations:** none.
