### PR TITLE
[release/8.0.4xx] Update branding to 8.0.426

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
   <!-- Repo Version Information -->
   <PropertyGroup>
-    <VersionPrefix>8.0.425</VersionPrefix>
+    <VersionPrefix>8.0.426</VersionPrefix>
     <WorkloadsFeatureBand>8.0.400</WorkloadsFeatureBand>
     <!-- Enable to remove prerelease label. -->
     <StabilizePackageVersion Condition="'$(StabilizePackageVersion)' == ''">true</StabilizePackageVersion>


### PR DESCRIPTION
This PR updates version branding on branch `release/8.0.4xx`.

**Changes:**
- Repository: sdk
  - PatchVersion: `25` -> `26`

**Files Modified:**
- eng/Versions.props (+1 -1)
