### PR TITLE
Expand MSBuild properties across launch profiles

### DIFF
--- a/src/Cli/dotnet/Commands/Run/AotRunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/AotRunCommand.cs
@@ -266,7 +266,12 @@ internal static class AotRunCommand
             // Explicit verbosity is not eligible for the AOT path, so every reachable invocation
             // has the managed command's default non-quiet run verbosity.
             reportUsingLaunchSettings: true,
-            (message, isError) => messages.Add((message, isError)));
+            (message, isError) => messages.Add((message, isError)),
+            new LaunchProfileParserOptions(
+                ExpandMSBuildProperty: null,
+                ExpandProjectProfile: false,
+                ExpandExecutableProfile: false,
+                ExpandCommandLineArgs: false));
         if (result.FailureReason is not null)
         {
             messages.Add((string.Format(

--- a/src/Cli/dotnet/Commands/Run/AotRunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/AotRunCommand.cs
@@ -268,7 +268,7 @@ internal static class AotRunCommand
             reportUsingLaunchSettings: true,
             (message, isError) => messages.Add((message, isError)),
             new LaunchProfileParserOptions(
-                ExpandMSBuildProperty: null,
+                EvaluateExpression: null,
                 ExpandProjectProfile: false,
                 ExpandExecutableProfile: false,
                 ExpandCommandLineArgs: false),

--- a/src/Cli/dotnet/Commands/Run/AotRunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/AotRunCommand.cs
@@ -118,6 +118,10 @@ internal static class AotRunCommand
         if (profileResult.Profile is ExecutableLaunchProfile executableProfile &&
             (executableCanBypassCache || plan?.Tier == RunTier.CachedLaunch))
         {
+            EnsureLaunchProfileDoesNotRequireMSBuild(
+                executableProfile,
+                baseArguments: null,
+                applicationArguments);
             if (noBuild)
             {
                 artifactsPath = null;
@@ -135,6 +139,10 @@ internal static class AotRunCommand
         else if (plan is { Launch: { } launchInfo })
         {
             validatedRunProperties = launchInfo.RunProperties;
+            EnsureLaunchProfileDoesNotRequireMSBuild(
+                profileResult.Profile,
+                validatedRunProperties?.Arguments,
+                applicationArguments);
             command = launchInfo.Command;
             commandArguments = CommonRunHelpers.CombineRunArguments(
                 validatedRunProperties?.Arguments,
@@ -192,6 +200,32 @@ internal static class AotRunCommand
             workingDirectory,
             artifactsPath));
         return exitCode;
+    }
+
+    private static void EnsureLaunchProfileDoesNotRequireMSBuild(
+        LaunchProfile? launchProfile,
+        string? baseArguments,
+        string[] applicationArguments)
+    {
+        bool requiresMSBuild = launchProfile switch
+        {
+            ExecutableLaunchProfile profile =>
+                LaunchProfileParser.RequiresMSBuildExpansion(profile.ExecutablePath) ||
+                LaunchProfileParser.RequiresMSBuildExpansion(profile.WorkingDirectory) ||
+                profile.EnvironmentVariables.Values.Any(LaunchProfileParser.RequiresMSBuildExpansion),
+            ProjectLaunchProfile profile =>
+                LaunchProfileParser.RequiresMSBuildExpansion(profile.ApplicationUrl) ||
+                profile.EnvironmentVariables.Values.Any(LaunchProfileParser.RequiresMSBuildExpansion),
+            _ => false,
+        };
+
+        if (requiresMSBuild ||
+            (applicationArguments.Length == 0 &&
+             string.IsNullOrEmpty(baseArguments) &&
+             LaunchProfileParser.RequiresMSBuildExpansion(launchProfile?.CommandLineArgs)))
+        {
+            throw CreateManagedFallbackException("the launch profile contains MSBuild properties");
+        }
     }
 
     private static int Launch(AotRunInvocation invocation)

--- a/src/Cli/dotnet/Commands/Run/AotRunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/AotRunCommand.cs
@@ -271,7 +271,8 @@ internal static class AotRunCommand
                 ExpandMSBuildProperty: null,
                 ExpandProjectProfile: false,
                 ExpandExecutableProfile: false,
-                ExpandCommandLineArgs: false));
+                ExpandCommandLineArgs: false),
+            out _);
         if (result.FailureReason is not null)
         {
             messages.Add((string.Format(

--- a/src/Cli/dotnet/Commands/Run/Api/RunApiCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/Api/RunApiCommand.cs
@@ -130,7 +130,9 @@ internal abstract class RunApiInput
                 readCodeFromStdin: false,
                 environmentVariables: ReadOnlyDictionary<string, string>.Empty);
 
-            var result = runCommand.ReadLaunchProfileSettings();
+            var result = runCommand.ReadLaunchProfileSettings(
+                buildCommand.CreateProjectInstance,
+                expandExecutableProfile: true);
             var targetCommand = (Utils.Command)runCommand.GetTargetCommand(result.Profile, buildCommand.CreateProjectInstance, cachedRunProperties: null, runPropertiesFromEvaluation: false, logger: null);
 
             return new RunApiOutput.RunCommand

--- a/src/Cli/dotnet/Commands/Run/Api/RunApiCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/Api/RunApiCommand.cs
@@ -132,7 +132,8 @@ internal abstract class RunApiInput
 
             var result = runCommand.ReadLaunchProfileSettings(
                 buildCommand.CreateProjectInstance,
-                expandExecutableProfile: true);
+                expandExecutableProfile: true,
+                out _);
             var targetCommand = (Utils.Command)runCommand.GetTargetCommand(result.Profile, buildCommand.CreateProjectInstance, cachedRunProperties: null, runPropertiesFromEvaluation: false, logger: null);
 
             return new RunApiOutput.RunCommand

--- a/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
+++ b/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
@@ -138,7 +138,8 @@ internal static class CommonRunHelpers
         string? launchProfile,
         bool noLaunchProfile,
         bool reportUsingLaunchSettings,
-        Action<string, bool> report)
+        Action<string, bool> report,
+        Func<string, string>? expandMSBuildProperty = null)
     {
         if (noLaunchProfile || projectOrEntryPointFilePath is null)
         {
@@ -159,7 +160,7 @@ internal static class CommonRunHelpers
             report(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath), true);
         }
 
-        return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, launchProfile);
+        return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, launchProfile, expandMSBuildProperty);
     }
 
     /// <summary>

--- a/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
+++ b/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
@@ -3,6 +3,9 @@
 
 using System.CommandLine;
 using System.CommandLine.Parsing;
+#if !CLI_AOT
+using Microsoft.Build.Exceptions;
+#endif
 using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.FileBasedPrograms;
 using Microsoft.DotNet.ProjectTools;
@@ -160,7 +163,26 @@ internal static class CommonRunHelpers
             report(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath), true);
         }
 
+        return ReadLaunchProfileFromFile(launchSettingsPath, launchProfile, expandMSBuildProperty);
+    }
+
+    internal static LaunchProfileParseResult ReadLaunchProfileFromFile(
+        string launchSettingsPath,
+        string? launchProfile,
+        Func<string, string>? expandMSBuildProperty)
+    {
+#if CLI_AOT
         return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, launchProfile, expandMSBuildProperty);
+#else
+        try
+        {
+            return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, launchProfile, expandMSBuildProperty);
+        }
+        catch (InvalidProjectFileException ex)
+        {
+            return LaunchProfileParseResult.Failure(ex.Message);
+        }
+#endif
     }
 
     /// <summary>

--- a/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
+++ b/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
@@ -142,14 +142,16 @@ internal static class CommonRunHelpers
         bool noLaunchProfile,
         bool reportUsingLaunchSettings,
         Action<string, bool> report,
-        LaunchProfileParserOptions parserOptions)
+        LaunchProfileParserOptions parserOptions,
+        out string? launchSettingsPath)
     {
+        launchSettingsPath = null;
         if (noLaunchProfile || projectOrEntryPointFilePath is null)
         {
             return LaunchProfileParseResult.Success(model: null);
         }
 
-        string? launchSettingsPath = LaunchSettings.TryFindLaunchSettingsFile(
+        launchSettingsPath = LaunchSettings.TryFindLaunchSettingsFile(
             projectOrEntryPointFilePath,
             launchProfile,
             report);

--- a/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
+++ b/src/Cli/dotnet/Commands/Run/CommonRunHelpers.cs
@@ -142,7 +142,7 @@ internal static class CommonRunHelpers
         bool noLaunchProfile,
         bool reportUsingLaunchSettings,
         Action<string, bool> report,
-        Func<string, string>? expandMSBuildProperty = null)
+        LaunchProfileParserOptions parserOptions)
     {
         if (noLaunchProfile || projectOrEntryPointFilePath is null)
         {
@@ -163,20 +163,20 @@ internal static class CommonRunHelpers
             report(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath), true);
         }
 
-        return ReadLaunchProfileFromFile(launchSettingsPath, launchProfile, expandMSBuildProperty);
+        return ReadLaunchProfileFromFile(launchSettingsPath, launchProfile, parserOptions);
     }
 
     internal static LaunchProfileParseResult ReadLaunchProfileFromFile(
         string launchSettingsPath,
         string? launchProfile,
-        Func<string, string>? expandMSBuildProperty)
+        LaunchProfileParserOptions parserOptions)
     {
 #if CLI_AOT
-        return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, launchProfile, expandMSBuildProperty);
+        return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, launchProfile, parserOptions);
 #else
         try
         {
-            return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, launchProfile, expandMSBuildProperty);
+            return LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, launchProfile, parserOptions);
         }
         catch (InvalidProjectFileException ex)
         {

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -490,7 +490,7 @@ public class RunCommand
         try
         {
             return read(new LaunchProfileParserOptions(
-                ExpandMSBuildProperty,
+                EvaluateExpression,
                 ExpandProjectProfile: false,
                 ExpandExecutableProfile: expandExecutableProfile,
                 ExpandCommandLineArgs: !NoLaunchProfileArguments && ApplicationArgs.Length == 0));
@@ -500,7 +500,7 @@ public class RunCommand
             environmentScope?.Dispose();
         }
 
-        string ExpandMSBuildProperty(string property)
+        string EvaluateExpression(string expression)
         {
             environmentScope ??= MSBuildForwardingAppWithoutLogging.SetMSBuildRequiredEnvironmentVariables();
             project ??= EvaluateProject(
@@ -508,7 +508,7 @@ public class RunCommand
                 projectFactory ?? (EntryPointFileFullPath is null ? null : CreateProjectBuilder().CreateProjectInstance),
                 MSBuildArgs,
                 binaryLogger: null);
-            return project.ExpandString(property);
+            return project.ExpandString(expression);
         }
     }
 

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -166,11 +166,19 @@ public class RunCommand
                 return 1;
             }
 
-            var launchProfileParseResult = ReadLaunchProfileSettings();
-            if (launchProfileParseResult.FailureReason != null)
-            {
-                Reporter.Error.WriteLine(string.Format(CliCommandStrings.RunCommandExceptionCouldNotApplyLaunchSettings, LaunchProfileParser.GetLaunchProfileDisplayName(LaunchProfile), launchProfileParseResult.FailureReason).Bold().Red());
-            }
+            var launchProfileParseResult = ReadLaunchProfileSettings(
+                projectFactory: null,
+                expandExecutableProfile: false);
+            ReportLaunchProfileFailure(launchProfileParseResult);
+
+            bool requiresProjectExpansion = launchProfileParseResult.Profile is ProjectLaunchProfile projectProfile
+                && ProjectLaunchProfileParser.RequiresMSBuildExpansion(
+                    projectProfile,
+                    includeCommandLineArgs: !NoLaunchProfileArguments && ApplicationArgs.Length == 0);
+            bool requiresExecutableExpansion = launchProfileParseResult.Profile is ExecutableLaunchProfile executableProfile
+                && ExecutableLaunchProfileParser.RequiresMSBuildExpansion(
+                    executableProfile,
+                    includeCommandLineArgs: !NoLaunchProfileArguments && ApplicationArgs.Length == 0);
 
             Func<ProjectCollection, ProjectInstance>? projectFactory = null;
             RunProperties? cachedRunProperties = null;
@@ -183,7 +191,13 @@ public class RunCommand
                     Reporter.Output.WriteLine(CliCommandStrings.RunCommandBuilding);
                 }
 
-                EnsureProjectIsBuilt(out projectFactory, out cachedRunProperties, out projectBuilder, selector?.IntermediateOutputPath, selector?.HasRuntimeEnvironmentVariableSupport ?? false);
+                EnsureProjectIsBuilt(
+                    out projectFactory,
+                    out cachedRunProperties,
+                    out projectBuilder,
+                    selector?.IntermediateOutputPath,
+                    selector?.HasRuntimeEnvironmentVariableSupport ?? false,
+                    requiresProjectExpansion);
                 runPropertiesFromEvaluation = projectBuilder?.LastBuild.Level == BuildLevel.All;
             }
             else if (EntryPointFileFullPath is not null && launchProfileParseResult.Profile is not ExecutableLaunchProfile)
@@ -196,7 +210,9 @@ public class RunCommand
 
                 Reporter.Verbose.WriteLine("Checking changes for run properties");
                 var buildLevel = projectBuilder.GetBuildLevel(out var cache);
-                projectFactory = CanUseRunPropertiesForCscBuiltProgram(BuildLevel.None, cache?.PreviousEntry) ? null : projectBuilder.CreateProjectInstance;
+                projectFactory = requiresProjectExpansion || !CanUseRunPropertiesForCscBuiltProgram(BuildLevel.None, cache?.PreviousEntry)
+                    ? projectBuilder.CreateProjectInstance
+                    : null;
                 cachedRunProperties = buildLevel != BuildLevel.All ? cache?.PreviousEntry?.Run : null;
             }
 
@@ -209,6 +225,14 @@ public class RunCommand
                 {
                     throw new GracefulException(CliCommandStrings.RunCommandDeployFailed);
                 }
+            }
+
+            if (requiresExecutableExpansion)
+            {
+                launchProfileParseResult = ReadLaunchProfileSettings(
+                    projectFactory,
+                    expandExecutableProfile: true);
+                ReportLaunchProfileFailure(launchProfileParseResult);
             }
 
             var targetCommand = GetTargetCommand(launchProfileParseResult.Profile, projectFactory, cachedRunProperties, runPropertiesFromEvaluation, logger);
@@ -230,6 +254,17 @@ public class RunCommand
         finally
         {
             logger?.ReallyShutdown();
+        }
+
+        void ReportLaunchProfileFailure(LaunchProfileParseResult result)
+        {
+            if (result.FailureReason is not null)
+            {
+                Reporter.Error.WriteLine(string.Format(
+                    CliCommandStrings.RunCommandExceptionCouldNotApplyLaunchSettings,
+                    LaunchProfileParser.GetLaunchProfileDisplayName(LaunchProfile),
+                    result.FailureReason).Bold().Red());
+            }
         }
     }
 
@@ -413,7 +448,9 @@ public class RunCommand
         return command;
     }
 
-    internal LaunchProfileParseResult ReadLaunchProfileSettings()
+    internal LaunchProfileParseResult ReadLaunchProfileSettings(
+        Func<ProjectCollection, ProjectInstance>? projectFactory,
+        bool expandExecutableProfile)
     {
         IDisposable? environmentScope = null;
         ProjectInstance? project = null;
@@ -425,7 +462,11 @@ public class RunCommand
                 NoLaunchProfile,
                 reportUsingLaunchSettings: !RunCommandVerbosity.IsQuiet(),
                 static (message, isError) => (isError ? Reporter.Error : Reporter.Output).WriteLine(message),
-                ExpandMSBuildProperty);
+                new LaunchProfileParserOptions(
+                    ExpandMSBuildProperty,
+                    ExpandProjectProfile: false,
+                    ExpandExecutableProfile: expandExecutableProfile,
+                    ExpandCommandLineArgs: !NoLaunchProfileArguments && ApplicationArgs.Length == 0));
         }
         finally
         {
@@ -437,21 +478,29 @@ public class RunCommand
             environmentScope ??= MSBuildForwardingAppWithoutLogging.SetMSBuildRequiredEnvironmentVariables();
             project ??= EvaluateProject(
                 ProjectFileFullPath,
-                EntryPointFileFullPath is null ? null : CreateProjectBuilder().CreateProjectInstance,
+                projectFactory ?? (EntryPointFileFullPath is null ? null : CreateProjectBuilder().CreateProjectInstance),
                 MSBuildArgs,
                 binaryLogger: null);
             return project.ExpandString(property);
         }
     }
 
