### PR TITLE
Use built-in MSTest combinatorial data

### DIFF
--- a/.github/skills/migrate-xunit-to-mstest/SKILL.md
+++ b/.github/skills/migrate-xunit-to-mstest/SKILL.md
@@ -376,7 +376,7 @@ public sealed class MyTests
 | xUnit companion | MSTest equivalent |
 |---|---|
 | `Xunit.SkippableFact` (`[SkippableFact]`, `Skip.If`, `Skip.IfNot`) | For environmental predicates (OS/CI/arch): MSTest 3.10+ condition attributes (`[OSCondition]`, `[CICondition]`, etc.). Otherwise: `[Ignore]` (compile-time) or `Assert.Inconclusive("reason")` (runtime). Remove the package |
-| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | [`Combinatorial.MSTest`](https://github.com/Youssef1313/Combinatorial.MSTest) (community port; attribute surface matches xUnit.Combinatorial). Or expand combinations into explicit `[DataRow]`s / `[DynamicData]` |
+| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | MSTest 4.4+'s built-in combinatorial data support. Import `Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial`; the attribute surface matches `Xunit.Combinatorial`. |
 | `Xunit.StaFact` (`[StaFact]`, `[WpfFact]`) | `[TestMethod]` + manual STA thread. No MSTest equivalent for `[WpfFact]`; flag for manual conversion |
 | `Verify.Xunit` | `Verify.MSTest` -- swap the package; usage is similar |
 | `FluentAssertions` / `Shouldly` / `AwesomeAssertions` | Keep -- assertion library is framework-agnostic |

--- a/.github/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
+++ b/.github/skills/migrate-xunit-to-mstest/references/mapping-cheatsheet.md
@@ -379,7 +379,7 @@ With the pin in `global.json`, the project line simplifies to `<Project Sdk="MST
 | xUnit companion | MSTest equivalent |
 |---|---|
 | `Xunit.SkippableFact` (`[SkippableFact]`, `Skip.If`, `Skip.IfNot`) | `[Ignore]` (compile-time) or `Assert.Inconclusive("reason")` (runtime). Remove the package |
-| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | [`Combinatorial.MSTest`](https://github.com/Youssef1313/Combinatorial.MSTest) (community port) -- attribute surface is the same as xUnit.Combinatorial. Alternatively, expand combinations into explicit `[DataRow]`s or compute them in `[DynamicData]` |
+| `Xunit.Combinatorial` (`[CombinatorialData]`, `[CombinatorialValues]`) | MSTest 4.4+'s built-in combinatorial data support. Import `Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial`; the attribute surface is the same as `Xunit.Combinatorial`. |
 | `Xunit.StaFact` (`[StaFact]`, `[WpfFact]`) | No equivalent -- manual STA thread or flag for review |
 | `Xunit.Priority` (`[TestCaseOrderer]`) | MSTest ordering is different -- flag for manual |
 | `Verify.Xunit` | `Verify.MSTest` (swap the package; same usage) |

--- a/eng/Version.Details.props
+++ b/eng/Version.Details.props
@@ -137,10 +137,10 @@ This file should be imported by eng/Versions.props
     <SystemTextJsonPackageVersion>11.0.0-rc.1.26451.109</SystemTextJsonPackageVersion>
     <SystemWindowsExtensionsPackageVersion>11.0.0-rc.1.26451.109</SystemWindowsExtensionsPackageVersion>
     <!-- microsoft-testfx dependencies -->
-    <MicrosoftTestingPlatformPackageVersion>2.4.0-preview.26429.4</MicrosoftTestingPlatformPackageVersion>
+    <MicrosoftTestingPlatformPackageVersion>2.4.0</MicrosoftTestingPlatformPackageVersion>
     <MicrosoftTestingPlatformInternalDotnetTestPackageVersion>2.3.0-preview.26330.8</MicrosoftTestingPlatformInternalDotnetTestPackageVersion>
-    <MSTestPackageVersion>4.4.0-preview.26429.4</MSTestPackageVersion>
-    <MSTestSdkPackageVersion>4.4.0-preview.26429.4</MSTestSdkPackageVersion>
+    <MSTestPackageVersion>4.4.0</MSTestPackageVersion>
+    <MSTestSdkPackageVersion>4.4.0</MSTestSdkPackageVersion>
   </PropertyGroup>
   <!--Property group for alternate package version names-->
   <PropertyGroup>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -544,18 +544,18 @@
     <!-- KEEP IN SYNC: the following testfx packages (Microsoft.Testing.Platform, MSTest, MSTest.Sdk) must
          stay on the SAME testfx build/Sha. The MSTest.Sdk source generator emits registrations against the
          MSTest.TestFramework runtime, so a version skew breaks the NativeAOT CLI test build. See #55302. -->
-    <Dependency Name="Microsoft.Testing.Platform" Version="2.4.0-preview.26429.4">
+    <Dependency Name="Microsoft.Testing.Platform" Version="2.4.0">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>16f55b613b1bf4c445521fd546981c104dbcab7b</Sha>
+      <Sha>a81dff85c81f88b1cd0421619225b1037341d201</Sha>
     </Dependency>
-    <Dependency Name="MSTest" Version="4.4.0-preview.26429.4">
+    <Dependency Name="MSTest" Version="4.4.0">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>16f55b613b1bf4c445521fd546981c104dbcab7b</Sha>
+      <Sha>a81dff85c81f88b1cd0421619225b1037341d201</Sha>
     </Dependency>
     <!-- MSTest.Sdk is consumed from global.json's msbuild-sdks (not as a PackageReference). -->
-    <Dependency Name="MSTest.Sdk" Version="4.4.0-preview.26429.4">
+    <Dependency Name="MSTest.Sdk" Version="4.4.0">
       <Uri>https://github.com/microsoft/testfx</Uri>
-      <Sha>16f55b613b1bf4c445521fd546981c104dbcab7b</Sha>
+      <Sha>a81dff85c81f88b1cd0421619225b1037341d201</Sha>
     </Dependency>
     <Dependency Name="Microsoft.Extensions.Configuration.Ini" Version="11.0.0-rc.1.26451.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>

--- a/eng/dependabot/Packages.props
+++ b/eng/dependabot/Packages.props
@@ -4,7 +4,6 @@
 
   <ItemGroup>
     <!--Test dependencies-->
-    <PackageVersion Include="Combinatorial.MSTest" Version="2.0.0" />
     <PackageVersion Include="DiffPlex" Version="1.8.0" />
     <PackageVersion Include="FakeItEasy" Version="8.0.0" />
     <PackageVersion Include="Verify.DiffPlex" Version="3.1.2" />

--- a/global.json
+++ b/global.json
@@ -32,6 +32,6 @@
     "Microsoft.Build.NoTargets": "3.7.134",
     "Microsoft.Build.Traversal": "4.1.82",
     "Microsoft.WixToolset.Sdk": "6.0.3-dotnet.14",
-    "MSTest.Sdk": "4.4.0-preview.26429.4"
+    "MSTest.Sdk": "4.4.0"
   }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj
@@ -19,11 +19,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis" VersionOverride="$(MicrosoftCodeAnalysisPackageVersion)" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="$(MicrosoftCodeAnalysisCSharpPackageVersion)" />
-    <PackageReference Include="Combinatorial.MSTest" />
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Combinatorial.MSTest" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial" />
     <!-- Test.Utilities defines its own WorkItemAttribute(int, string); alias it so the unqualified
          [WorkItem(...)] usages bind to it instead of MSTest's WorkItemAttribute(int). -->
     <Using Include="Test.Utilities.WorkItemAttribute" Alias="WorkItemAttribute" />

--- a/test/AGENTS.md
+++ b/test/AGENTS.md
@@ -58,6 +58,10 @@ Guidance for changes under `test/`.
 - **MSTest output is live.** `test/testconfig.json` is copied beside each MSTest
   test executable as `<AssemblyName>.testconfig.json`, so console, trace, and
   `TestContext` output is both captured in the result and shown while the test runs.
+- **Use MSTest's built-in combinatorial data support.** Import
+  `Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial` for
+  `[CombinatorialData]`, `[CombinatorialValues]`, and `[CombinatorialRange]`; do not add
+  the third-party `Combinatorial.MSTest` package.
 - **Run all local tests through `run-tests`.** It selects and executes the appropriate
   test platform while preserving actionable output and diagnostics.
 - **Map new substantive test areas for targeted testing.** Prefer adding a

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests.csproj
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Microsoft.Extensions.DotNetDeltaApplier.Tests.csproj
@@ -10,7 +10,6 @@
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <ProjectReference Include="..\..\src\Dotnet.Watch\DotNetDeltaApplier\Microsoft.Extensions.DotNetDeltaApplier.csproj" />
     <ProjectReference Include="..\Microsoft.DotNet.Test.MSTest.Utilities\Microsoft.DotNet.Test.MSTest.Utilities.csproj" />
-    <PackageReference Include="Combinatorial.MSTest" />
     <PackageReference Include="Moq" />
   </ItemGroup>
 

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StreamExtensionsTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/StreamExtensionsTests.cs
@@ -1,7 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Combinatorial.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial;
 
 namespace Microsoft.DotNet.HotReload.UnitTests;
 

--- a/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
+++ b/test/dotnet-watch.Tests/HotReload/SourceFileUpdateTests.HotReloadNotSupported.cs
@@ -3,7 +3,7 @@
 
 #nullable disable
 
-using Combinatorial.MSTest;
+using Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 

--- a/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
+++ b/test/dotnet-watch.Tests/dotnet-watch.Tests.csproj
@@ -10,7 +10,7 @@
     <MSTestParallelizeScope>ClassLevel</MSTestParallelizeScope>
   </PropertyGroup>
   <ItemGroup>
-    <Using Include="Combinatorial.MSTest" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Microsoft.NET.Build.Tasks.Tests\Mocks\MockBuildEngine.cs" Link="TestUtilities\MockBuildEngine.cs" />
@@ -32,7 +32,6 @@
     <PackageReference Include="Microsoft.Build.Locator" />
     <PackageReference Include="Moq" />
     <PackageReference Include="Spectre.Console.Testing" />
-    <PackageReference Include="Combinatorial.MSTest" />
   </ItemGroup>
 
   <!-- Copies test browser files to test-browser output directory -->

--- a/test/dotnet.Tests/dotnet.Tests.csproj
+++ b/test/dotnet.Tests/dotnet.Tests.csproj
@@ -94,13 +94,12 @@
     <PackageReference Include="Verify.DiffPlex" />
     <!-- This package comes from dotnet/runtime-assets -->
     <PackageReference Include="Microsoft.DotNet.Installer.Windows.Security.TestData" GeneratePathProperty="true" />
-    <PackageReference Include="Combinatorial.MSTest" />
   </ItemGroup>
 
   <!-- Global usings -->
   <ItemGroup>
     <Using Include="Microsoft.DotNet.Cli.Telemetry" />
-    <Using Include="Combinatorial.MSTest" />
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial" />
     <!-- Aliases -->
     <!-- Note: '%3C' is for '<' and '%3E' is for '>' -->
     <Using Include="System.Collections.Generic.Dictionary%3CMicrosoft.NET.Sdk.WorkloadManifestReader.WorkloadId, Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadDefinition%3E" Alias="WorkloadCollection" />


### PR DESCRIPTION
MSTest 4.4 includes built-in combinatorial data support, so the SDK no longer needs the third-party `Combinatorial.MSTest` package.

This updates the coherent testfx dependency set to stable MSTest/MSTest.Sdk 4.4.0 and Microsoft.Testing.Platform 2.4.0. The four consuming test projects now import `Microsoft.VisualStudio.TestTools.UnitTesting.Combinatorial`, and repository test-authoring and migration guidance point to the built-in API.

Validation:
- `build.cmd`
- 103 `StreamExtensionsTests` cases
- 69 `DoNotDirectlyAwaitATaskTests` cases
- 25 `FileWatcherTests` cases
- 165 `DotnetProjectConvertTests` cases