### PR TITLE
Update servicing consider labeling to include 10.0.4xx

### DIFF
--- a/.github/workflows/add-servicing-consider-label.yml
+++ b/.github/workflows/add-servicing-consider-label.yml
@@ -6,8 +6,6 @@ on:
     types: [opened, reopened, ready_for_review]
     branches:
       - 'release/[0-9]*'
-      # ignore 10.0.4xx until we release it
-      - '!release/10.0.4xx'
 
 permissions:
   contents: read


### PR DESCRIPTION
I also manually added the label to some PRs:

- #55939
- #55640
- #55629

Ensuring that the PRs follow the servicing process and don't get merged accidentally without Tactics approval.