-    private void EnsureProjectIsBuilt(out Func<ProjectCollection, ProjectInstance>? projectFactory, out RunProperties? cachedRunProperties, out VirtualProjectBuildingCommand? projectBuilder, string? intermediateOutputPath, bool hasRuntimeEnvironmentVariableSupport)
+    private void EnsureProjectIsBuilt(
+        out Func<ProjectCollection, ProjectInstance>? projectFactory,
+        out RunProperties? cachedRunProperties,
+        out VirtualProjectBuildingCommand? projectBuilder,
+        string? intermediateOutputPath,
+        bool hasRuntimeEnvironmentVariableSupport,
+        bool requiresProjectExpansion)
     {
         int buildResult;
         if (EntryPointFileFullPath is not null)
         {
             projectBuilder = CreateProjectBuilder();
             buildResult = projectBuilder.Execute();
-            projectFactory = CanUseRunPropertiesForCscBuiltProgram(projectBuilder.LastBuild.Level, projectBuilder.LastBuild.Cache?.PreviousEntry) ? null : projectBuilder.CreateProjectInstance;
+            projectFactory = requiresProjectExpansion || !CanUseRunPropertiesForCscBuiltProgram(projectBuilder.LastBuild.Level, projectBuilder.LastBuild.Cache?.PreviousEntry)
+                ? projectBuilder.CreateProjectInstance
+                : null;
             cachedRunProperties = projectBuilder.LastRunProperties ?? projectBuilder.LastBuild.Cache?.CurrentEntry.Run;
         }
         else
@@ -544,15 +593,19 @@ public class RunCommand
     {
         ICommand command;
         ProjectInstance? project = null;
+        bool requiresProjectExpansion = launchSettings is not null
+            && ProjectLaunchProfileParser.RequiresMSBuildExpansion(
+                launchSettings,
+                includeCommandLineArgs: !NoLaunchProfileArguments && ApplicationArgs.Length == 0);
         IReadOnlyDictionary<string, string> runtimeEnvironmentVariables = EnvironmentVariables;
-        if (cachedRunProperties != null)
+        if (cachedRunProperties != null && !requiresProjectExpansion)
         {
             // We can skip project evaluation if we already evaluated the project during virtual build
             // or we have cached run properties in previous run (and this is a --no-build or skip-msbuild run).
             Reporter.Verbose.WriteLine($"Getting target command: from {(runPropertiesFromEvaluation ? "previous evaluation" : "cache")}.");
             command = CreateCommandFromRunProperties(cachedRunProperties.WithApplicationArguments(ApplicationArgs));
         }
-        else if (projectFactory is null && ProjectFileFullPath is null)
+        else if (projectFactory is null && ProjectFileFullPath is null && !requiresProjectExpansion)
         {
             // If we are running a file-based app and projectFactory is null, it means csc was used instead of full msbuild.
             // So we can skip project evaluation to continue the optimized path.
@@ -564,17 +617,10 @@ public class RunCommand
         {
             Reporter.Verbose.WriteLine("Getting target command: evaluating project.");
 
-            bool hasRuntimeEnvironmentVariableSupport;
-            try
-            {
-                using var _ = MSBuildForwardingAppWithoutLogging.SetMSBuildRequiredEnvironmentVariables();
-                project = EvaluateProject(ProjectFileFullPath, projectFactory, MSBuildArgs, logger);
-                ValidatePreconditions(project);
-                hasRuntimeEnvironmentVariableSupport = InvokeRunArgumentsTarget(project, NoBuild, logger, MSBuildArgs, EnvironmentVariables);
-            }
-            finally
-            {
-                    }
+            using var _ = MSBuildForwardingAppWithoutLogging.SetMSBuildRequiredEnvironmentVariables();
+            project = EvaluateProject(ProjectFileFullPath, projectFactory, MSBuildArgs, logger);
+            ValidatePreconditions(project);
+            bool hasRuntimeEnvironmentVariableSupport = InvokeRunArgumentsTarget(project, NoBuild, logger, MSBuildArgs, EnvironmentVariables);
 
             var runProperties = RunProperties.FromProject(project).WithApplicationArguments(ApplicationArgs);
             command = CreateCommandFromRunProperties(runProperties);
@@ -584,6 +630,28 @@ public class RunCommand
             if (hasRuntimeEnvironmentVariableSupport)
             {
                 runtimeEnvironmentVariables = EnvironmentVariablesToMSBuild.ReadFromItems(project);
+            }
+        }
+
+        if (requiresProjectExpansion)
+        {
+            ProjectLaunchProfile profile = launchSettings ?? throw new InvalidOperationException();
+            ProjectInstance expansionProject = project ?? throw new InvalidOperationException();
+            try
+            {
+                launchSettings = ProjectLaunchProfileParser.ExpandMSBuildProperties(
+                    profile,
+                    expansionProject.ExpandString,
+                    expandCommandLineArgs: !NoLaunchProfileArguments && string.IsNullOrEmpty(command.CommandArgs),
+                    expandApplicationUrl: true);
+            }
+            catch (InvalidProjectFileException ex)
+            {
+                Reporter.Error.WriteLine(string.Format(
+                    CliCommandStrings.RunCommandExceptionCouldNotApplyLaunchSettings,
+                    LaunchProfileParser.GetLaunchProfileDisplayName(LaunchProfile),
+                    ex.Message).Bold().Red());
+                launchSettings = null;
             }
         }
 

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -7,7 +7,6 @@ using System.CommandLine;
 using System.CommandLine.Parsing;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Text.RegularExpressions;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
@@ -27,8 +26,6 @@ namespace Microsoft.DotNet.Cli.Commands.Run;
 [RequiresDynamicCode("Uses MSBuild Object Model types, which are not AOT-safe")]
 public class RunCommand
 {
-    private static readonly Regex s_msBuildPropertyRegex = new(@"\$\((?!\[)(?<token>[^\)]+)\)", RegexOptions.IgnoreCase);
-
     public bool NoBuild { get; }
 
     /// <summary>
@@ -417,12 +414,35 @@ public class RunCommand
     }
 
     internal LaunchProfileParseResult ReadLaunchProfileSettings()
-        => CommonRunHelpers.ReadLaunchProfile(
-            ReadCodeFromStdin ? null : ProjectFileFullPath ?? EntryPointFileFullPath!,
-            LaunchProfile,
-            NoLaunchProfile,
-            reportUsingLaunchSettings: !RunCommandVerbosity.IsQuiet(),
-            static (message, isError) => (isError ? Reporter.Error : Reporter.Output).WriteLine(message));
+    {
+        IDisposable? environmentScope = null;
+        ProjectInstance? project = null;
+        try
+        {
+            return CommonRunHelpers.ReadLaunchProfile(
+                ReadCodeFromStdin ? null : ProjectFileFullPath ?? EntryPointFileFullPath!,
+                LaunchProfile,
+                NoLaunchProfile,
+                reportUsingLaunchSettings: !RunCommandVerbosity.IsQuiet(),
+                static (message, isError) => (isError ? Reporter.Error : Reporter.Output).WriteLine(message),
+                ExpandMSBuildProperty);
+        }
+        finally
+        {
+            environmentScope?.Dispose();
+        }
+
+        string ExpandMSBuildProperty(string property)
+        {
+            environmentScope ??= MSBuildForwardingAppWithoutLogging.SetMSBuildRequiredEnvironmentVariables();
+            project ??= EvaluateProject(
+                ProjectFileFullPath,
+                EntryPointFileFullPath is null ? null : CreateProjectBuilder().CreateProjectInstance,
+                MSBuildArgs,
+                binaryLogger: null);
+            return project.ExpandString(property);
+        }
+    }
 
     private void EnsureProjectIsBuilt(out Func<ProjectCollection, ProjectInstance>? projectFactory, out RunProperties? cachedRunProperties, out VirtualProjectBuildingCommand? projectBuilder, string? intermediateOutputPath, bool hasRuntimeEnvironmentVariableSupport)
     {
@@ -574,33 +594,10 @@ public class RunCommand
 
         if (!NoLaunchProfileArguments && string.IsNullOrEmpty(command.CommandArgs) && launchSettings?.CommandLineArgs != null)
         {
-            command.SetCommandArgs(
-                project is null
-                    ? launchSettings.CommandLineArgs
-                    : s_msBuildPropertyRegex.Replace(launchSettings.CommandLineArgs, match => project.ExpandString(match.Value)));
+            command.SetCommandArgs(launchSettings.CommandLineArgs);
         }
 
         return command;
-
-        static ProjectInstance EvaluateProject(string? projectFilePath, Func<ProjectCollection, ProjectInstance>? projectFactory, MSBuildArgs msbuildArgs, ILogger? binaryLogger)
-        {
-            var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
-            var collection = new ProjectCollection(globalProperties: globalProperties, loggers: binaryLogger is null ? null : [binaryLogger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
-
-            if (projectFactory != null)
-            {
-                return projectFactory(collection);
-            }
-
-            try
-            {
-                return collection.LoadProject(projectFilePath).CreateProjectInstance();
-            }
-            catch (InvalidProjectFileException e)
-            {
-                throw new GracefulException(string.Format(CliCommandStrings.RunCommandSpecifiedFileIsNotAValidProject, projectFilePath), e);
-            }
-        }
 
         static void ValidatePreconditions(ProjectInstance project)
         {
@@ -684,6 +681,30 @@ public class RunCommand
             }
 
             return hasRuntimeEnvironmentVariableSupport;
+        }
+    }
+
+    private static ProjectInstance EvaluateProject(
+        string? projectFilePath,
+        Func<ProjectCollection, ProjectInstance>? projectFactory,
+        MSBuildArgs msbuildArgs,
+        ILogger? binaryLogger)
+    {
+        var globalProperties = CommonRunHelpers.GetGlobalPropertiesFromArgs(msbuildArgs);
+        var collection = new ProjectCollection(globalProperties: globalProperties, loggers: binaryLogger is null ? null : [binaryLogger], toolsetDefinitionLocations: ToolsetDefinitionLocations.Default);
+
+        if (projectFactory != null)
+        {
+            return projectFactory(collection);
+        }
+
+        try
+        {
+            return collection.LoadProject(projectFilePath).CreateProjectInstance();
+        }
+        catch (InvalidProjectFileException e)
+        {
+            throw new GracefulException(string.Format(CliCommandStrings.RunCommandSpecifiedFileIsNotAValidProject, projectFilePath), e);
         }
     }
 

--- a/src/Cli/dotnet/Commands/Run/RunCommand.cs
+++ b/src/Cli/dotnet/Commands/Run/RunCommand.cs
@@ -168,7 +168,8 @@ public class RunCommand
 
             var launchProfileParseResult = ReadLaunchProfileSettings(
                 projectFactory: null,
-                expandExecutableProfile: false);
+                expandExecutableProfile: false,
+                out string? launchSettingsPath);
             ReportLaunchProfileFailure(launchProfileParseResult);
 
             bool requiresProjectExpansion = launchProfileParseResult.Profile is ProjectLaunchProfile projectProfile
@@ -230,6 +231,7 @@ public class RunCommand
             if (requiresExecutableExpansion)
             {
                 launchProfileParseResult = ReadLaunchProfileSettings(
+                    launchSettingsPath ?? throw new InvalidOperationException(),
                     projectFactory,
                     expandExecutableProfile: true);
                 ReportLaunchProfileFailure(launchProfileParseResult);
@@ -450,23 +452,48 @@ public class RunCommand
 
     internal LaunchProfileParseResult ReadLaunchProfileSettings(
         Func<ProjectCollection, ProjectInstance>? projectFactory,
-        bool expandExecutableProfile)
+        bool expandExecutableProfile,
+        out string? launchSettingsPath)
     {
-        IDisposable? environmentScope = null;
-        ProjectInstance? project = null;
-        try
-        {
-            return CommonRunHelpers.ReadLaunchProfile(
+        string? discoveredPath = null;
+        LaunchProfileParseResult result = ReadLaunchProfileSettingsCore(
+            projectFactory,
+            expandExecutableProfile,
+            options => CommonRunHelpers.ReadLaunchProfile(
                 ReadCodeFromStdin ? null : ProjectFileFullPath ?? EntryPointFileFullPath!,
                 LaunchProfile,
                 NoLaunchProfile,
                 reportUsingLaunchSettings: !RunCommandVerbosity.IsQuiet(),
                 static (message, isError) => (isError ? Reporter.Error : Reporter.Output).WriteLine(message),
-                new LaunchProfileParserOptions(
-                    ExpandMSBuildProperty,
-                    ExpandProjectProfile: false,
-                    ExpandExecutableProfile: expandExecutableProfile,
-                    ExpandCommandLineArgs: !NoLaunchProfileArguments && ApplicationArgs.Length == 0));
+                options,
+                out discoveredPath));
+        launchSettingsPath = discoveredPath;
+        return result;
+    }
+
+    private LaunchProfileParseResult ReadLaunchProfileSettings(
+        string launchSettingsPath,
+        Func<ProjectCollection, ProjectInstance>? projectFactory,
+        bool expandExecutableProfile)
+        => ReadLaunchProfileSettingsCore(
+            projectFactory,
+            expandExecutableProfile,
+            options => CommonRunHelpers.ReadLaunchProfileFromFile(launchSettingsPath, LaunchProfile, options));
+
+    private LaunchProfileParseResult ReadLaunchProfileSettingsCore(
+        Func<ProjectCollection, ProjectInstance>? projectFactory,
+        bool expandExecutableProfile,
+        Func<LaunchProfileParserOptions, LaunchProfileParseResult> read)
+    {
+        IDisposable? environmentScope = null;
+        ProjectInstance? project = null;
+        try
+        {
+            return read(new LaunchProfileParserOptions(
+                ExpandMSBuildProperty,
+                ExpandProjectProfile: false,
+                ExpandExecutableProfile: expandExecutableProfile,
+                ExpandCommandLineArgs: !NoLaunchProfileArguments && ApplicationArgs.Length == 0));
         }
         finally
         {

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -760,13 +760,40 @@ internal static class SolutionAndProjectUtility
             Reporter.Error.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
-        LaunchProfileParseResult result = CommonRunHelpers.ReadLaunchProfileFromFile(launchSettingsPath, profileName, expandMSBuildProperty);
+        LaunchProfileParseResult result = CommonRunHelpers.ReadLaunchProfileFromFile(
+            launchSettingsPath,
+            profileName,
+            new LaunchProfileParserOptions(
+                expandMSBuildProperty,
+                ExpandProjectProfile: false,
+                ExpandExecutableProfile: false,
+                ExpandCommandLineArgs: !buildOptions.NoLaunchProfileArguments));
         if (!result.Successful)
         {
             Reporter.Error.WriteLine(string.Format(CliCommandStrings.RunCommandExceptionCouldNotApplyLaunchSettings, profileName, result.FailureReason).Bold().Red());
             return null;
         }
 
-        return result.Profile;
+        if (result.Profile is not ProjectLaunchProfile projectProfile)
+        {
+            return result.Profile;
+        }
+
+        try
+        {
+            return ProjectLaunchProfileParser.ExpandMSBuildProperties(
+                projectProfile,
+                expandMSBuildProperty,
+                expandCommandLineArgs: !buildOptions.NoLaunchProfileArguments,
+                expandApplicationUrl: false);
+        }
+        catch (Microsoft.Build.Exceptions.InvalidProjectFileException ex)
+        {
+            Reporter.Error.WriteLine(string.Format(
+                CliCommandStrings.RunCommandExceptionCouldNotApplyLaunchSettings,
+                profileName,
+                ex.Message).Bold().Red());
+            return null;
+        }
     }
 }

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -6,7 +6,6 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
-using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Extensions;
@@ -761,16 +760,7 @@ internal static class SolutionAndProjectUtility
             Reporter.Error.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
-        LaunchProfileParseResult result;
-        try
-        {
-            result = LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, profileName, expandMSBuildProperty);
-        }
-        catch (InvalidProjectFileException ex)
-        {
-            result = LaunchProfileParseResult.Failure(ex.Message);
-        }
-
+        LaunchProfileParseResult result = CommonRunHelpers.ReadLaunchProfileFromFile(launchSettingsPath, profileName, expandMSBuildProperty);
         if (!result.Successful)
         {
             Reporter.Error.WriteLine(string.Format(CliCommandStrings.RunCommandExceptionCouldNotApplyLaunchSettings, profileName, result.FailureReason).Bold().Red());

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -640,7 +640,13 @@ internal static class SolutionAndProjectUtility
         }
 
         // TODO: Support --launch-profile and pass it here.
-        var launchSettings = TryGetLaunchProfileSettings(Path.GetDirectoryName(projectFullPath)!, Path.GetFileNameWithoutExtension(projectFullPath), project.GetPropertyValue(ProjectProperties.AppDesignerFolder), buildOptions, profileName: null);
+        var launchSettings = TryGetLaunchProfileSettings(
+            Path.GetDirectoryName(projectFullPath)!,
+            Path.GetFileNameWithoutExtension(projectFullPath),
+            project.GetPropertyValue(ProjectProperties.AppDesignerFolder),
+            buildOptions,
+            profileName: null,
+            project.ExpandString);
 
         var rootVariableName = EnvironmentVariableNames.TryGetDotNetRootArchVariableName(
             runProperties.RuntimeIdentifier,
@@ -713,7 +719,13 @@ internal static class SolutionAndProjectUtility
         }
     }
 
-    private static LaunchProfile? TryGetLaunchProfileSettings(string projectDirectory, string projectNameWithoutExtension, string appDesignerFolder, BuildOptions buildOptions, string? profileName)
+    private static LaunchProfile? TryGetLaunchProfileSettings(
+        string projectDirectory,
+        string projectNameWithoutExtension,
+        string appDesignerFolder,
+        BuildOptions buildOptions,
+        string? profileName,
+        Func<string, string> expandMSBuildProperty)
     {
         if (buildOptions.NoLaunchProfile)
         {
@@ -748,7 +760,7 @@ internal static class SolutionAndProjectUtility
             Reporter.Error.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
-        var result = LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, profileName);
+        var result = LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, profileName, expandMSBuildProperty);
         if (!result.Successful)
         {
             Reporter.Error.WriteLine(string.Format(CliCommandStrings.RunCommandExceptionCouldNotApplyLaunchSettings, profileName, result.FailureReason).Bold().Red());

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -725,7 +725,7 @@ internal static class SolutionAndProjectUtility
         string appDesignerFolder,
         BuildOptions buildOptions,
         string? profileName,
-        Func<string, string> expandMSBuildProperty)
+        Func<string, string> evaluateExpression)
     {
         if (buildOptions.NoLaunchProfile)
         {
@@ -764,7 +764,7 @@ internal static class SolutionAndProjectUtility
             launchSettingsPath,
             profileName,
             new LaunchProfileParserOptions(
-                expandMSBuildProperty,
+                evaluateExpression,
                 ExpandProjectProfile: false,
                 ExpandExecutableProfile: false,
                 ExpandCommandLineArgs: !buildOptions.NoLaunchProfileArguments));
@@ -783,7 +783,7 @@ internal static class SolutionAndProjectUtility
         {
             return ProjectLaunchProfileParser.ExpandMSBuildProperties(
                 projectProfile,
-                expandMSBuildProperty,
+                evaluateExpression,
                 expandCommandLineArgs: !buildOptions.NoLaunchProfileArguments,
                 expandApplicationUrl: false);
         }

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.Exceptions;
 using Microsoft.Build.Execution;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Extensions;
@@ -760,7 +761,16 @@ internal static class SolutionAndProjectUtility
             Reporter.Error.WriteLine(string.Format(CliCommandStrings.UsingLaunchSettingsFromMessage, launchSettingsPath));
         }
 
-        var result = LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, profileName, expandMSBuildProperty);
+        LaunchProfileParseResult result;
+        try
+        {
+            result = LaunchSettings.ReadProfileSettingsFromFile(launchSettingsPath, profileName, expandMSBuildProperty);
+        }
+        catch (InvalidProjectFileException ex)
+        {
+            result = LaunchProfileParseResult.Failure(ex.Message);
+        }
+
         if (!result.Successful)
         {
             Reporter.Error.WriteLine(string.Format(CliCommandStrings.RunCommandExceptionCouldNotApplyLaunchSettings, profileName, result.FailureReason).Bold().Red());

--- a/src/Dotnet.Watch/Watch/Browser/BrowserLauncher.cs
+++ b/src/Dotnet.Watch/Watch/Browser/BrowserLauncher.cs
@@ -24,7 +24,7 @@ internal sealed class BrowserLauncher(ILogger logger, IProcessOutputReporter pro
         AbstractBrowserRefreshServer? server,
         CancellationToken cancellationToken)
     {
-        if (!CanLaunchBrowser(projectOptions, out var launchProfile))
+        if (!CanLaunchBrowser(projectNode, projectOptions, out var launchProfile))
         {
             if (environmentOptions.TestFlags.HasFlag(TestFlags.MockBrowser))
             {
@@ -104,7 +104,10 @@ internal sealed class BrowserLauncher(ILogger logger, IProcessOutputReporter pro
         }
     }
 
-    private bool CanLaunchBrowser(ProjectOptions projectOptions, [NotNullWhen(true)] out LaunchSettingsProfile? launchProfile)
+    private bool CanLaunchBrowser(
+        ProjectGraphNode projectNode,
+        ProjectOptions projectOptions,
+        [NotNullWhen(true)] out LaunchSettingsProfile? launchProfile)
     {
         launchProfile = null;
 
@@ -119,7 +122,7 @@ internal sealed class BrowserLauncher(ILogger logger, IProcessOutputReporter pro
             return false;
         }
 
-        launchProfile = GetLaunchProfile(projectOptions);
+        launchProfile = GetLaunchProfile(projectNode, projectOptions);
         if (launchProfile is not { LaunchBrowser: true })
         {
             logger.LogDebug("launchSettings does not allow launching browsers.");
@@ -130,10 +133,14 @@ internal sealed class BrowserLauncher(ILogger logger, IProcessOutputReporter pro
         return true;
     }
 
-    private LaunchSettingsProfile GetLaunchProfile(ProjectOptions projectOptions)
+    private LaunchSettingsProfile GetLaunchProfile(ProjectGraphNode projectNode, ProjectOptions projectOptions)
     {
         var profile = projectOptions.LaunchProfileName.HasValue
-            ? LaunchSettingsProfile.ReadLaunchProfile(projectOptions.Representation, projectOptions.LaunchProfileName.Value, logger)
+            ? LaunchSettingsProfile.ReadLaunchProfile(
+                projectOptions.Representation,
+                projectOptions.LaunchProfileName.Value,
+                logger,
+                projectNode.ProjectInstance.ExpandString)
             : null;
 
         return profile ?? new();

--- a/src/Dotnet.Watch/Watch/Process/LaunchSettingsProfile.cs
+++ b/src/Dotnet.Watch/Watch/Process/LaunchSettingsProfile.cs
@@ -28,7 +28,7 @@ internal sealed class LaunchSettingsProfile
         ProjectRepresentation project,
         string? launchProfileName,
         ILogger logger,
-        Func<string, string> getVariableValue)
+        Func<string, string> evaluateExpression)
     {
         var launchSettingsPath = LaunchSettings.TryFindLaunchSettingsFile(project.ProjectOrEntryPointFilePath, launchProfileName, (message, isError) =>
         {
@@ -63,7 +63,7 @@ internal sealed class LaunchSettingsProfile
         if (string.IsNullOrEmpty(launchProfileName))
         {
             // Load the default (first) launch profile
-            return ReadDefaultLaunchProfile(launchSettings, logger)?.WithExpandedVariables(getVariableValue, logger);
+            return ReadDefaultLaunchProfile(launchSettings, logger)?.WithExpandedVariables(evaluateExpression, logger);
         }
 
         // Load the specified launch profile
@@ -83,16 +83,16 @@ internal sealed class LaunchSettingsProfile
                 logger.LogWarning("Note: Launch profile names are case-sensitive. Did you mean '{ProfileName}'?", caseInsensitiveNamedProfile);
             }
 
-            return ReadDefaultLaunchProfile(launchSettings, logger)?.WithExpandedVariables(getVariableValue, logger);
+            return ReadDefaultLaunchProfile(launchSettings, logger)?.WithExpandedVariables(evaluateExpression, logger);
         }
 
         logger.LogDebug("Found named launch profile '{ProfileName}'.", launchProfileName);
         namedProfile.LaunchProfileName = launchProfileName;
-        return namedProfile.WithExpandedVariables(getVariableValue, logger);
+        return namedProfile.WithExpandedVariables(evaluateExpression, logger);
     }
 
     private LaunchSettingsProfile? WithExpandedVariables(
-        Func<string, string> getVariableValue,
+        Func<string, string> evaluateExpression,
         ILogger logger)
     {
         try
@@ -105,7 +105,7 @@ internal sealed class LaunchSettingsProfile
                 LaunchBrowser = LaunchBrowser,
                 LaunchUrl = LaunchUrl is null
                     ? null
-                    : LaunchProfileParser.ExpandVariables(LaunchUrl, getVariableValue),
+                    : LaunchProfileParser.ExpandVariables(LaunchUrl, evaluateExpression),
             };
         }
         catch (InvalidProjectFileException e)

--- a/src/Dotnet.Watch/Watch/Process/LaunchSettingsProfile.cs
+++ b/src/Dotnet.Watch/Watch/Process/LaunchSettingsProfile.cs
@@ -28,7 +28,7 @@ internal sealed class LaunchSettingsProfile
         ProjectRepresentation project,
         string? launchProfileName,
         ILogger logger,
-        Func<string, string> expandMSBuildProperty)
+        Func<string, string> getVariableValue)
     {
         var launchSettingsPath = LaunchSettings.TryFindLaunchSettingsFile(project.ProjectOrEntryPointFilePath, launchProfileName, (message, isError) =>
         {
@@ -63,7 +63,7 @@ internal sealed class LaunchSettingsProfile
         if (string.IsNullOrEmpty(launchProfileName))
         {
             // Load the default (first) launch profile
-            return ExpandMSBuildProperties(ReadDefaultLaunchProfile(launchSettings, logger), expandMSBuildProperty, logger);
+            return ReadDefaultLaunchProfile(launchSettings, logger)?.WithExpandedVariables(getVariableValue, logger);
         }
 
         // Load the specified launch profile
@@ -83,35 +83,29 @@ internal sealed class LaunchSettingsProfile
                 logger.LogWarning("Note: Launch profile names are case-sensitive. Did you mean '{ProfileName}'?", caseInsensitiveNamedProfile);
             }
 
-            return ExpandMSBuildProperties(ReadDefaultLaunchProfile(launchSettings, logger), expandMSBuildProperty, logger);
+            return ReadDefaultLaunchProfile(launchSettings, logger)?.WithExpandedVariables(getVariableValue, logger);
         }
 
         logger.LogDebug("Found named launch profile '{ProfileName}'.", launchProfileName);
         namedProfile.LaunchProfileName = launchProfileName;
-        return ExpandMSBuildProperties(namedProfile, expandMSBuildProperty, logger);
+        return namedProfile.WithExpandedVariables(getVariableValue, logger);
     }
 
-    private static LaunchSettingsProfile? ExpandMSBuildProperties(
-        LaunchSettingsProfile? profile,
-        Func<string, string> expandMSBuildProperty,
+    private LaunchSettingsProfile? WithExpandedVariables(
+        Func<string, string> getVariableValue,
         ILogger logger)
     {
-        if (profile is null)
-        {
-            return null;
-        }
-
         try
         {
             return new LaunchSettingsProfile
             {
-                LaunchProfileName = profile.LaunchProfileName,
-                ApplicationUrl = profile.ApplicationUrl,
-                CommandName = profile.CommandName,
-                LaunchBrowser = profile.LaunchBrowser,
-                LaunchUrl = profile.LaunchUrl is null
+                LaunchProfileName = LaunchProfileName,
+                ApplicationUrl = ApplicationUrl,
+                CommandName = CommandName,
+                LaunchBrowser = LaunchBrowser,
+                LaunchUrl = LaunchUrl is null
                     ? null
-                    : LaunchProfileParser.ExpandVariables(profile.LaunchUrl, expandMSBuildProperty),
+                    : LaunchProfileParser.ExpandVariables(LaunchUrl, getVariableValue),
             };
         }
         catch (InvalidProjectFileException e)

--- a/src/Dotnet.Watch/Watch/Process/LaunchSettingsProfile.cs
+++ b/src/Dotnet.Watch/Watch/Process/LaunchSettingsProfile.cs
@@ -3,6 +3,7 @@
 
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Microsoft.Build.Exceptions;
 using Microsoft.DotNet.ProjectTools;
 using Microsoft.Extensions.Logging;
 
@@ -23,7 +24,11 @@ internal sealed class LaunchSettingsProfile
     public bool LaunchBrowser { get; init; }
     public string? LaunchUrl { get; init; }
 
-    internal static LaunchSettingsProfile? ReadLaunchProfile(ProjectRepresentation project, string? launchProfileName, ILogger logger)
+    internal static LaunchSettingsProfile? ReadLaunchProfile(
+        ProjectRepresentation project,
+        string? launchProfileName,
+        ILogger logger,
+        Func<string, string> expandMSBuildProperty)
     {
         var launchSettingsPath = LaunchSettings.TryFindLaunchSettingsFile(project.ProjectOrEntryPointFilePath, launchProfileName, (message, isError) =>
         {
@@ -58,7 +63,7 @@ internal sealed class LaunchSettingsProfile
         if (string.IsNullOrEmpty(launchProfileName))
         {
             // Load the default (first) launch profile
-            return ReadDefaultLaunchProfile(launchSettings, logger);
+            return ExpandMSBuildProperties(ReadDefaultLaunchProfile(launchSettings, logger), expandMSBuildProperty, logger);
         }
 
         // Load the specified launch profile
@@ -78,12 +83,42 @@ internal sealed class LaunchSettingsProfile
                 logger.LogWarning("Note: Launch profile names are case-sensitive. Did you mean '{ProfileName}'?", caseInsensitiveNamedProfile);
             }
 
-            return ReadDefaultLaunchProfile(launchSettings, logger);
+            return ExpandMSBuildProperties(ReadDefaultLaunchProfile(launchSettings, logger), expandMSBuildProperty, logger);
         }
 
         logger.LogDebug("Found named launch profile '{ProfileName}'.", launchProfileName);
         namedProfile.LaunchProfileName = launchProfileName;
-        return namedProfile;
+        return ExpandMSBuildProperties(namedProfile, expandMSBuildProperty, logger);
+    }
+
+    private static LaunchSettingsProfile? ExpandMSBuildProperties(
+        LaunchSettingsProfile? profile,
+        Func<string, string> expandMSBuildProperty,
+        ILogger logger)
+    {
+        if (profile is null)
+        {
+            return null;
+        }
+
+        try
+        {
+            return new LaunchSettingsProfile
+            {
+                LaunchProfileName = profile.LaunchProfileName,
+                ApplicationUrl = profile.ApplicationUrl,
+                CommandName = profile.CommandName,
+                LaunchBrowser = profile.LaunchBrowser,
+                LaunchUrl = profile.LaunchUrl is null
+                    ? null
+                    : LaunchProfileParser.ExpandVariables(profile.LaunchUrl, expandMSBuildProperty),
+            };
+        }
+        catch (InvalidProjectFileException e)
+        {
+            logger.LogDebug("Error expanding launch profile: {Message}.", e.Message);
+            return null;
+        }
     }
 
     private static LaunchSettingsProfile? ReadDefaultLaunchProfile(LaunchSettingsJson? launchSettings, ILogger logger)

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
@@ -20,7 +20,8 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
         string launchSettingsPath,
         string? launchProfileName,
         string json,
-        Func<string, string>? expandMSBuildProperty = null)
+        Func<string, string>? expandMSBuildProperty,
+        bool expandCommandLineArgs)
     {
         var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ExecutableLaunchProfile);
         if (profile == null)
@@ -37,12 +38,18 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
         {
             LaunchProfileName = launchProfileName,
             ExecutablePath = ExpandVariables(profile.ExecutablePath, expandMSBuildProperty),
-            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, expandMSBuildProperty),
+            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, expandMSBuildProperty, expandCommandLineArgs),
             WorkingDirectory = workingDirectory,
             DotNetRunMessages = profile.DotNetRunMessages,
             EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, expandMSBuildProperty),
         });
     }
