### PR TITLE
Shut down MSBuild server after workload update

### DIFF
--- a/src/Cli/dotnet/Commands/Workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Workload/WorkloadCommandParser.cs
@@ -42,9 +42,21 @@ internal static class WorkloadCommandParser
         def.InstallCommand.SetAction(parseResult => new WorkloadInstallCommand(parseResult).Execute());
         def.UpdateCommand.SetAction(parseResult =>
         {
-            int exitCode = executeUpdate(parseResult);
-            msbuildServer.Shutdown();
-            return exitCode;
+            try
+            {
+                return executeUpdate(parseResult);
+            }
+            finally
+            {
+                try
+                {
+                    msbuildServer.Shutdown();
+                }
+                catch (Exception e)
+                {
+                    Reporter.Verbose.WriteLine(e.ToString());
+                }
+            }
         });
         def.ListCommand.SetAction(parseResult => new WorkloadListCommand(parseResult).Execute());
         def.SearchCommand.SetAction(parseResult => new WorkloadSearchCommand(parseResult).Execute());

--- a/src/Cli/dotnet/Commands/Workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Workload/WorkloadCommandParser.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using Microsoft.DotNet.Cli.BuildServer;
 using Microsoft.DotNet.Cli.Commands.Workload.Clean;
 using Microsoft.DotNet.Cli.Commands.Workload.Config;
 using Microsoft.DotNet.Cli.Commands.Workload.Elevate;
