### PR TITLE
[release/8.0.1xx] Update branding to 8.0.132

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <VersionPrefix>8.0.131</VersionPrefix>
+    <VersionPrefix>8.0.132</VersionPrefix>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>
     <DotNetFinalVersionKind Condition="'$(StabilizePackageVersion)' == 'true'">release</DotNetFinalVersionKind>


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0.1xx`.

**Changes:**
- Repository: sdk
  - PatchVersion: `31` -> `32`

**Files Modified:**
- eng/Versions.props (+1 -1)