+
+    internal static bool RequiresMSBuildExpansion(ExecutableLaunchProfile profile, bool includeCommandLineArgs)
+        => LaunchProfileParser.RequiresMSBuildExpansion(profile.ExecutablePath)
+            || LaunchProfileParser.RequiresMSBuildExpansion(profile.WorkingDirectory)
+            || (includeCommandLineArgs && LaunchProfileParser.RequiresMSBuildExpansion(profile.CommandLineArgs))
+            || profile.EnvironmentVariables.Values.Any(LaunchProfileParser.RequiresMSBuildExpansion);
 
     private static bool TryParseWorkingDirectory(
         string launchSettingsPath,

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
@@ -16,7 +16,11 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
     {
     }
 
-    public override LaunchProfileParseResult ParseProfile(string launchSettingsPath, string? launchProfileName, string json)
+    public override LaunchProfileParseResult ParseProfile(
+        string launchSettingsPath,
+        string? launchProfileName,
+        string json,
+        Func<string, string>? expandMSBuildProperty = null)
     {
         var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ExecutableLaunchProfile);
         if (profile == null)
@@ -24,7 +28,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
             return LaunchProfileParseResult.Failure(Resources.LaunchProfileIsNotAJsonObject);
         }
 
-        if (!TryParseWorkingDirectory(launchSettingsPath, profile.WorkingDirectory, out var workingDirectory, out var error))
+        if (!TryParseWorkingDirectory(launchSettingsPath, profile.WorkingDirectory, expandMSBuildProperty, out var workingDirectory, out var error))
         {
             return LaunchProfileParseResult.Failure(error);
         }
@@ -32,15 +36,20 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
         return LaunchProfileParseResult.Success(new ExecutableLaunchProfile
         {
             LaunchProfileName = launchProfileName,
-            ExecutablePath = ExpandVariables(profile.ExecutablePath),
-            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs),
+            ExecutablePath = ExpandVariables(profile.ExecutablePath, expandMSBuildProperty),
+            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, expandMSBuildProperty),
             WorkingDirectory = workingDirectory,
             DotNetRunMessages = profile.DotNetRunMessages,
-            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables),
+            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, expandMSBuildProperty),
         });
     }
 