@@ -24,13 +25,27 @@ namespace Microsoft.DotNet.Cli.Commands.Workload;
 internal static class WorkloadCommandParser
 {
     public static void ConfigureCommand(WorkloadCommandDefinition def)
+        => ConfigureCommand(
+            def,
+            parseResult => new WorkloadUpdateCommand(parseResult).Execute(),
+            new MSBuildServer());
+
+    internal static void ConfigureCommand(
+        WorkloadCommandDefinition def,
+        Func<ParseResult, int> executeUpdate,
+        IBuildServer msbuildServer)
     {
         def.SetAction(parseResult => parseResult.HandleMissingCommand());
         def.InfoOption.Action = new ShowWorkloadsInfoAction();
         def.VersionOption.Action = new ShowWorkloadsVersionOption();
 
         def.InstallCommand.SetAction(parseResult => new WorkloadInstallCommand(parseResult).Execute());
-        def.UpdateCommand.SetAction(parseResult => new WorkloadUpdateCommand(parseResult).Execute());
+        def.UpdateCommand.SetAction(parseResult =>
+        {
+            int exitCode = executeUpdate(parseResult);
+            msbuildServer.Shutdown();
+            return exitCode;
+        });
         def.ListCommand.SetAction(parseResult => new WorkloadListCommand(parseResult).Execute());
         def.SearchCommand.SetAction(parseResult => new WorkloadSearchCommand(parseResult).Execute());
         def.SearchCommand.VersionCommand.SetAction(parseResult => new WorkloadSearchVersionsCommand(parseResult).Execute());

--- a/src/Cli/dotnet/Commands/Workload/WorkloadCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Workload/WorkloadCommandParser.cs
@@ -42,19 +42,28 @@ internal static class WorkloadCommandParser
         def.InstallCommand.SetAction(parseResult => new WorkloadInstallCommand(parseResult).Execute());
         def.UpdateCommand.SetAction(parseResult =>
         {
+            bool shouldShutdown =
+                !parseResult.GetValue(def.UpdateCommand.PrintDownloadLinkOnlyOption) &&
+                string.IsNullOrWhiteSpace(parseResult.GetValue(def.UpdateCommand.DownloadToCacheOption)) &&
+                !parseResult.GetValue(def.UpdateCommand.AdManifestOnlyOption) &&
+                !parseResult.GetValue(def.UpdateCommand.PrintRollbackOption);
+
             try
             {
                 return executeUpdate(parseResult);
             }
             finally
             {
-                try
+                if (shouldShutdown)
                 {
-                    msbuildServer.Shutdown();
-                }
-                catch (Exception e)
-                {
-                    Reporter.Verbose.WriteLine(e.ToString());
+                    try
+                    {
+                        msbuildServer.Shutdown();
+                    }
+                    catch (Exception e)
+                    {
+                        Reporter.Verbose.WriteLine(e.ToString());
+                    }
                 }
             }
         });

--- a/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
@@ -4,6 +4,7 @@
 #nullable disable
 
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.Runtime.CompilerServices;
 using ManifestReaderTests;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
@@ -12,6 +13,7 @@ using Microsoft.DotNet.Cli.Workload.Install.Tests;
 using Microsoft.NET.Sdk.WorkloadManifestReader;
 using static Microsoft.NET.Sdk.WorkloadManifestReader.WorkloadResolver;
 using System.Text.Json;
+using Microsoft.DotNet.Cli.BuildServer;
 using Microsoft.DotNet.Cli.Workload.Search.Tests;
 using NuGet.Versioning;
 using Microsoft.DotNet.Cli.Commands.Workload;
@@ -19,6 +21,7 @@ using Microsoft.DotNet.Cli.Commands.Workload.Install;
 using Microsoft.DotNet.Cli.Commands.Workload.Config;
 using Microsoft.DotNet.Cli.Commands.Workload.Update;
 using Microsoft.DotNet.Cli.Commands;
+using Moq;
 
 namespace Microsoft.DotNet.Cli.Workload.Update.Tests
 {
@@ -34,6 +37,33 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             _reporter = new BufferedReporter();
             _manifestPath = Path.Combine(TestAssetsManager.GetAndValidateTestProjectDirectory("SampleManifest"), "Sample.json");
             _parseResult = Parser.Parse(new string[] { "dotnet", "workload", "update" });
+        }
+
+        [TestMethod]
+        public void GivenWorkloadUpdateItShutsDownMSBuildServerAfterTheUpdateFinishes()
+        {
+            bool updateFinished = false;
+            var msbuildServer = new Mock<IBuildServer>(MockBehavior.Strict);
+            msbuildServer
+                .Setup(server => server.Shutdown())
+                .Callback(() => updateFinished.Should().BeTrue());
+
+            var workloadCommand = new WorkloadCommandDefinition();
+            WorkloadCommandParser.ConfigureCommand(
+                workloadCommand,
+                _ =>
+                {
+                    updateFinished = true;
+                    return 42;
+                },
+                msbuildServer.Object);
+
+            var rootCommand = new RootCommand();
+            rootCommand.Subcommands.Add(workloadCommand);
+            int exitCode = rootCommand.Parse(["workload", "update"]).Invoke(new InvocationConfiguration());
+
+            exitCode.Should().Be(42);
+            msbuildServer.Verify(server => server.Shutdown(), Times.Once);
         }
 
         [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
@@ -4,7 +4,6 @@
 #nullable disable
 
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Runtime.CompilerServices;
 using ManifestReaderTests;
 using Microsoft.DotNet.Cli.NuGetPackageDownloader;
@@ -48,22 +47,58 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 .Setup(server => server.Shutdown())
                 .Callback(() => updateFinished.Should().BeTrue());
 
-            var workloadCommand = new WorkloadCommandDefinition();
-            WorkloadCommandParser.ConfigureCommand(
-                workloadCommand,
+            int exitCode = ParseWorkloadUpdate(
                 _ =>
                 {
                     updateFinished = true;
                     return 42;
                 },
-                msbuildServer.Object);
-
-            var rootCommand = new RootCommand();
-            rootCommand.Subcommands.Add(workloadCommand);
-            int exitCode = rootCommand.Parse(["workload", "update"]).Invoke(new InvocationConfiguration());
+                msbuildServer.Object).Invoke(Parser.InvocationConfiguration);
 
             exitCode.Should().Be(42);
             msbuildServer.Verify(server => server.Shutdown(), Times.Once);
+        }
+
+        [TestMethod]
+        public void GivenWorkloadUpdateFailsItStillShutsDownMSBuildServer()
+        {
+            var expectedException = new InvalidOperationException("Update failed");
+            var msbuildServer = new Mock<IBuildServer>(MockBehavior.Strict);
+            msbuildServer
+                .Setup(server => server.Shutdown())
+                .Throws(new InvalidOperationException("Shutdown failed"));
+
+            var actualException = Assert.ThrowsExactly<InvalidOperationException>(() =>
+                ParseWorkloadUpdate(_ => throw expectedException, msbuildServer.Object)
+                    .Invoke(Parser.InvocationConfiguration));
+
+            actualException.Should().BeSameAs(expectedException);
+            msbuildServer.Verify(server => server.Shutdown(), Times.Once);
+        }
+
+        [TestMethod]
+        public void GivenMSBuildServerShutdownFailsItPreservesTheWorkloadUpdateExitCode()
+        {
+            var msbuildServer = new Mock<IBuildServer>(MockBehavior.Strict);
+            msbuildServer
+                .Setup(server => server.Shutdown())
+                .Throws(new InvalidOperationException("Shutdown failed"));
+
+            int exitCode = ParseWorkloadUpdate(_ => 42, msbuildServer.Object)
+                .Invoke(Parser.InvocationConfiguration);
+
+            exitCode.Should().Be(42);
+            msbuildServer.Verify(server => server.Shutdown(), Times.Once);
+        }
+
+        private static ParseResult ParseWorkloadUpdate(Func<ParseResult, int> executeUpdate, IBuildServer msbuildServer)
+        {
+            var workloadCommand = new WorkloadCommandDefinition();
+            WorkloadCommandParser.ConfigureCommand(workloadCommand, executeUpdate, msbuildServer);
+
+            var rootCommand = new RootCommand();
+            rootCommand.Subcommands.Add(workloadCommand);
+            return rootCommand.Parse(["workload", "update"]);
         }
 
         [TestMethod]

--- a/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
@@ -42,10 +42,11 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
         public void GivenWorkloadUpdateItShutsDownMSBuildServerAfterTheUpdateFinishes()
         {
             bool updateFinished = false;
+            bool shutdownAfterUpdate = false;
             var msbuildServer = new Mock<IBuildServer>(MockBehavior.Strict);
             msbuildServer
                 .Setup(server => server.Shutdown())
-                .Callback(() => updateFinished.Should().BeTrue());
+                .Callback(() => shutdownAfterUpdate = updateFinished);
 
             int exitCode = ParseWorkloadUpdate(
                 _ =>
@@ -56,6 +57,7 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
                 msbuildServer.Object).Invoke(Parser.InvocationConfiguration);
 
             exitCode.Should().Be(42);
+            shutdownAfterUpdate.Should().BeTrue();
             msbuildServer.Verify(server => server.Shutdown(), Times.Once);
         }
 

--- a/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
+++ b/test/dotnet.Tests/CommandTests/Workload/Update/GivenDotnetWorkloadUpdate.cs
@@ -93,14 +93,34 @@ namespace Microsoft.DotNet.Cli.Workload.Update.Tests
             msbuildServer.Verify(server => server.Shutdown(), Times.Once);
         }
 
-        private static ParseResult ParseWorkloadUpdate(Func<ParseResult, int> executeUpdate, IBuildServer msbuildServer)
+        [TestMethod]
+        [DataRow("--print-rollback", null)]
+        [DataRow("--print-download-link-only", null)]
+        [DataRow("--download-to-cache", "cache")]
+        [DataRow("--advertising-manifests-only", null)]
+        public void GivenNonMutatingWorkloadUpdateItDoesNotShutDownMSBuildServer(string option, string value)
+        {
+            var msbuildServer = new Mock<IBuildServer>(MockBehavior.Strict);
+            string[] arguments = value is null ? [option] : [option, value];
+
+            int exitCode = ParseWorkloadUpdate(_ => 42, msbuildServer.Object, arguments)
+                .Invoke(Parser.InvocationConfiguration);
+
+            exitCode.Should().Be(42);
+            msbuildServer.Verify(server => server.Shutdown(), Times.Never);
+        }
+
+        private static ParseResult ParseWorkloadUpdate(
+            Func<ParseResult, int> executeUpdate,
+            IBuildServer msbuildServer,
+            params string[] arguments)
         {
             var workloadCommand = new WorkloadCommandDefinition();
             WorkloadCommandParser.ConfigureCommand(workloadCommand, executeUpdate, msbuildServer);
 
             var rootCommand = new RootCommand();
             rootCommand.Subcommands.Add(workloadCommand);
-            return rootCommand.Parse(["workload", "update"]);
+            return rootCommand.Parse(["workload", "update", .. arguments]);
         }
 
         [TestMethod]


### PR DESCRIPTION
Part of #56045

### Context

The MSBuild server can retain workload resolver state across builds. A state-changing `dotnet workload update` must therefore shut the server down so subsequent builds do not reuse stale resolver data.

### Changes Made

- Shut down the MSBuild server after top-level workload updates that can change installed state.
- Keep the server running for print-only, cache-download, and advertising-manifest-only modes.
- Attempt shutdown when workload update throws without replacing the original exception.
- Preserve the workload update exit code when server shutdown fails.
- Add focused parser-action coverage for ordering, failure handling, and non-mutating modes.

### Testing

- Built `test/dotnet.Tests/dotnet.Tests.csproj` — 0 warnings, 0 errors.
- Ran the focused `GivenDotnetWorkloadUpdate` server-shutdown tests through `scripts/RunTests.cs`.
- Result: 7 passed, 0 failed, including all four non-mutating modes.
- Manually exercised the built redist CLI with a real MSBuild server:
  - `--print-rollback` preserved the existing server process.
  - A safely failing state-changing update shut down the server.
  - The next build created a fresh server process.

### Notes

- This PR covers workload updates. Other immutable-state invalidation scenarios remain tracked by #56045.