-    private static bool TryParseWorkingDirectory(string launchSettingsPath, string? value, out string? workingDirectory, [NotNullWhen(false)] out string? error)
+    private static bool TryParseWorkingDirectory(
+        string launchSettingsPath,
+        string? value,
+        Func<string, string>? expandMSBuildProperty,
+        out string? workingDirectory,
+        [NotNullWhen(false)] out string? error)
     {
         if (value == null)
         {
@@ -49,7 +58,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
             return true;
         }
 
-        var expandedValue = ExpandVariables(value);
+        var expandedValue = ExpandVariables(value, expandMSBuildProperty);
 
         try
         {

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
@@ -20,7 +20,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
         string launchSettingsPath,
         string? launchProfileName,
         string json,
-        Func<string, string>? expandMSBuildProperty,
+        Func<string, string>? getVariableValue,
         bool expandCommandLineArgs)
     {
         var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ExecutableLaunchProfile);
@@ -29,7 +29,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
             return LaunchProfileParseResult.Failure(Resources.LaunchProfileIsNotAJsonObject);
         }
 
-        if (!TryParseWorkingDirectory(launchSettingsPath, profile.WorkingDirectory, expandMSBuildProperty, out var workingDirectory, out var error))
+        if (!TryParseWorkingDirectory(launchSettingsPath, profile.WorkingDirectory, getVariableValue, out var workingDirectory, out var error))
         {
             return LaunchProfileParseResult.Failure(error);
         }
@@ -37,11 +37,11 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
         return LaunchProfileParseResult.Success(new ExecutableLaunchProfile
         {
             LaunchProfileName = launchProfileName,
-            ExecutablePath = ExpandVariables(profile.ExecutablePath, expandMSBuildProperty),
-            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, expandMSBuildProperty, expandCommandLineArgs),
+            ExecutablePath = ExpandVariables(profile.ExecutablePath, getVariableValue),
+            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, getVariableValue, expandCommandLineArgs),
             WorkingDirectory = workingDirectory,
             DotNetRunMessages = profile.DotNetRunMessages,
-            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, expandMSBuildProperty),
+            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, getVariableValue),
         });
     }
 
@@ -54,7 +54,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
     private static bool TryParseWorkingDirectory(
         string launchSettingsPath,
         string? value,
-        Func<string, string>? expandMSBuildProperty,
+        Func<string, string>? getVariableValue,
         out string? workingDirectory,
         [NotNullWhen(false)] out string? error)
     {
@@ -65,7 +65,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
             return true;
         }
 
-        var expandedValue = ExpandVariables(value, expandMSBuildProperty);
+        var expandedValue = ExpandVariables(value, getVariableValue);
 
         try
         {

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ExecutableLaunchProfileParser.cs
@@ -20,7 +20,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
         string launchSettingsPath,
         string? launchProfileName,
         string json,
-        Func<string, string>? getVariableValue,
+        Func<string, string>? evaluateExpression,
         bool expandCommandLineArgs)
     {
         var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ExecutableLaunchProfile);
@@ -29,7 +29,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
             return LaunchProfileParseResult.Failure(Resources.LaunchProfileIsNotAJsonObject);
         }
 
-        if (!TryParseWorkingDirectory(launchSettingsPath, profile.WorkingDirectory, getVariableValue, out var workingDirectory, out var error))
+        if (!TryParseWorkingDirectory(launchSettingsPath, profile.WorkingDirectory, evaluateExpression, out var workingDirectory, out var error))
         {
             return LaunchProfileParseResult.Failure(error);
         }
@@ -37,11 +37,11 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
         return LaunchProfileParseResult.Success(new ExecutableLaunchProfile
         {
             LaunchProfileName = launchProfileName,
-            ExecutablePath = ExpandVariables(profile.ExecutablePath, getVariableValue),
-            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, getVariableValue, expandCommandLineArgs),
+            ExecutablePath = ExpandVariables(profile.ExecutablePath, evaluateExpression),
+            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, evaluateExpression, expandCommandLineArgs),
             WorkingDirectory = workingDirectory,
             DotNetRunMessages = profile.DotNetRunMessages,
-            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, getVariableValue),
+            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, evaluateExpression),
         });
     }
 
@@ -54,7 +54,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
     private static bool TryParseWorkingDirectory(
         string launchSettingsPath,
         string? value,
-        Func<string, string>? getVariableValue,
+        Func<string, string>? evaluateExpression,
         out string? workingDirectory,
         [NotNullWhen(false)] out string? error)
     {
@@ -65,7 +65,7 @@ internal sealed class ExecutableLaunchProfileParser : LaunchProfileParser
             return true;
         }
 
-        var expandedValue = ExpandVariables(value, getVariableValue);
+        var expandedValue = ExpandVariables(value, evaluateExpression);
 
         try
         {

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 namespace Microsoft.DotNet.ProjectTools;
 
 internal readonly record struct LaunchProfileParserOptions(
-    Func<string, string>? ExpandMSBuildProperty,
+    Func<string, string>? EvaluateExpression,
     bool ExpandProjectProfile,
     bool ExpandExecutableProfile,
     bool ExpandCommandLineArgs);
@@ -22,15 +22,15 @@ internal abstract partial class LaunchProfileParser
         string launchSettingsPath,
         string? launchProfileName,
         string json,
-        Func<string, string>? getVariableValue,
+        Func<string, string>? evaluateExpression,
         bool expandCommandLineArgs);
 
     protected static string? ParseCommandLineArgs(
         string? value,
-        Func<string, string>? getVariableValue,
+        Func<string, string>? evaluateExpression,
         bool expandCommandLineArgs)
         => value is not null
-            ? ExpandVariables(value, expandCommandLineArgs ? getVariableValue : null)
+            ? ExpandVariables(value, expandCommandLineArgs ? evaluateExpression : null)
             : null;
 
     public static string GetLaunchProfileDisplayName(string? launchProfile)
@@ -41,7 +41,7 @@ internal abstract partial class LaunchProfileParser
 
     protected static ImmutableDictionary<string, string> ParseEnvironmentVariables(
         ImmutableDictionary<string, string> values,
-        Func<string, string>? getVariableValue)
+        Func<string, string>? evaluateExpression)
     {
         if (values.Count == 0)
         {
@@ -52,7 +52,7 @@ internal abstract partial class LaunchProfileParser
         foreach (var (key, value) in values)
         {
             // override previously set variables:
-            builder[key] = ExpandVariables(value, getVariableValue);
+            builder[key] = ExpandVariables(value, evaluateExpression);
         }
 
         return builder.ToImmutable();
@@ -60,7 +60,7 @@ internal abstract partial class LaunchProfileParser
 
     protected static ImmutableDictionary<string, string> ExpandMSBuildProperties(
         ImmutableDictionary<string, string> values,
-        Func<string, string> getVariableValue)
+        Func<string, string> evaluateExpression)
     {
         if (values.Count == 0)
         {
@@ -70,20 +70,20 @@ internal abstract partial class LaunchProfileParser
         var builder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
         foreach (var (key, value) in values)
         {
-            builder[key] = ExpandMSBuildProperties(value, getVariableValue);
+            builder[key] = ExpandMSBuildProperties(value, evaluateExpression);
         }
 
         return builder.ToImmutable();
     }
 
-    protected static string ExpandMSBuildProperties(string value, Func<string, string> getVariableValue)
-        => MSBuildPropertyRegex().Replace(value, match => getVariableValue(match.Value));
+    protected static string ExpandMSBuildProperties(string value, Func<string, string> evaluateExpression)
+        => MSBuildPropertyRegex().Replace(value, match => evaluateExpression(match.Value));
 
-    internal static string ExpandVariables(string value, Func<string, string>? getVariableValue)
+    internal static string ExpandVariables(string value, Func<string, string>? evaluateExpression)
     {
         string expandedValue = Environment.ExpandEnvironmentVariables(value);
-        return getVariableValue is null
+        return evaluateExpression is null
             ? expandedValue
-            : ExpandMSBuildProperties(expandedValue, getVariableValue);
+            : ExpandMSBuildProperties(expandedValue, evaluateExpression);
     }
 }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
@@ -2,20 +2,33 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Immutable;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.ProjectTools;
 
-internal abstract class LaunchProfileParser
+internal abstract partial class LaunchProfileParser
 {
-    public abstract LaunchProfileParseResult ParseProfile(string launchSettingsPath, string? launchProfileName, string json);
+    [GeneratedRegex(@"\$\([^)]+\)", RegexOptions.IgnoreCase)]
+    private static partial Regex MSBuildPropertyRegex();
 
-    protected static string? ParseCommandLineArgs(string? value)
-        => value != null ? ExpandVariables(value) : null;
+    public abstract LaunchProfileParseResult ParseProfile(
+        string launchSettingsPath,
+        string? launchProfileName,
+        string json,
+        Func<string, string>? expandMSBuildProperty = null);
+
+    protected static string? ParseCommandLineArgs(string? value, Func<string, string>? expandMSBuildProperty)
+        => value is not null ? ExpandVariables(value, expandMSBuildProperty) : null;
 
     public static string GetLaunchProfileDisplayName(string? launchProfile)
         => string.IsNullOrEmpty(launchProfile) ? Resources.DefaultLaunchProfileDisplayName : launchProfile;
 
-    protected static ImmutableDictionary<string, string> ParseEnvironmentVariables(ImmutableDictionary<string, string> values)
+    internal static bool RequiresMSBuildExpansion(string? value)
+        => value is not null && MSBuildPropertyRegex().IsMatch(value);
+
+    protected static ImmutableDictionary<string, string> ParseEnvironmentVariables(
+        ImmutableDictionary<string, string> values,
+        Func<string, string>? expandMSBuildProperty)
     {
         if (values.Count == 0)
         {
@@ -26,12 +39,17 @@ internal abstract class LaunchProfileParser
         foreach (var (key, value) in values)
         {
             // override previously set variables:
-            builder[key] = ExpandVariables(value);
+            builder[key] = ExpandVariables(value, expandMSBuildProperty);
         }
 
         return builder.ToImmutable();
     }
 
-    protected static string ExpandVariables(string value)
-        => Environment.ExpandEnvironmentVariables(value);
+    protected static string ExpandVariables(string value, Func<string, string>? expandMSBuildProperty)
+    {
+        string expandedValue = Environment.ExpandEnvironmentVariables(value);
+        return expandMSBuildProperty is null
+            ? expandedValue
+            : MSBuildPropertyRegex().Replace(expandedValue, match => expandMSBuildProperty(match.Value));
+    }
 }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
@@ -48,10 +48,9 @@ internal abstract partial class LaunchProfileParser
             return values;
         }
 
-        var builder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        var builder = values.ToBuilder();
         foreach (var (key, value) in values)
         {
-            // override previously set variables:
             builder[key] = ExpandVariables(value, evaluateExpression);
         }
 
@@ -67,7 +66,7 @@ internal abstract partial class LaunchProfileParser
             return values;
         }
 
-        var builder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        var builder = values.ToBuilder();
         foreach (var (key, value) in values)
         {
             builder[key] = ExpandMSBuildProperties(value, evaluateExpression);

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
@@ -22,15 +22,15 @@ internal abstract partial class LaunchProfileParser
         string launchSettingsPath,
         string? launchProfileName,
         string json,
-        Func<string, string>? expandMSBuildProperty,
+        Func<string, string>? getVariableValue,
         bool expandCommandLineArgs);
 
     protected static string? ParseCommandLineArgs(
         string? value,
-        Func<string, string>? expandMSBuildProperty,
+        Func<string, string>? getVariableValue,
         bool expandCommandLineArgs)
         => value is not null
-            ? ExpandVariables(value, expandCommandLineArgs ? expandMSBuildProperty : null)
+            ? ExpandVariables(value, expandCommandLineArgs ? getVariableValue : null)
             : null;
 
     public static string GetLaunchProfileDisplayName(string? launchProfile)
@@ -41,7 +41,7 @@ internal abstract partial class LaunchProfileParser
 
     protected static ImmutableDictionary<string, string> ParseEnvironmentVariables(
         ImmutableDictionary<string, string> values,
-        Func<string, string>? expandMSBuildProperty)
+        Func<string, string>? getVariableValue)
     {
         if (values.Count == 0)
         {
@@ -52,7 +52,7 @@ internal abstract partial class LaunchProfileParser
         foreach (var (key, value) in values)
         {
             // override previously set variables:
-            builder[key] = ExpandVariables(value, expandMSBuildProperty);
+            builder[key] = ExpandVariables(value, getVariableValue);
         }
 
         return builder.ToImmutable();
@@ -60,7 +60,7 @@ internal abstract partial class LaunchProfileParser
 
     protected static ImmutableDictionary<string, string> ExpandMSBuildProperties(
         ImmutableDictionary<string, string> values,
-        Func<string, string> expandMSBuildProperty)
+        Func<string, string> getVariableValue)
     {
         if (values.Count == 0)
         {
@@ -70,20 +70,20 @@ internal abstract partial class LaunchProfileParser
         var builder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
         foreach (var (key, value) in values)
         {
-            builder[key] = ExpandMSBuildProperties(value, expandMSBuildProperty);
+            builder[key] = ExpandMSBuildProperties(value, getVariableValue);
         }
 
         return builder.ToImmutable();
     }
 
-    protected static string ExpandMSBuildProperties(string value, Func<string, string> expandMSBuildProperty)
-        => MSBuildPropertyRegex().Replace(value, match => expandMSBuildProperty(match.Value));
+    protected static string ExpandMSBuildProperties(string value, Func<string, string> getVariableValue)
+        => MSBuildPropertyRegex().Replace(value, match => getVariableValue(match.Value));
 
-    internal static string ExpandVariables(string value, Func<string, string>? expandMSBuildProperty)
+    internal static string ExpandVariables(string value, Func<string, string>? getVariableValue)
     {
         string expandedValue = Environment.ExpandEnvironmentVariables(value);
-        return expandMSBuildProperty is null
+        return getVariableValue is null
             ? expandedValue
-            : ExpandMSBuildProperties(expandedValue, expandMSBuildProperty);
+            : ExpandMSBuildProperties(expandedValue, getVariableValue);
     }
 }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
@@ -6,6 +6,12 @@ using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.ProjectTools;
 
+internal readonly record struct LaunchProfileParserOptions(
+    Func<string, string>? ExpandMSBuildProperty,
+    bool ExpandProjectProfile,
+    bool ExpandExecutableProfile,
+    bool ExpandCommandLineArgs);
+
 internal abstract partial class LaunchProfileParser
 {
     // Keep launch profile expansion consistent with Visual Studio's DebugTokenReplacer.
@@ -16,10 +22,16 @@ internal abstract partial class LaunchProfileParser
         string launchSettingsPath,
         string? launchProfileName,
         string json,
-        Func<string, string>? expandMSBuildProperty = null);
+        Func<string, string>? expandMSBuildProperty,
+        bool expandCommandLineArgs);
 
-    protected static string? ParseCommandLineArgs(string? value, Func<string, string>? expandMSBuildProperty)
-        => value is not null ? ExpandVariables(value, expandMSBuildProperty) : null;
+    protected static string? ParseCommandLineArgs(
+        string? value,
+        Func<string, string>? expandMSBuildProperty,
+        bool expandCommandLineArgs)
+        => value is not null
+            ? ExpandVariables(value, expandCommandLineArgs ? expandMSBuildProperty : null)
+            : null;
 
     public static string GetLaunchProfileDisplayName(string? launchProfile)
         => string.IsNullOrEmpty(launchProfile) ? Resources.DefaultLaunchProfileDisplayName : launchProfile;
@@ -46,11 +58,32 @@ internal abstract partial class LaunchProfileParser
         return builder.ToImmutable();
     }
 
-    protected static string ExpandVariables(string value, Func<string, string>? expandMSBuildProperty)
+    protected static ImmutableDictionary<string, string> ExpandMSBuildProperties(
+        ImmutableDictionary<string, string> values,
+        Func<string, string> expandMSBuildProperty)
+    {
+        if (values.Count == 0)
+        {
+            return values;
+        }
+
+        var builder = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.Ordinal);
+        foreach (var (key, value) in values)
+        {
+            builder[key] = ExpandMSBuildProperties(value, expandMSBuildProperty);
+        }
+
+        return builder.ToImmutable();
+    }
+
+    protected static string ExpandMSBuildProperties(string value, Func<string, string> expandMSBuildProperty)
+        => MSBuildPropertyRegex().Replace(value, match => expandMSBuildProperty(match.Value));
+
+    internal static string ExpandVariables(string value, Func<string, string>? expandMSBuildProperty)
     {
         string expandedValue = Environment.ExpandEnvironmentVariables(value);
         return expandMSBuildProperty is null
             ? expandedValue
-            : MSBuildPropertyRegex().Replace(expandedValue, match => expandMSBuildProperty(match.Value));
+            : ExpandMSBuildProperties(expandedValue, expandMSBuildProperty);
     }
 }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchProfileParser.cs
@@ -8,6 +8,7 @@ namespace Microsoft.DotNet.ProjectTools;
 
 internal abstract partial class LaunchProfileParser
 {
+    // Keep launch profile expansion consistent with Visual Studio's DebugTokenReplacer.
     [GeneratedRegex(@"\$\([^)]+\)", RegexOptions.IgnoreCase)]
     private static partial Regex MSBuildPropertyRegex();
 

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
@@ -71,7 +71,10 @@ public static class LaunchSettings
         return null;
     }
 
-    internal static LaunchProfileParseResult ReadProfileSettingsFromFile(string launchSettingsPath, string? profileName = null)
+    internal static LaunchProfileParseResult ReadProfileSettingsFromFile(
+        string launchSettingsPath,
+        string? profileName = null,
+        Func<string, string>? expandMSBuildProperty = null)
     {
         try
         {
@@ -160,7 +163,7 @@ public static class LaunchSettings
                     return LaunchProfileParseResult.Failure(string.Format(Resources.LaunchProfileHandlerCannotBeLocated, commandName));
                 }
 
-                return provider.ParseProfile(launchSettingsPath, selectedProfileName, profileObject.GetRawText());
+                return provider.ParseProfile(launchSettingsPath, selectedProfileName, profileObject.GetRawText(), expandMSBuildProperty);
             }
         }
         catch (Exception ex) when (ex is JsonException or IOException)

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
@@ -163,7 +163,7 @@ public static class LaunchSettings
                     return LaunchProfileParseResult.Failure(string.Format(Resources.LaunchProfileHandlerCannotBeLocated, commandName));
                 }
 
-                Func<string, string>? expandMSBuildProperty = provider switch
+                Func<string, string>? getVariableValue = provider switch
                 {
                     ProjectLaunchProfileParser when parserOptions.ExpandProjectProfile => parserOptions.ExpandMSBuildProperty,
                     ExecutableLaunchProfileParser when parserOptions.ExpandExecutableProfile => parserOptions.ExpandMSBuildProperty,
@@ -174,7 +174,7 @@ public static class LaunchSettings
                     launchSettingsPath,
                     selectedProfileName,
                     profileObject.GetRawText(),
-                    expandMSBuildProperty,
+                    getVariableValue,
                     parserOptions.ExpandCommandLineArgs);
             }
         }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
@@ -163,10 +163,10 @@ public static class LaunchSettings
                     return LaunchProfileParseResult.Failure(string.Format(Resources.LaunchProfileHandlerCannotBeLocated, commandName));
                 }
 
-                Func<string, string>? getVariableValue = provider switch
+                Func<string, string>? evaluateExpression = provider switch
                 {
-                    ProjectLaunchProfileParser when parserOptions.ExpandProjectProfile => parserOptions.ExpandMSBuildProperty,
-                    ExecutableLaunchProfileParser when parserOptions.ExpandExecutableProfile => parserOptions.ExpandMSBuildProperty,
+                    ProjectLaunchProfileParser when parserOptions.ExpandProjectProfile => parserOptions.EvaluateExpression,
+                    ExecutableLaunchProfileParser when parserOptions.ExpandExecutableProfile => parserOptions.EvaluateExpression,
                     _ => null,
                 };
 
@@ -174,7 +174,7 @@ public static class LaunchSettings
                     launchSettingsPath,
                     selectedProfileName,
                     profileObject.GetRawText(),
-                    getVariableValue,
+                    evaluateExpression,
                     parserOptions.ExpandCommandLineArgs);
             }
         }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/LaunchSettings.cs
@@ -73,8 +73,8 @@ public static class LaunchSettings
 
     internal static LaunchProfileParseResult ReadProfileSettingsFromFile(
         string launchSettingsPath,
-        string? profileName = null,
-        Func<string, string>? expandMSBuildProperty = null)
+        string? profileName,
+        LaunchProfileParserOptions parserOptions)
     {
         try
         {
@@ -163,7 +163,19 @@ public static class LaunchSettings
                     return LaunchProfileParseResult.Failure(string.Format(Resources.LaunchProfileHandlerCannotBeLocated, commandName));
                 }
 
-                return provider.ParseProfile(launchSettingsPath, selectedProfileName, profileObject.GetRawText(), expandMSBuildProperty);
+                Func<string, string>? expandMSBuildProperty = provider switch
+                {
+                    ProjectLaunchProfileParser when parserOptions.ExpandProjectProfile => parserOptions.ExpandMSBuildProperty,
+                    ExecutableLaunchProfileParser when parserOptions.ExpandExecutableProfile => parserOptions.ExpandMSBuildProperty,
+                    _ => null,
+                };
+
+                return provider.ParseProfile(
+                    launchSettingsPath,
+                    selectedProfileName,
+                    profileObject.GetRawText(),
+                    expandMSBuildProperty,
+                    parserOptions.ExpandCommandLineArgs);
             }
         }
         catch (Exception ex) when (ex is JsonException or IOException)

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
@@ -19,7 +19,7 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
         string launchSettingsPath,
         string? launchProfileName,
         string json,
-        Func<string, string>? expandMSBuildProperty,
+        Func<string, string>? getVariableValue,
         bool expandCommandLineArgs)
     {
         var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ProjectLaunchProfile);
@@ -31,12 +31,12 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
         return LaunchProfileParseResult.Success(new ProjectLaunchProfile
         {
             LaunchProfileName = launchProfileName,
-            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, expandMSBuildProperty, expandCommandLineArgs),
+            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, getVariableValue, expandCommandLineArgs),
             LaunchBrowser = profile.LaunchBrowser,
-            LaunchUrl = profile.LaunchUrl is null ? null : ExpandVariables(profile.LaunchUrl, expandMSBuildProperty: null),
-            ApplicationUrl = profile.ApplicationUrl is null ? null : ExpandVariables(profile.ApplicationUrl, expandMSBuildProperty),
+            LaunchUrl = profile.LaunchUrl is null ? null : ExpandVariables(profile.LaunchUrl, getVariableValue: null),
+            ApplicationUrl = profile.ApplicationUrl is null ? null : ExpandVariables(profile.ApplicationUrl, getVariableValue),
             DotNetRunMessages = profile.DotNetRunMessages,
-            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, expandMSBuildProperty),
+            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, getVariableValue),
         });
     }
 
@@ -47,21 +47,21 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
 
     internal static ProjectLaunchProfile ExpandMSBuildProperties(
         ProjectLaunchProfile profile,
-        Func<string, string> expandMSBuildProperty,
+        Func<string, string> getVariableValue,
         bool expandCommandLineArgs,
         bool expandApplicationUrl)
         => new()
         {
             LaunchProfileName = profile.LaunchProfileName,
             CommandLineArgs = expandCommandLineArgs && profile.CommandLineArgs is not null
-                ? ExpandMSBuildProperties(profile.CommandLineArgs, expandMSBuildProperty)
+                ? ExpandMSBuildProperties(profile.CommandLineArgs, getVariableValue)
                 : profile.CommandLineArgs,
             LaunchBrowser = profile.LaunchBrowser,
             LaunchUrl = profile.LaunchUrl,
             ApplicationUrl = !expandApplicationUrl || profile.ApplicationUrl is null
                 ? profile.ApplicationUrl
-                : ExpandMSBuildProperties(profile.ApplicationUrl, expandMSBuildProperty),
+                : ExpandMSBuildProperties(profile.ApplicationUrl, getVariableValue),
             DotNetRunMessages = profile.DotNetRunMessages,
-            EnvironmentVariables = ExpandMSBuildProperties(profile.EnvironmentVariables, expandMSBuildProperty),
+            EnvironmentVariables = ExpandMSBuildProperties(profile.EnvironmentVariables, getVariableValue),
         };
 }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
@@ -19,7 +19,7 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
         string launchSettingsPath,
         string? launchProfileName,
         string json,
-        Func<string, string>? getVariableValue,
+        Func<string, string>? evaluateExpression,
         bool expandCommandLineArgs)
     {
         var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ProjectLaunchProfile);
@@ -31,12 +31,12 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
         return LaunchProfileParseResult.Success(new ProjectLaunchProfile
         {
             LaunchProfileName = launchProfileName,
-            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, getVariableValue, expandCommandLineArgs),
+            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, evaluateExpression, expandCommandLineArgs),
             LaunchBrowser = profile.LaunchBrowser,
-            LaunchUrl = profile.LaunchUrl is null ? null : ExpandVariables(profile.LaunchUrl, getVariableValue: null),
-            ApplicationUrl = profile.ApplicationUrl is null ? null : ExpandVariables(profile.ApplicationUrl, getVariableValue),
+            LaunchUrl = profile.LaunchUrl is null ? null : ExpandVariables(profile.LaunchUrl, evaluateExpression: null),
+            ApplicationUrl = profile.ApplicationUrl is null ? null : ExpandVariables(profile.ApplicationUrl, evaluateExpression),
             DotNetRunMessages = profile.DotNetRunMessages,
-            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, getVariableValue),
+            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, evaluateExpression),
         });
     }
 
@@ -47,21 +47,21 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
 
     internal static ProjectLaunchProfile ExpandMSBuildProperties(
         ProjectLaunchProfile profile,
-        Func<string, string> getVariableValue,
+        Func<string, string> evaluateExpression,
         bool expandCommandLineArgs,
         bool expandApplicationUrl)
         => new()
         {
             LaunchProfileName = profile.LaunchProfileName,
             CommandLineArgs = expandCommandLineArgs && profile.CommandLineArgs is not null
-                ? ExpandMSBuildProperties(profile.CommandLineArgs, getVariableValue)
+                ? ExpandMSBuildProperties(profile.CommandLineArgs, evaluateExpression)
                 : profile.CommandLineArgs,
             LaunchBrowser = profile.LaunchBrowser,
             LaunchUrl = profile.LaunchUrl,
             ApplicationUrl = !expandApplicationUrl || profile.ApplicationUrl is null
                 ? profile.ApplicationUrl
-                : ExpandMSBuildProperties(profile.ApplicationUrl, getVariableValue),
+                : ExpandMSBuildProperties(profile.ApplicationUrl, evaluateExpression),
             DotNetRunMessages = profile.DotNetRunMessages,
-            EnvironmentVariables = ExpandMSBuildProperties(profile.EnvironmentVariables, getVariableValue),
+            EnvironmentVariables = ExpandMSBuildProperties(profile.EnvironmentVariables, evaluateExpression),
         };
 }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
@@ -15,7 +15,11 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
     {
     }
 
-    public override LaunchProfileParseResult ParseProfile(string launchSettingsPath, string? launchProfileName, string json)
+    public override LaunchProfileParseResult ParseProfile(
+        string launchSettingsPath,
+        string? launchProfileName,
+        string json,
+        Func<string, string>? expandMSBuildProperty = null)
     {
         var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ProjectLaunchProfile);
         if (profile == null)
@@ -26,12 +30,12 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
         return LaunchProfileParseResult.Success(new ProjectLaunchProfile
         {
             LaunchProfileName = launchProfileName,
-            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs),
+            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, expandMSBuildProperty),
             LaunchBrowser = profile.LaunchBrowser,
-            LaunchUrl = profile.LaunchUrl,
-            ApplicationUrl = profile.ApplicationUrl,
+            LaunchUrl = profile.LaunchUrl is null ? null : ExpandVariables(profile.LaunchUrl, expandMSBuildProperty),
+            ApplicationUrl = profile.ApplicationUrl is null ? null : ExpandVariables(profile.ApplicationUrl, expandMSBuildProperty),
             DotNetRunMessages = profile.DotNetRunMessages,
-            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables),
+            EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, expandMSBuildProperty),
         });
     }
 }

--- a/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
+++ b/src/Microsoft.DotNet.ProjectTools/LaunchSettings/ProjectLaunchProfileParser.cs
@@ -19,7 +19,8 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
         string launchSettingsPath,
         string? launchProfileName,
         string json,
-        Func<string, string>? expandMSBuildProperty = null)
+        Func<string, string>? expandMSBuildProperty,
+        bool expandCommandLineArgs)
     {
         var profile = JsonSerializer.Deserialize(json, LaunchProfileJsonSerializerContext.Default.ProjectLaunchProfile);
         if (profile == null)
@@ -30,12 +31,37 @@ internal sealed class ProjectLaunchProfileParser : LaunchProfileParser
         return LaunchProfileParseResult.Success(new ProjectLaunchProfile
         {
             LaunchProfileName = launchProfileName,
-            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, expandMSBuildProperty),
+            CommandLineArgs = ParseCommandLineArgs(profile.CommandLineArgs, expandMSBuildProperty, expandCommandLineArgs),
             LaunchBrowser = profile.LaunchBrowser,
-            LaunchUrl = profile.LaunchUrl is null ? null : ExpandVariables(profile.LaunchUrl, expandMSBuildProperty),
+            LaunchUrl = profile.LaunchUrl is null ? null : ExpandVariables(profile.LaunchUrl, expandMSBuildProperty: null),
             ApplicationUrl = profile.ApplicationUrl is null ? null : ExpandVariables(profile.ApplicationUrl, expandMSBuildProperty),
             DotNetRunMessages = profile.DotNetRunMessages,
             EnvironmentVariables = ParseEnvironmentVariables(profile.EnvironmentVariables, expandMSBuildProperty),
         });
     }
+
+    internal static bool RequiresMSBuildExpansion(ProjectLaunchProfile profile, bool includeCommandLineArgs)
+        => (includeCommandLineArgs && LaunchProfileParser.RequiresMSBuildExpansion(profile.CommandLineArgs))
+            || LaunchProfileParser.RequiresMSBuildExpansion(profile.ApplicationUrl)
+            || profile.EnvironmentVariables.Values.Any(LaunchProfileParser.RequiresMSBuildExpansion);
+
+    internal static ProjectLaunchProfile ExpandMSBuildProperties(
+        ProjectLaunchProfile profile,
+        Func<string, string> expandMSBuildProperty,
+        bool expandCommandLineArgs,
+        bool expandApplicationUrl)
+        => new()
+        {
+            LaunchProfileName = profile.LaunchProfileName,
+            CommandLineArgs = expandCommandLineArgs && profile.CommandLineArgs is not null
+                ? ExpandMSBuildProperties(profile.CommandLineArgs, expandMSBuildProperty)
+                : profile.CommandLineArgs,
+            LaunchBrowser = profile.LaunchBrowser,
+            LaunchUrl = profile.LaunchUrl,
+            ApplicationUrl = !expandApplicationUrl || profile.ApplicationUrl is null
+                ? profile.ApplicationUrl
+                : ExpandMSBuildProperties(profile.ApplicationUrl, expandMSBuildProperty),
+            DotNetRunMessages = profile.DotNetRunMessages,
+            EnvironmentVariables = ExpandMSBuildProperties(profile.EnvironmentVariables, expandMSBuildProperty),
+        };
 }

--- a/src/Microsoft.DotNet.ProjectTools/Microsoft.DotNet.ProjectTools.csproj
+++ b/src/Microsoft.DotNet.ProjectTools/Microsoft.DotNet.ProjectTools.csproj
@@ -32,6 +32,7 @@
     <InternalsVisibleTo Include="dotnet" />
     <InternalsVisibleTo Include="dotnet-aot" />
     <InternalsVisibleTo Include="dotnet-aot.Tests" />
+    <InternalsVisibleTo Include="Microsoft.DotNet.HotReload.Watch" />
     <InternalsVisibleTo Include="dotnet-watch.Tests" />
     <InternalsVisibleTo Include="dotnet.Tests" />
     <InternalsVisibleTo Include="Microsoft.NET.Build.Tests" Key="$(MicrosoftSharedPublicKey)" />

--- a/test/dotnet-aot.Tests/AotRunCommandTests.cs
+++ b/test/dotnet-aot.Tests/AotRunCommandTests.cs
@@ -294,6 +294,86 @@ public class AotRunCommandTests
         }
     }
 
+    /// <summary>Verifies that launch profile arguments requiring MSBuild defer to the managed CLI.</summary>
+    [TestMethod]
+    [DataRow("Project", "ProjectProfile")]
+    [DataRow("Executable", "ExecutableProfile")]
+    public void LaunchProfileWithMSBuildPropertiesFallsBackToManaged(string commandName, string profileName)
+    {
+        var fixture = CreateFixture();
+        try
+        {
+            WriteLaunchSettings(fixture, $$"""
+                {
+                    "profiles": {
+                        "{{profileName}}": {
+                            "commandName": "{{commandName}}",
+                            "executablePath": "profile-executable",
+                            "commandLineArgs": "$(MSBuildProjectDirectory)"
+                        }
+                    }
+                }
+                """);
+            var parseResult = Parser.Parse([
+                "run",
+                "--file", fixture.EntryPointPath,
+                "--no-build",
+                "--launch-profile", profileName,
+            ]);
+
+            Assert.ThrowsExactly<CommandNotAvailableInAotException>(() =>
+                AotRunCommand.Execute(
+                    parseResult,
+                    static _ => throw new InvalidOperationException("Launcher should not be called."),
+                    fixture.TestDirectory));
+        }
+        finally
+        {
+            DeleteFixture(fixture);
+        }
+    }
+
+    /// <summary>Verifies that launch profile fields requiring MSBuild defer to the managed CLI.</summary>
+    [TestMethod]
+    [DataRow("Executable", "\"executablePath\": \"$(MSBuildProjectDirectory)\"")]
+    [DataRow("Executable", "\"executablePath\": \"profile-executable\", \"workingDirectory\": \"$(MSBuildProjectDirectory)\"")]
+    [DataRow("Executable", "\"executablePath\": \"profile-executable\", \"environmentVariables\": { \"VALUE\": \"$(MSBuildProjectDirectory)\" }")]
+    [DataRow("Project", "\"applicationUrl\": \"$(MSBuildProjectDirectory)\"")]
+    [DataRow("Project", "\"environmentVariables\": { \"VALUE\": \"$(MSBuildProjectDirectory)\" }")]
+    public void LaunchProfileFieldWithMSBuildPropertyFallsBackToManaged(string commandName, string settings)
+    {
+        var fixture = CreateFixture();
+        try
+        {
+            WriteLaunchSettings(fixture, $$"""
+                {
+                    "profiles": {
+                        "Profile": {
+                            "commandName": "{{commandName}}",
+                            {{settings}}
+                        }
+                    }
+                }
+                """);
+            var parseResult = Parser.Parse([
+                "run",
+                "--file", fixture.EntryPointPath,
+                "--no-build",
+                "--launch-profile", "Profile",
+            ]);
+
+            Assert.ThrowsExactly<CommandNotAvailableInAotException>(() =>
+                AotRunCommand.Execute(
+                    parseResult,
+                    static _ => throw new InvalidOperationException("Launcher should not be called."),
+                    fixture.TestDirectory));
+        }
+        finally
+        {
+            DeleteFixture(fixture);
+        }
+    }
+
     /// <summary>Verifies that a no-build Executable launch profile bypasses the synthetic build cache.</summary>
     [TestMethod]
     public void ExecutableLaunchProfileBypassesSyntheticCache()
@@ -310,7 +390,7 @@ public class AotRunCommandTests
                             "commandName": "Executable",
                             "executablePath": "profile-executable",
                             "workingDirectory": "profile-working-directory",
-                            "commandLineArgs": "profileArg1 profileArg2",
+                            "commandLineArgs": "$(MSBuildProjectDirectory)",
                             "environmentVariables": {
                                 "PROFILE_ONLY": "profile-value",
                                 "OVERRIDE": "profile-value"

--- a/test/dotnet-watch.Tests/Process/LaunchSettingsProfileTest.cs
+++ b/test/dotnet-watch.Tests/Process/LaunchSettingsProfileTest.cs
@@ -54,16 +54,86 @@ public class LaunchSettingsProfileTest
             projectPath: Path.Combine(project.TestRoot, "Project1", "Project1.csproj"),
             entryPointFilePath: null);
 
-        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, launchProfileName: "http", Logger);
+        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, launchProfileName: "http", Logger, static value => value);
         Assert.IsNotNull(expected);
         Assert.AreEqual("http://localhost:5000", expected.ApplicationUrl);
 
-        expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, "https", Logger);
+        expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, "https", Logger, static value => value);
         Assert.IsNotNull(expected);
         Assert.AreEqual("https://localhost:5001", expected.ApplicationUrl);
 
-        expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, "notfound", Logger);
+        expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, "notfound", Logger, static value => value);
         Assert.IsNotNull(expected);
+    }
+
+    [TestMethod]
+    public void ExpandsMSBuildPropertiesInLaunchUrl()
+    {
+        var project = TestAssets.CreateTestProject(new TestProject("Project1")
+        {
+            TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+        });
+
+        WriteFile(project, Path.Combine("Properties", "launchSettings.json"),
+        """
+        {
+          "profiles": {
+            "http": {
+              "applicationUrl": "$(ApplicationUrl)",
+              "commandName": "Project",
+              "launchUrl": "$(LaunchUrl)"
+            }
+          }
+        }
+        """);
+
+        var projectPath = new ProjectRepresentation(
+            projectPath: Path.Combine(project.TestRoot, "Project1", "Project1.csproj"),
+            entryPointFilePath: null);
+
+        var properties = new Dictionary<string, string>
+        {
+            ["$(LaunchUrl)"] = "path",
+        };
+        var profile = LaunchSettingsProfile.ReadLaunchProfile(projectPath, "http", Logger, value => properties[value]);
+
+        Assert.IsNotNull(profile);
+        Assert.AreEqual("$(ApplicationUrl)", profile.ApplicationUrl);
+        Assert.AreEqual("path", profile.LaunchUrl);
+    }
+
+    [TestMethod]
+    public void InvalidMSBuildPropertyInLaunchUrlDisablesLaunchProfile()
+    {
+        var project = TestAssets.CreateTestProject(new TestProject("Project1")
+        {
+            TargetFrameworks = ToolsetInfo.CurrentTargetFramework,
+        });
+
+        WriteFile(project, Path.Combine("Properties", "launchSettings.json"),
+        """
+        {
+          "profiles": {
+            "http": {
+              "commandName": "Project",
+              "launchBrowser": true,
+              "launchUrl": "$([)"
+            }
+          }
+        }
+        """);
+
+        var projectPath = new ProjectRepresentation(
+            projectPath: Path.Combine(project.TestRoot, "Project1", "Project1.csproj"),
+            entryPointFilePath: null);
+
+        var profile = LaunchSettingsProfile.ReadLaunchProfile(
+            projectPath,
+            "http",
+            Logger,
+            static _ => throw new Microsoft.Build.Exceptions.InvalidProjectFileException("Invalid expression."));
+
+        Assert.IsNull(profile);
     }
 
     [TestMethod]
@@ -89,7 +159,7 @@ public class LaunchSettingsProfileTest
             projectPath: Path.Combine(project.Path, "Project1", "Project1.csproj"),
             entryPointFilePath: null);
 
-        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, launchProfileName: null, Logger);
+        var expected = LaunchSettingsProfile.ReadLaunchProfile(projectPath, launchProfileName: null, Logger, static value => value);
         Assert.IsNull(expected);
     }
 

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -944,8 +944,12 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         {
             var testInstance = TestAssetsManager.CopyTestAsset("TestAppWithLaunchSettings")
                 .WithSource();
-
-            // launchSettings.json specifies commandLineArgs="TestAppCommandLineArguments SecondTestAppCommandLineArguments"
+            string launchSettingsPath = Path.Join(testInstance.Path, "Properties", "launchSettings.json");
+            File.WriteAllText(
+                launchSettingsPath,
+                File.ReadAllText(launchSettingsPath).Replace(
+                    "\"commandLineArgs\": \"TestAppCommandLineArguments SecondTestAppCommandLineArguments\"",
+                    "\"commandLineArgs\": \"$([)\""));
 
             new DotnetCommand(Log, "run", "--no-launch-profile-arguments")
                .WithWorkingDirectory(testInstance.Path)
@@ -955,7 +959,11 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                .And
                .NotHaveStdOutContaining("TestAppCommandLineArguments")
                .And
-               .NotHaveStdOutContaining("SecondTestAppCommandLineArguments");
+               .NotHaveStdOutContaining("SecondTestAppCommandLineArguments")
+               .And
+               .HaveStdOutContaining("env: MyCoolEnvironmentVariableKey=MyCoolEnvironmentVariableValue")
+               .And
+               .NotHaveStdErrContaining("could not be applied");
         }
 
         [TestMethod]
@@ -966,6 +974,12 @@ namespace Microsoft.DotNet.Cli.Run.Tests
             var testAppName = "TestAppWithLaunchSettings";
             var testInstance = TestAssetsManager.CopyTestAsset(testAppName)
                 .WithSource();
+            string launchSettingsPath = Path.Join(testInstance.Path, "Properties", "launchSettings.json");
+            File.WriteAllText(
+                launchSettingsPath,
+                File.ReadAllText(launchSettingsPath).Replace(
+                    "\"commandLineArgs\": \"TestAppCommandLineArguments SecondTestAppCommandLineArguments\"",
+                    "\"commandLineArgs\": \"$([)\""));
 
             new DotnetCommand(Log, "run", "-- test")
                .WithWorkingDirectory(testInstance.Path)
@@ -975,11 +989,30 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                .And
                .NotHaveStdOutContaining(expectedValue)
                .And
-               .NotHaveStdOutContaining(secondExpectedValue);
+               .NotHaveStdOutContaining(secondExpectedValue)
+               .And
+               .HaveStdOutContaining("env: MyCoolEnvironmentVariableKey=MyCoolEnvironmentVariableValue")
+               .And
+               .NotHaveStdErrContaining("could not be applied");
         }
 
         [TestMethod]
         public void ItIncludesApplicationUrlSpecifiedInLaunchSettings()
+        {
+            var testInstance = TestAssetsManager.CopyTestAsset("TestAppWithLaunchSettings")
+                .WithSource();
+
+            new DotnetCommand(Log, "run")
+               .WithWorkingDirectory(testInstance.Path)
+               .Execute()
+               .Should()
+               .Pass()
+               .And
+               .HaveStdOutContaining("env: ASPNETCORE_URLS=http://localhost:5000");
+        }
+
+        [TestMethod]
+        public void ItExpandsMSBuildPropertyInApplicationUrlSpecifiedInLaunchSettings()
         {
             var testInstance = TestAssetsManager.CopyTestAsset("TestAppWithLaunchSettings")
                 .WithSource();

--- a/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
+++ b/test/dotnet.Tests/CommandTests/Run/GivenDotnetRunBuildsCsProj.cs
@@ -983,6 +983,19 @@ namespace Microsoft.DotNet.Cli.Run.Tests
         {
             var testInstance = TestAssetsManager.CopyTestAsset("TestAppWithLaunchSettings")
                 .WithSource();
+            string launchSettingsPath = Path.Join(testInstance.Path, "Properties", "launchSettings.json");
+            File.WriteAllText(
+                launchSettingsPath,
+                File.ReadAllText(launchSettingsPath).Replace(
+                    "\"applicationUrl\": \"http://localhost:5000\"",
+                    "\"applicationUrl\": \"$(LaunchApplicationUrl)\""));
+            File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <LaunchApplicationUrl>http://localhost:5001</LaunchApplicationUrl>
+                  </PropertyGroup>
+                </Project>
+                """);
 
             new DotnetCommand(Log, "run")
                .WithWorkingDirectory(testInstance.Path)
@@ -990,7 +1003,7 @@ namespace Microsoft.DotNet.Cli.Run.Tests
                .Should()
                .Pass()
                .And
-               .HaveStdOutContaining("env: ASPNETCORE_URLS=http://localhost:5000");
+               .HaveStdOutContaining("env: ASPNETCORE_URLS=http://localhost:5001");
         }
 
         [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -312,7 +312,8 @@ public sealed class RunCommandTests : SdkTest
         var runCommand = CreateRunCommand(projectPath);
         var result = runCommand.ReadLaunchProfileSettings(
             projectFactory: null,
-            expandExecutableProfile: true);
+            expandExecutableProfile: true,
+            out _);
 
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(result.Profile);
         Assert.AreEqual("executable", model.ExecutablePath);
@@ -327,7 +328,8 @@ public sealed class RunCommandTests : SdkTest
         TestAsset testInstance = TestAssetsManager.CopyTestAsset("AppThatOutputsDotnetLaunchProfile")
             .WithSource();
 
-        File.WriteAllText(Path.Combine(testInstance.Path, "Properties", "launchSettings.json"), """
+        string launchSettingsPath = Path.Combine(testInstance.Path, "Properties", "launchSettings.json");
+        File.WriteAllText(launchSettingsPath, """
             {
               "profiles": {
                 "First": {
@@ -338,6 +340,9 @@ public sealed class RunCommandTests : SdkTest
               }
             }
             """);
+        string projectPath = Directory.GetFiles(testInstance.Path, "*.csproj").Single();
+        string runJsonPath = Path.ChangeExtension(projectPath, ".run.json");
+        File.WriteAllText(runJsonPath, "{}");
         File.WriteAllText(Path.Combine(testInstance.Path, "Directory.Build.targets"), """
             <Project>
               <Import Project="$(BaseIntermediateOutputPath)launch-profile.props"
@@ -351,11 +356,23 @@ public sealed class RunCommandTests : SdkTest
             </Project>
             """);
 
-        new DotnetCommand(Log, "run")
+        CommandResult result = new DotnetCommand(Log, "run")
             .WithWorkingDirectory(testInstance.Path)
-            .Execute()
-            .Should().Pass()
-            .And.HaveStdOut(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
+            .Execute();
+
+        result.Should().Pass()
+            .And.HaveStdOutContaining(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
+        string usingLaunchSettingsMessage = string.Format(
+            CliCommandStrings.UsingLaunchSettingsFromMessage,
+            launchSettingsPath);
+        string ignoredRunJsonWarning = string.Format(
+            CliCommandStrings.RunCommandWarningRunJsonNotUsed,
+            runJsonPath,
+            launchSettingsPath);
+        Assert.IsNotNull(result.StdErr);
+        Assert.IsNotNull(result.StdOut);
+        Assert.AreEqual(1, result.StdErr.Split(usingLaunchSettingsMessage, StringSplitOptions.None).Length - 1);
+        Assert.AreEqual(1, result.StdOut.Split(ignoredRunJsonWarning, StringSplitOptions.None).Length - 1);
     }
 
     [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -88,7 +88,10 @@ public sealed class RunCommandTests : SdkTest
               "profiles": {
                 "First": {
                   "commandName": "Project",
-                  "commandLineArgs": "\"$(MSBuildProjectDirectory)\" \"$([System.IO.Path]::DirectorySeparatorChar)\" \"@(Items)\" \"%(Identity)\""
+                  "commandLineArgs": "\"$(MSBuildProjectDirectory)\" \"$([System.Int32]::MaxValue)\" \"@(Items)\" \"%(Identity)\"",
+                  "environmentVariables": {
+                    "TEST_VAR1": "$(MSBuildProjectDirectory)"
+                  }
                 }
               }
             }
@@ -98,7 +101,8 @@ public sealed class RunCommandTests : SdkTest
             .WithWorkingDirectory(testProjectDirectory)
             .Execute()
             .Should().Pass()
-            .And.HaveStdOutContaining($"ARGS={testProjectDirectory},$([System.IO.Path]::DirectorySeparatorChar),@(Items),%(Identity)");
+            .And.HaveStdOutContaining($"ARGS={testProjectDirectory},{int.MaxValue},@(Items),%(Identity)")
+            .And.HaveStdOutContaining($"TEST_VAR1=<<<{testProjectDirectory}>>>");
     }
 
     [TestMethod]
@@ -169,6 +173,49 @@ public sealed class RunCommandTests : SdkTest
         var command = (Command)runCommand.GetTargetCommand(model, projectFactory: null, cachedRunProperties: null, runPropertiesFromEvaluation: false, logger: null);
 
         Assert.AreEqual("\"app 1\" \"app 2\"", command.StartInfo.Arguments);
+    }
+
+    [TestMethod]
+    public void Executable_MSBuildPropertyExpansion()
+    {
+        var root = TestAssetsManager.CreateTestDirectory().Path;
+        var projectPath = Path.Combine(root, "myproj.csproj");
+        var launchSettingsDirectory = Path.Combine(root, "Properties");
+        Directory.CreateDirectory(launchSettingsDirectory);
+        File.WriteAllText(projectPath, """
+            <Project>
+              <PropertyGroup>
+                <LaunchExecutable>executable</LaunchExecutable>
+                <LaunchArgument>expanded-argument</LaunchArgument>
+                <LaunchWorkingDirectory>working</LaunchWorkingDirectory>
+                <LaunchEnvironment>expanded-environment</LaunchEnvironment>
+              </PropertyGroup>
+            </Project>
+            """);
+        File.WriteAllText(Path.Combine(launchSettingsDirectory, "launchSettings.json"), """
+            {
+              "profiles": {
+                "MyProfile": {
+                  "commandName": "Executable",
+                  "executablePath": "$(LaunchExecutable)",
+                  "commandLineArgs": "$(LaunchArgument)",
+                  "workingDirectory": "$(LaunchWorkingDirectory)",
+                  "environmentVariables": {
+                    "VALUE": "$(LaunchEnvironment)"
+                  }
+                }
+              }
+            }
+            """);
+
+        var runCommand = CreateRunCommand(projectPath);
+        var result = runCommand.ReadLaunchProfileSettings();
+
+        var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(result.Profile);
+        Assert.AreEqual("executable", model.ExecutablePath);
+        Assert.AreEqual("expanded-argument", model.CommandLineArgs);
+        Assert.AreEqual(Path.Combine(launchSettingsDirectory, "working"), model.WorkingDirectory);
+        Assert.AreEqual("expanded-environment", model.EnvironmentVariables["VALUE"]);
     }
 
     [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -106,6 +106,79 @@ public sealed class RunCommandTests : SdkTest
     }
 
     [TestMethod]
+    public void MSBuildPropertyExpansion_Project_UsesPostComputeRunArgumentsValue()
+    {
+        TestAsset testInstance = TestAssetsManager.CopyTestAsset("AppThatOutputsDotnetLaunchProfile")
+            .WithSource();
+
+        File.WriteAllText(Path.Combine(testInstance.Path, "Properties", "launchSettings.json"), """
+            {
+              "profiles": {
+                "First": {
+                  "commandName": "Project",
+                  "environmentVariables": {
+                    "TEST_VAR1": "$(LaunchEnvironment)"
+                  }
+                }
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(testInstance.Path, "Directory.Build.targets"), """
+            <Project>
+              <Target Name="SetLaunchEnvironment" BeforeTargets="ComputeRunArguments">
+                <PropertyGroup>
+                  <LaunchEnvironment>post-target</LaunchEnvironment>
+                </PropertyGroup>
+              </Target>
+            </Project>
+            """);
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOutContaining("TEST_VAR1=<<<post-target>>>");
+    }
+
+    [TestMethod]
+    public void MSBuildPropertyExpansion_Project_IgnoresCommandLineArgsWhenRunArgumentsAreSet()
+    {
+        TestAsset testInstance = TestAssetsManager.CopyTestAsset("AppThatOutputsDotnetLaunchProfile")
+            .WithSource();
+
+        File.WriteAllText(Path.Combine(testInstance.Path, "Properties", "launchSettings.json"), """
+            {
+              "profiles": {
+                "First": {
+                  "commandName": "Project",
+                  "commandLineArgs": "$([)",
+                  "environmentVariables": {
+                    "TEST_VAR1": "profile-environment"
+                  }
+                }
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(testInstance.Path, "Directory.Build.targets"), """
+            <Project>
+              <Target Name="SetRunArguments" AfterTargets="ComputeRunArguments">
+                <PropertyGroup>
+                  <RunArguments>target-argument</RunArguments>
+                </PropertyGroup>
+              </Target>
+            </Project>
+            """);
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOutContaining("ARGS=target-argument")
+            .And.HaveStdOutContaining("TEST_VAR1=<<<profile-environment>>>")
+            .And.NotHaveStdErrContaining("could not be applied");
+    }
+
+    [TestMethod]
     public void InvalidMSBuildExpressionInLaunchSettingsDoesNotPreventRun()
     {
         TestAsset testInstance = TestAssetsManager.CopyTestAsset("AppThatOutputsDotnetLaunchProfile")
@@ -237,13 +310,52 @@ public sealed class RunCommandTests : SdkTest
             """);
 
         var runCommand = CreateRunCommand(projectPath);
-        var result = runCommand.ReadLaunchProfileSettings();
+        var result = runCommand.ReadLaunchProfileSettings(
+            projectFactory: null,
+            expandExecutableProfile: true);
 
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(result.Profile);
         Assert.AreEqual("executable", model.ExecutablePath);
         Assert.AreEqual("expanded-argument", model.CommandLineArgs);
         Assert.AreEqual(Path.Combine(launchSettingsDirectory, "working"), model.WorkingDirectory);
         Assert.AreEqual("expanded-environment", model.EnvironmentVariables["VALUE"]);
+    }
+
+    [TestMethod]
+    public void Executable_MSBuildPropertyExpansion_UsesPostBuildEvaluation()
+    {
+        TestAsset testInstance = TestAssetsManager.CopyTestAsset("AppThatOutputsDotnetLaunchProfile")
+            .WithSource();
+
+        File.WriteAllText(Path.Combine(testInstance.Path, "Properties", "launchSettings.json"), """
+            {
+              "profiles": {
+                "First": {
+                  "commandName": "Executable",
+                  "executablePath": "dotnet",
+                  "commandLineArgs": "$(GeneratedArgument)"
+                }
+              }
+            }
+            """);
+        File.WriteAllText(Path.Combine(testInstance.Path, "Directory.Build.targets"), """
+            <Project>
+              <Import Project="$(BaseIntermediateOutputPath)launch-profile.props"
+                      Condition="Exists('$(BaseIntermediateOutputPath)launch-profile.props')" />
+              <Target Name="GenerateLaunchProfileProperties" BeforeTargets="Build">
+                <WriteLinesToFile
+                  File="$(BaseIntermediateOutputPath)launch-profile.props"
+                  Lines="&lt;Project&gt;&lt;PropertyGroup&gt;&lt;GeneratedArgument&gt;--version&lt;/GeneratedArgument&gt;&lt;/PropertyGroup&gt;&lt;/Project&gt;"
+                  Overwrite="true" />
+              </Target>
+            </Project>
+            """);
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(SdkTestContext.Current.ToolsetUnderTest.SdkVersion);
     }
 
     [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunCommandTests.cs
@@ -106,6 +106,34 @@ public sealed class RunCommandTests : SdkTest
     }
 
     [TestMethod]
+    public void InvalidMSBuildExpressionInLaunchSettingsDoesNotPreventRun()
+    {
+        TestAsset testInstance = TestAssetsManager.CopyTestAsset("AppThatOutputsDotnetLaunchProfile")
+            .WithSource();
+
+        string launchSettingsPath = Path.Combine(testInstance.Path, "Properties", "launchSettings.json");
+        File.WriteAllText(launchSettingsPath, """
+            {
+              "profiles": {
+                "First": {
+                  "commandName": "Project",
+                  "commandLineArgs": "$([)"
+                }
+              }
+            }
+            """);
+
+        new DotnetCommand(Log, "run")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdErrContaining(string.Format(
+                CliCommandStrings.RunCommandExceptionCouldNotApplyLaunchSettings,
+                LaunchProfileParser.GetLaunchProfileDisplayName(launchProfile: null),
+                "").Trim());
+    }
+
+    [TestMethod]
     public void Executable_DefaultWorkingDirectory()
     {
         var root = TestAssetsManager.CreateTestDirectory().Path;

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_BuildCommands.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_BuildCommands.cs
@@ -1082,6 +1082,41 @@ public sealed class RunFileTests_BuildCommands : RunFileTestBase
                 """);
     }
 
+    [TestMethod, CombinatorialData]
+    public void LaunchProfile_MSBuildPropertyExpansion(bool cscOnly)
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory(baseDirectory: cscOnly ? OutOfTreeBaseDirectory : null);
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), s_program);
+        if (!cscOnly)
+        {
+            File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), "<Project />");
+        }
+
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.run.json"), """
+            {
+                "profiles": {
+                    "TestProfile": {
+                        "commandName": "Project",
+                        "commandLineArgs": "\"$(MSBuildProjectDirectory)\""
+                    }
+                }
+            }
+            """);
+
+        string prefix = cscOnly
+            ? CliCommandStrings.NoBinaryLogBecauseRunningJustCsc + Environment.NewLine
+            : string.Empty;
+
+        new DotnetCommand(Log, "run", "-bl", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOut(prefix + $"""
+                echo args:{testInstance.Path}
+                Hello from Program
+                """);
+    }
+
     /// <summary>
     /// <c>Properties/launchSettings.json</c> takes precedence over <c>Program.run.json</c>.
     /// </summary>

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
@@ -1712,6 +1712,47 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
     }
 
     [TestMethod]
+    public void Api_RunCommand_LaunchProfileExpansionUsesArtifactsPath()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        string programPath = Path.Join(testInstance.Path, "Program.cs");
+        File.WriteAllText(programPath, """
+            Console.WriteLine();
+            """);
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.run.json"), """
+            {
+              "profiles": {
+                "Program": {
+                  "commandName": "Executable",
+                  "executablePath": "$(ArtifactsPath)",
+                  "workingDirectory": "$(ArtifactsPath)",
+                  "environmentVariables": {
+                    "PROFILE_ARTIFACTS": "$(ArtifactsPath)"
+                  }
+                }
+              }
+            }
+            """);
+
+        string artifactsPath = Path.Join(testInstance.Path, "custom-artifacts");
+
+        new DotnetCommand(Log, "run-api")
+            .WithEnvironmentVariable("DOTNET_ROOT", string.Empty)
+            .WithEnvironmentVariable($"DOTNET_ROOT_{RuntimeInformation.OSArchitecture.ToString().ToUpperInvariant()}", string.Empty)
+            .WithStandardInput($$"""
+                {"$type":"GetRunCommand","EntryPointFileFullPath":{{ToJson(programPath)}},"ArtifactsPath":{{ToJson(artifactsPath)}}}
+                """)
+            .Execute()
+            .Should().Pass()
+            .And.HaveStdOutContaining($$"""
+                {"$type":"RunCommand","Version":1,"ExecutablePath":{{ToJson(artifactsPath)}},"CommandLineArguments":"","WorkingDirectory":{{ToJson(artifactsPath)}}
+                """)
+            .And.HaveStdOutContaining($$"""
+                "PROFILE_ARTIFACTS":{{ToJson(artifactsPath)}}
+                """);
+    }
+
+    [TestMethod]
     public void Api_VirtualProjectBuilder_CreateProjectRootElement()
     {
         var testInstance = TestAssetsManager.CreateTestDirectory();

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -139,15 +139,23 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             var launchSettingsPath = Path.Join(testInstance.Path, "Properties", "launchSettings.json");
             var runJsonPath = Path.Join(testInstance.Path, "TestProjectWithLaunchSettings.run.json");
+            File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <LaunchArgument>--from-launch-settings</LaunchArgument>
+                    <LaunchEnvironment>TestValue1</LaunchEnvironment>
+                  </PropertyGroup>
+                </Project>
+                """);
 
-            File.WriteAllText(launchSettingsPath, $$"""
+            File.WriteAllText(launchSettingsPath, """
                 {
                     "profiles": {
                         "ConsoleApp25": {
                             "commandName": "Project",
-                            "commandLineArgs": "--from-launch-settings",
+                            "commandLineArgs": "$(LaunchArgument)",
                             "environmentVariables": {
-                                "MY_VARIABLE_FROM_LAUNCH_SETTINGS": "{{EnvironmentVariableReference("TEST_ENV_VAR")}}"
+                                "MY_VARIABLE_FROM_LAUNCH_SETTINGS": "$(LaunchEnvironment)"
                             }
                         }
                     }
@@ -161,7 +169,6 @@ namespace Microsoft.DotNet.Cli.Test.Tests
 
             CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
                                     .WithWorkingDirectory(testInstance.Path)
-                                    .WithEnvironmentVariable("TEST_ENV_VAR", "TestValue1")
                                     .Execute("-c", configuration);
 
             if (!SdkTestContext.IsLocalized())

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -190,6 +190,38 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
+        [TestMethod]
+        public void RunTestProjectWithInvalidMSBuildExpressionInLaunchSettings_ShouldReturnExitCodeSuccess()
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithTests")
+                .WithSource();
+
+            string propertiesDirectory = Path.Join(testInstance.Path, "Properties");
+            Directory.CreateDirectory(propertiesDirectory);
+            File.WriteAllText(Path.Join(propertiesDirectory, "launchSettings.json"), """
+                {
+                    "profiles": {
+                        "TestProjectWithTests": {
+                            "commandName": "Project",
+                            "commandLineArgs": "$([)"
+                        }
+                    }
+                }
+                """);
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute("-c", TestingConstants.Debug);
+
+            if (!SdkTestContext.IsLocalized())
+            {
+                result.StdErr.Should().Contain("could not be applied");
+                result.StdOut.Should().Contain("Test run summary: Passed!");
+            }
+
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
+
         [DataRow(TestingConstants.Debug)]
         [DataRow(TestingConstants.Release)]
         [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestBuildsAndRunsTests.cs
@@ -222,6 +222,52 @@ namespace Microsoft.DotNet.Cli.Test.Tests
             result.ExitCode.Should().Be(ExitCodes.Success);
         }
 
+        [TestMethod]
+        public void RunTestProjectWithIgnoredInvalidLaunchArguments_AppliesEnvironmentVariables()
+        {
+            TestAsset testInstance = TestAssetsManager.CopyTestAsset("TestProjectWithLaunchSettings")
+                .WithSource();
+
+            File.WriteAllText(Path.Join(testInstance.Path, "Properties", "launchSettings.json"), """
+                {
+                    "profiles": {
+                        "TestProjectWithLaunchSettings": {
+                            "commandName": "Project",
+                            "commandLineArgs": "$([)",
+                            "applicationUrl": "$([)",
+                            "environmentVariables": {
+                                "MY_VARIABLE_FROM_LAUNCH_SETTINGS": "$(LaunchEnvironment)"
+                            }
+                        }
+                    }
+                }
+                """);
+            File.WriteAllText(Path.Join(testInstance.Path, "Directory.Build.props"), """
+                <Project>
+                  <PropertyGroup>
+                    <LaunchEnvironment>expanded-environment</LaunchEnvironment>
+                  </PropertyGroup>
+                </Project>
+                """);
+            string programPath = Path.Join(testInstance.Path, "Program.cs");
+            File.WriteAllText(
+                programPath,
+                File.ReadAllText(programPath).Replace(
+                    "if (!args.Contains(\"--from-launch-settings\"))",
+                    "if (args.Contains(\"--from-launch-settings\"))"));
+
+            CommandResult result = new DotnetTestCommand(Log, disableNewOutput: false)
+                .WithWorkingDirectory(testInstance.Path)
+                .Execute("-c", TestingConstants.Debug, "--no-launch-profile-arguments");
+
+            if (!SdkTestContext.IsLocalized())
+            {
+                result.StdOut.Should().Contain("MY_VARIABLE_FROM_LAUNCH_SETTINGS=expanded-environment");
+            }
+
+            result.ExitCode.Should().Be(ExitCodes.Success);
+        }
+
         [DataRow(TestingConstants.Debug)]
         [DataRow(TestingConstants.Release)]
         [TestMethod]

--- a/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
+++ b/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
@@ -195,4 +195,74 @@ public class LaunchSettingsParserTests
             ("VAR2", "ENV_VALUE2")
         ], model.EnvironmentVariables.OrderBy(e => e.Key).Select(e => (e.Key, e.Value)));
     }
+
+    [TestMethod]
+    public void MSBuildPropertyExpansion_Executable()
+    {
+        string root = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        string launchSettingsPath = Path.Combine(root, "Properties", "launchSettings.json");
+        var properties = new Dictionary<string, string>
+        {
+            ["$(Executable)"] = "tool",
+            ["$(Argument)"] = "argument",
+            ["$(WorkingDirectory)"] = root,
+            ["$(EnvironmentValue)"] = "environment",
+        };
+
+        var settings = ExecutableLaunchProfileParser.Instance.ParseProfile(
+            launchSettingsPath,
+            "MyProfile",
+            """
+            {
+                "commandName": "Executable",
+                "executablePath": "$(Executable)",
+                "commandLineArgs": "$(Argument)",
+                "workingDirectory": "$(WorkingDirectory)",
+                "environmentVariables": {
+                    "VALUE": "$(EnvironmentValue)"
+                }
+            }
+            """,
+            value => properties[value]);
+
+        var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(settings.Profile);
+        Assert.AreEqual("tool", model.ExecutablePath);
+        Assert.AreEqual("argument", model.CommandLineArgs);
+        Assert.AreEqual(root, model.WorkingDirectory);
+        Assert.AreEqual("environment", model.EnvironmentVariables["VALUE"]);
+    }
+
+    [TestMethod]
+    public void MSBuildPropertyExpansion_Project()
+    {
+        var properties = new Dictionary<string, string>
+        {
+            ["$(Argument)"] = "argument",
+            ["$(LaunchUrl)"] = "path",
+            ["$(ApplicationUrl)"] = "https://localhost:5001",
+            ["$(EnvironmentValue)"] = "environment",
+        };
+
+        var settings = ProjectLaunchProfileParser.Instance.ParseProfile(
+            "launchSettings.json",
+            "MyProfile",
+            """
+            {
+                "commandName": "Project",
+                "commandLineArgs": "$(Argument)",
+                "launchUrl": "$(LaunchUrl)",
+                "applicationUrl": "$(ApplicationUrl)",
+                "environmentVariables": {
+                    "VALUE": "$(EnvironmentValue)"
+                }
+            }
+            """,
+            value => properties[value]);
+
+        var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(settings.Profile);
+        Assert.AreEqual("argument", model.CommandLineArgs);
+        Assert.AreEqual("path", model.LaunchUrl);
+        Assert.AreEqual("https://localhost:5001", model.ApplicationUrl);
+        Assert.AreEqual("environment", model.EnvironmentVariables["VALUE"]);
+    }
 }

--- a/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
+++ b/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
@@ -34,7 +34,7 @@ public class LaunchSettingsParserTests
             {
                 "commandName": "Executable"
             }
-            """, expandMSBuildProperty: null, expandCommandLineArgs: true));
+            """,             getVariableValue: null, expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -50,7 +50,7 @@ public class LaunchSettingsParserTests
                 "executablePath": "executable",
                 "dotnetRunMessages": {{value}}
             }
-            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
+            """,             getVariableValue: null, expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         Assert.IsNotNull(result.Profile);
@@ -68,7 +68,7 @@ public class LaunchSettingsParserTests
                 "executablePath": "executable",
                 "dotnetRunMessages": "true"
             }
-            """, expandMSBuildProperty: null, expandCommandLineArgs: true));
+            """,             getVariableValue: null, expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -81,7 +81,7 @@ public class LaunchSettingsParserTests
                 "commandName": "Project",
                 "dotnetRunMessages": "true"
             }
-            """, expandMSBuildProperty: null, expandCommandLineArgs: true));
+            """,             getVariableValue: null, expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -98,7 +98,7 @@ public class LaunchSettingsParserTests
                     "VAR1": "VALUE1", // trailing comma below
                 },
             }
-            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
+            """,             getVariableValue: null, expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(result.Profile);
@@ -120,7 +120,7 @@ public class LaunchSettingsParserTests
                     "VAR1": "VALUE1", // trailing comma below
                 },
             }
-            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
+            """,             getVariableValue: null, expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(result.Profile);
@@ -149,7 +149,7 @@ public class LaunchSettingsParserTests
                     "VAR2": "ENV_VALUE2"
                 }
             }
-            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
+            """,             getVariableValue: null, expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(settings.Profile);
 
@@ -183,7 +183,7 @@ public class LaunchSettingsParserTests
                     "VAR2": "ENV_VALUE2"
                 }
             }
-            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
+            """,             getVariableValue: null, expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(settings.Profile);
 

--- a/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
+++ b/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
@@ -34,7 +34,7 @@ public class LaunchSettingsParserTests
             {
                 "commandName": "Executable"
             }
-            """));
+            """, expandMSBuildProperty: null, expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -50,7 +50,7 @@ public class LaunchSettingsParserTests
                 "executablePath": "executable",
                 "dotnetRunMessages": {{value}}
             }
-            """);
+            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         Assert.IsNotNull(result.Profile);
@@ -68,7 +68,7 @@ public class LaunchSettingsParserTests
                 "executablePath": "executable",
                 "dotnetRunMessages": "true"
             }
-            """));
+            """, expandMSBuildProperty: null, expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -81,7 +81,7 @@ public class LaunchSettingsParserTests
                 "commandName": "Project",
                 "dotnetRunMessages": "true"
             }
-            """));
+            """, expandMSBuildProperty: null, expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -98,7 +98,7 @@ public class LaunchSettingsParserTests
                     "VAR1": "VALUE1", // trailing comma below
                 },
             }
-            """);
+            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(result.Profile);
@@ -120,7 +120,7 @@ public class LaunchSettingsParserTests
                     "VAR1": "VALUE1", // trailing comma below
                 },
             }
-            """);
+            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(result.Profile);
@@ -149,7 +149,7 @@ public class LaunchSettingsParserTests
                     "VAR2": "ENV_VALUE2"
                 }
             }
-            """);
+            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(settings.Profile);
 
@@ -183,7 +183,7 @@ public class LaunchSettingsParserTests
                     "VAR2": "ENV_VALUE2"
                 }
             }
-            """);
+            """, expandMSBuildProperty: null, expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(settings.Profile);
 
@@ -223,7 +223,8 @@ public class LaunchSettingsParserTests
                 }
             }
             """,
-            value => properties[value]);
+            value => properties[value],
+            expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(settings.Profile);
         Assert.AreEqual("tool", model.ExecutablePath);
@@ -257,12 +258,36 @@ public class LaunchSettingsParserTests
                 }
             }
             """,
-            value => properties[value]);
+            value => properties[value],
+            expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(settings.Profile);
         Assert.AreEqual("argument", model.CommandLineArgs);
-        Assert.AreEqual("path", model.LaunchUrl);
+        Assert.AreEqual("$(LaunchUrl)", model.LaunchUrl);
         Assert.AreEqual("https://localhost:5001", model.ApplicationUrl);
+        Assert.AreEqual("environment", model.EnvironmentVariables["VALUE"]);
+    }
+
+    [TestMethod]
+    public void MSBuildPropertyExpansion_Project_IgnoresDisabledCommandLineArgs()
+    {
+        var settings = ProjectLaunchProfileParser.Instance.ParseProfile(
+            "launchSettings.json",
+            "MyProfile",
+            """
+            {
+                "commandName": "Project",
+                "commandLineArgs": "$([)",
+                "environmentVariables": {
+                    "VALUE": "$(EnvironmentValue)"
+                }
+            }
+            """,
+            value => value == "$(EnvironmentValue)" ? "environment" : throw new InvalidOperationException(),
+            expandCommandLineArgs: false);
+
+        var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(settings.Profile);
+        Assert.AreEqual("$([)", model.CommandLineArgs);
         Assert.AreEqual("environment", model.EnvironmentVariables["VALUE"]);
     }
 }

--- a/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
+++ b/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using System.Text.Json;
 
 namespace Microsoft.DotNet.ProjectTools.Tests;
@@ -30,11 +31,16 @@ public class LaunchSettingsParserTests
     {
         var parser = ExecutableLaunchProfileParser.Instance;
 
-        Assert.ThrowsExactly<JsonException>(() => parser.ParseProfile("path", "Execute", """
-            {
-                "commandName": "Executable"
-            }
-            """,             evaluateExpression: null, expandCommandLineArgs: true));
+        Assert.ThrowsExactly<JsonException>(() => parser.ParseProfile(
+            "path",
+            "Execute",
+            """
+                {
+                    "commandName": "Executable"
+                }
+                """,
+            evaluateExpression: null,
+            expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -44,13 +50,18 @@ public class LaunchSettingsParserTests
     {
         var parser = ExecutableLaunchProfileParser.Instance;
 
-        var result = parser.ParseProfile("path", "name", $$"""
-            {
-                "commandName": "Executable",
-                "executablePath": "executable",
-                "dotnetRunMessages": {{value}}
-            }
-            """,             evaluateExpression: null, expandCommandLineArgs: true);
+        var result = parser.ParseProfile(
+            "path",
+            "name",
+            $$"""
+                {
+                    "commandName": "Executable",
+                    "executablePath": "executable",
+                    "dotnetRunMessages": {{value}}
+                }
+                """,
+            evaluateExpression: null,
+            expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         Assert.IsNotNull(result.Profile);
@@ -62,13 +73,18 @@ public class LaunchSettingsParserTests
     {
         var parser = ProjectLaunchProfileParser.Instance;
 
-        Assert.ThrowsExactly<JsonException>(() => parser.ParseProfile("path", "name", $$"""
-            {
-                "commandName": "Executable",
-                "executablePath": "executable",
-                "dotnetRunMessages": "true"
-            }
-            """,             evaluateExpression: null, expandCommandLineArgs: true));
+        Assert.ThrowsExactly<JsonException>(() => parser.ParseProfile(
+            "path",
+            "name",
+            $$"""
+                {
+                    "commandName": "Executable",
+                    "executablePath": "executable",
+                    "dotnetRunMessages": "true"
+                }
+                """,
+            evaluateExpression: null,
+            expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -76,12 +92,17 @@ public class LaunchSettingsParserTests
     {
         var parser = ProjectLaunchProfileParser.Instance;
 
-        Assert.ThrowsExactly<JsonException>(() => parser.ParseProfile("path", "name", $$"""
-            {
-                "commandName": "Project",
-                "dotnetRunMessages": "true"
-            }
-            """,             evaluateExpression: null, expandCommandLineArgs: true));
+        Assert.ThrowsExactly<JsonException>(() => parser.ParseProfile(
+            "path",
+            "name",
+            $$"""
+                {
+                    "commandName": "Project",
+                    "dotnetRunMessages": "true"
+                }
+                """,
+            evaluateExpression: null,
+            expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -89,16 +110,21 @@ public class LaunchSettingsParserTests
     {
         var parser = ExecutableLaunchProfileParser.Instance;
 
-        var result = parser.ParseProfile("path", "name", """
-            {
-                // line comment
-                "commandName": "Executable",
-                "executablePath": "executable", /* block comment */
-                "environmentVariables": {
-                    "VAR1": "VALUE1", // trailing comma below
-                },
-            }
-            """,             evaluateExpression: null, expandCommandLineArgs: true);
+        var result = parser.ParseProfile(
+            "path",
+            "name",
+            """
+                {
+                    // line comment
+                    "commandName": "Executable",
+                    "executablePath": "executable", /* block comment */
+                    "environmentVariables": {
+                        "VAR1": "VALUE1", // trailing comma below
+                    },
+                }
+                """,
+            evaluateExpression: null,
+            expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(result.Profile);
@@ -111,16 +137,21 @@ public class LaunchSettingsParserTests
     {
         var parser = ProjectLaunchProfileParser.Instance;
 
-        var result = parser.ParseProfile("path", "name", """
-            {
-                // line comment
-                "commandName": "Project",
-                "commandLineArgs": "arg1", /* block comment */
-                "environmentVariables": {
-                    "VAR1": "VALUE1", // trailing comma below
-                },
-            }
-            """,             evaluateExpression: null, expandCommandLineArgs: true);
+        var result = parser.ParseProfile(
+            "path",
+            "name",
+            """
+                {
+                    // line comment
+                    "commandName": "Project",
+                    "commandLineArgs": "arg1", /* block comment */
+                    "environmentVariables": {
+                        "VAR1": "VALUE1", // trailing comma below
+                    },
+                }
+                """,
+            evaluateExpression: null,
+            expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(result.Profile);
@@ -137,19 +168,24 @@ public class LaunchSettingsParserTests
 
         var parser = ExecutableLaunchProfileParser.Instance;
 
-        var settings = parser.ParseProfile(launchSettingsPath, "MyProfile", $$"""
-            {
-                "commandName": "Executable",
-                "executablePath": "../path/{{EnvironmentVariableReference(s_environmentVariableName1)}}/executable",
-                "commandLineArgs": "arg1 {{EnvironmentVariableReference(s_environmentVariableName1)}} arg3",
-                "workingDirectory": "{{Path.Combine("..", EnvironmentVariableReference(s_environmentVariableName1)).Replace("\\", "\\\\")}}",
-                "environmentVariables": {
-                    "{{s_environmentVariableNameUnset}}": "{{EnvironmentVariableReference(s_environmentVariableName2)}}",
-                    "VAR1": "{{EnvironmentVariableReference(s_environmentVariableNameUnset)}}",
-                    "VAR2": "ENV_VALUE2"
+        var settings = parser.ParseProfile(
+            launchSettingsPath,
+            "MyProfile",
+            $$"""
+                {
+                    "commandName": "Executable",
+                    "executablePath": "../path/{{EnvironmentVariableReference(s_environmentVariableName1)}}/executable",
+                    "commandLineArgs": "arg1 {{EnvironmentVariableReference(s_environmentVariableName1)}} arg3",
+                    "workingDirectory": "{{Path.Combine("..", EnvironmentVariableReference(s_environmentVariableName1)).Replace("\\", "\\\\")}}",
+                    "environmentVariables": {
+                        "{{s_environmentVariableNameUnset}}": "{{EnvironmentVariableReference(s_environmentVariableName2)}}",
+                        "VAR1": "{{EnvironmentVariableReference(s_environmentVariableNameUnset)}}",
+                        "VAR2": "ENV_VALUE2"
+                    }
                 }
-            }
-            """,             evaluateExpression: null, expandCommandLineArgs: true);
+                """,
+            evaluateExpression: null,
+            expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(settings.Profile);
 
@@ -173,17 +209,22 @@ public class LaunchSettingsParserTests
 
         var parser = ProjectLaunchProfileParser.Instance;
 
-        var settings = parser.ParseProfile(launchSettingsPath, "MyProfile", $$"""
-            {
-                "commandName": "Project",
-                "commandLineArgs": "arg1 {{EnvironmentVariableReference(s_environmentVariableName1)}} arg3",
-                "environmentVariables": {
-                    "{{s_environmentVariableNameUnset}}": "{{EnvironmentVariableReference(s_environmentVariableName2)}}",
-                    "VAR1": "{{EnvironmentVariableReference(s_environmentVariableNameUnset)}}",
-                    "VAR2": "ENV_VALUE2"
+        var settings = parser.ParseProfile(
+            launchSettingsPath,
+            "MyProfile",
+            $$"""
+                {
+                    "commandName": "Project",
+                    "commandLineArgs": "arg1 {{EnvironmentVariableReference(s_environmentVariableName1)}} arg3",
+                    "environmentVariables": {
+                        "{{s_environmentVariableNameUnset}}": "{{EnvironmentVariableReference(s_environmentVariableName2)}}",
+                        "VAR1": "{{EnvironmentVariableReference(s_environmentVariableNameUnset)}}",
+                        "VAR2": "ENV_VALUE2"
+                    }
                 }
-            }
-            """,             evaluateExpression: null, expandCommandLineArgs: true);
+                """,
+            evaluateExpression: null,
+            expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(settings.Profile);
 
@@ -266,6 +307,29 @@ public class LaunchSettingsParserTests
         Assert.AreEqual("$(LaunchUrl)", model.LaunchUrl);
         Assert.AreEqual("https://localhost:5001", model.ApplicationUrl);
         Assert.AreEqual("environment", model.EnvironmentVariables["VALUE"]);
+    }
+
+    [TestMethod]
+    public void MSBuildPropertyExpansion_Project_PreservesEnvironmentVariableComparers()
+    {
+        var keyComparer = StringComparer.OrdinalIgnoreCase;
+        var valueComparer = StringComparer.OrdinalIgnoreCase;
+        var profile = new ProjectLaunchProfile
+        {
+            EnvironmentVariables = ImmutableDictionary<string, string>.Empty
+                .WithComparers(keyComparer, valueComparer)
+                .Add("VALUE", "$(EnvironmentValue)"),
+        };
+
+        ProjectLaunchProfile expandedProfile = ProjectLaunchProfileParser.ExpandMSBuildProperties(
+            profile,
+            _ => "environment",
+            expandCommandLineArgs: false,
+            expandApplicationUrl: false);
+
+        Assert.AreSame(keyComparer, expandedProfile.EnvironmentVariables.KeyComparer);
+        Assert.AreSame(valueComparer, expandedProfile.EnvironmentVariables.ValueComparer);
+        Assert.AreEqual("environment", expandedProfile.EnvironmentVariables["VALUE"]);
     }
 
     [TestMethod]

--- a/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
+++ b/test/dotnet.Tests/ProjectTools/LaunchSettingsParserTests.cs
@@ -34,7 +34,7 @@ public class LaunchSettingsParserTests
             {
                 "commandName": "Executable"
             }
-            """,             getVariableValue: null, expandCommandLineArgs: true));
+            """,             evaluateExpression: null, expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -50,7 +50,7 @@ public class LaunchSettingsParserTests
                 "executablePath": "executable",
                 "dotnetRunMessages": {{value}}
             }
-            """,             getVariableValue: null, expandCommandLineArgs: true);
+            """,             evaluateExpression: null, expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         Assert.IsNotNull(result.Profile);
@@ -68,7 +68,7 @@ public class LaunchSettingsParserTests
                 "executablePath": "executable",
                 "dotnetRunMessages": "true"
             }
-            """,             getVariableValue: null, expandCommandLineArgs: true));
+            """,             evaluateExpression: null, expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -81,7 +81,7 @@ public class LaunchSettingsParserTests
                 "commandName": "Project",
                 "dotnetRunMessages": "true"
             }
-            """,             getVariableValue: null, expandCommandLineArgs: true));
+            """,             evaluateExpression: null, expandCommandLineArgs: true));
     }
 
     [TestMethod]
@@ -98,7 +98,7 @@ public class LaunchSettingsParserTests
                     "VAR1": "VALUE1", // trailing comma below
                 },
             }
-            """,             getVariableValue: null, expandCommandLineArgs: true);
+            """,             evaluateExpression: null, expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(result.Profile);
@@ -120,7 +120,7 @@ public class LaunchSettingsParserTests
                     "VAR1": "VALUE1", // trailing comma below
                 },
             }
-            """,             getVariableValue: null, expandCommandLineArgs: true);
+            """,             evaluateExpression: null, expandCommandLineArgs: true);
 
         Assert.IsTrue(result.Successful);
         var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(result.Profile);
@@ -149,7 +149,7 @@ public class LaunchSettingsParserTests
                     "VAR2": "ENV_VALUE2"
                 }
             }
-            """,             getVariableValue: null, expandCommandLineArgs: true);
+            """,             evaluateExpression: null, expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ExecutableLaunchProfile>(settings.Profile);
 
@@ -183,7 +183,7 @@ public class LaunchSettingsParserTests
                     "VAR2": "ENV_VALUE2"
                 }
             }
-            """,             getVariableValue: null, expandCommandLineArgs: true);
+            """,             evaluateExpression: null, expandCommandLineArgs: true);
 
         var model = Assert.IsExactInstanceOfType<ProjectLaunchProfile>(settings.Profile);
 


### PR DESCRIPTION
Expands MSBuild properties consistently across all supported launch-profile string fields using the same token replacement behavior as Visual Studio. This covers Project and Executable profiles for project and file-based `dotnet run`, plus MTP test launches; Native AOT defers before launch when selected values require MSBuild.

This follows up #56051 and addresses the post-merge feedback.

cc @baronfel @jjonescz

> [!NOTE]
> This pull request was drafted with GitHub Copilot.