### PR TITLE
Allow acquiring the crossgen2 pack without PublishReadyToRun

### DIFF
--- a/src/Tasks/Common/Resources/Strings.resx
+++ b/src/Tasks/Common/Resources/Strings.resx
@@ -1054,5 +1054,13 @@ You may need to build the project on another operating system or architecture, o
     <value>NETSDK1244: 'IncludeAllContentForSelfExtract' enables a legacy compatibility mode that extracts all managed assemblies to disk at startup. Prefer the default in-memory single-file behavior by removing the 'IncludeAllContentForSelfExtract' property from your project.</value>
     <comment>{StrBegins="NETSDK1244: "}{Locked="IncludeAllContentForSelfExtract"}</comment>
   </data>
-  <!-- The latest message added is IncludeAllContentForSelfExtractIsLegacy. Please update this value with each PR to catch parallel PRs both adding a new message -->
+  <data name="Crossgen2UnsupportedHostRuntimeIdentifier" xml:space="preserve">
+    <value>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</value>
+    <comment>{StrBegins="NETSDK1245: "}</comment>
+  </data>
+  <data name="Crossgen2UnsupportedTargetFramework" xml:space="preserve">
+    <value>NETSDK1246: The crossgen2 pack is not available for the target framework.</value>
+    <comment>{StrBegins="NETSDK1246: "}</comment>
+  </data>
+  <!-- The latest message added is Crossgen2UnsupportedTargetFramework. Please update this value with each PR to catch parallel PRs both adding a new message -->
 </root>

--- a/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.cs.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: Pokud je UseCrossgen2 nastavené na true, musí se zadat Crossgen2Tool.</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: Pokud se publikuje pro .NET 5 s Crossgen2 pomocí kompozitního režimu, nedají se generovat symboly.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.de.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.de.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: "Crossgen2Tool" muss angegeben werden, wenn "UseCrossgen2" auf TRUE festgelegt ist.</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: Bei der Veröffentlichung für .NET 5 mit Crossgen2 im zusammengesetzten Modus können keine Symbole ausgegeben werden.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.es.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.es.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: Crossgen2Tool debe especificarse cuando UseCrossgen2 esté establecido en true.</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: No se pueden emitir símbolos al publicar para .NET 5 con Crossgen2 con el modo compuesto.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.fr.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: Crossgen2Tool doit être spécifié quand UseCrossgen2 a la valeur true.</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: impossible d'émettre des symboles durant la publication pour .NET 5 avec Crossgen2 en mode composite.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.it.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.it.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: è necessario specificare Crossgen2Tool quando UseCrossgen2 è impostato su true.</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: non è possibile creare simboli durante la pubblicazione per .NET 5 con Crossgen2 usando la modalità composita.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ja.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: UseCrossgen2 が true に設定されている場合は Crossgen2Tool を指定する必要があります。</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: 複合モードを使用して Crossgen2 で .NET 5 を対象に発行する場合、シンボルを生成できません。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ko.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: UseCrossgen2가 true로 설정된 경우 Crossgen2Tool을 지정해야 합니다.</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: 복합 모드를 사용하여 Crossgen2를 사용하여 .NET 5에 게시할 때 기호를 내보낼 수 없습니다.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pl.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: należy określić element Crossgen2Tool, gdy właściwość UseCrossgen2 jest ustawiona na wartość true.</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: nie można emitować symboli podczas publikowania w przypadku platformy .NET 5 z Crossgen2 przy użyciu trybu złożonego.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.pt-BR.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: crossgen2Tool deve ser especificado quando UseCrossgen2 é definido como verdadeiro.</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: não é possível emitir símbolos ao publicar para .NET 5 com Crossgen2 usando o modo composto.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.ru.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: если параметр "UseCrossgen2" имеет значение "true", должно быть указано значение параметра "Crossgen2Tool".</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: не удается создать символы при публикации для .NET 5 с Crossgen2 в составном режиме.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.tr.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: Crossgen2Tool, UseCrossgen2 true olarak ayarlandığında belirtilmelidir.</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: Bileşik modu kullanarak .NET 5 için Crossgen2 ile yayımlanırken semboller yayılamıyor.</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hans.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: 当 UseCrossgen2 设置为 true 时，必须指定 Crossgen2Tool。</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: 使用复合模式针对具有 Crossgen2 的 .NET 5 发布时，无法发出符号。</target>

--- a/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
+++ b/src/Tasks/Common/Resources/xlf/Strings.zh-Hant.xlf
@@ -344,6 +344,16 @@
         <target state="translated">NETSDK1154: 當 UseCrossgen2 設定為 true 時，必須指定 Crossgen2Tool。</target>
         <note>{StrBegins="NETSDK1154: "}</note>
       </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedHostRuntimeIdentifier">
+        <source>NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</source>
+        <target state="new">NETSDK1245: The crossgen2 pack is not available for the build host platform '{0}'.</target>
+        <note>{StrBegins="NETSDK1245: "}</note>
+      </trans-unit>
+      <trans-unit id="Crossgen2UnsupportedTargetFramework">
+        <source>NETSDK1246: The crossgen2 pack is not available for the target framework.</source>
+        <target state="new">NETSDK1246: The crossgen2 pack is not available for the target framework.</target>
+        <note>{StrBegins="NETSDK1246: "}</note>
+      </trans-unit>
       <trans-unit id="Crossgen5CannotEmitSymbolsInCompositeMode">
         <source>NETSDK1166: Cannot emit symbols when publishing for .NET 5 with Crossgen2 using composite mode.</source>
         <target state="translated">NETSDK1166: 使用複合模式透過 Crossgen2 發佈 .NET 5 時，無法發出符號。</target>

--- a/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/ProcessFrameworkReferences.cs
@@ -44,6 +44,12 @@ namespace Microsoft.NET.Build.Tasks
 
         public bool ReadyToRunUseCrossgen2 { get; set; }
 
+        /// <summary>
+        /// Acquires the crossgen2 pack for a build that uses the tool for something other than
+        /// compiling ReadyToRun images, such as reading the target's ABI from its type system.
+        /// </summary>
+        public bool RequiresCrossgen2Pack { get; set; }
+
         public bool PublishAot { get; set; }
 
         public bool RequiresILLinkPack { get; set; }
@@ -473,11 +479,27 @@ namespace Microsoft.NET.Build.Tasks
 
             List<ITaskItem> implicitPackageReferences = new();
 
-            if (ReadyToRunEnabled && ReadyToRunUseCrossgen2)
+            if ((ReadyToRunEnabled && ReadyToRunUseCrossgen2) || RequiresCrossgen2Pack)
             {
-                if (AddToolPack(ToolPackType.Crossgen2, _normalizedTargetFrameworkVersion, packagesToDownload, implicitPackageReferences) is not ToolPackSupport.Supported)
+                ToolPackSupport crossgen2PackSupport = AddToolPack(ToolPackType.Crossgen2, _normalizedTargetFrameworkVersion, packagesToDownload, implicitPackageReferences);
+                if (crossgen2PackSupport is not ToolPackSupport.Supported)
                 {
-                    Log.LogError(Strings.ReadyToRunNoValidRuntimePackageError);
+                    // ReadyToRun keeps NETSDK1094, which tells the user to turn PublishReadyToRun
+                    // off. That is no help to a build that asked for the tool itself, so report
+                    // whichever of the two the pack did not match: the host, or the target framework.
+                    if (ReadyToRunEnabled)
+                    {
+                        Log.LogError(Strings.ReadyToRunNoValidRuntimePackageError);
+                    }
+                    else if (crossgen2PackSupport is ToolPackSupport.UnsupportedForHostRuntimeIdentifier)
+                    {
+                        Log.LogError(Strings.Crossgen2UnsupportedHostRuntimeIdentifier, NETCoreSdkRuntimeIdentifier);
+                    }
+                    else
+                    {
+                        Log.LogError(Strings.Crossgen2UnsupportedTargetFramework);
+                    }
+
                     return;
                 }
             }

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -488,6 +488,29 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
+                                        ResolveCrossgen2ToolPath
+
+    Reports the crossgen2 executable in $(Crossgen2ToolPath) for builds that use the tool for
+    something other than compiling ReadyToRun images.
+
+    ResolveReadyToRunCompilers derives the same path, but it runs only from CreateReadyToRunImages,
+    which is part of publish, and it reports the result as an item rather than a property. Nothing
+    invokes this target either, so a consumer has to depend on it; it is separate from the
+    ReadyToRun path so that acquiring the pack and compiling images stay independent.
+    ============================================================
+    -->
+  <Target Name="ResolveCrossgen2ToolPath"
+          DependsOnTargets="ResolveFrameworkReferences"
+          Condition="'$(Crossgen2ToolPath)' == '' and '@(ResolvedCrossgen2Pack)' != ''">
+    <PropertyGroup>
+      <_Crossgen2ToolFileName>crossgen2</_Crossgen2ToolFileName>
+      <_Crossgen2ToolFileName Condition="$([MSBuild]::IsOSPlatform('Windows'))">crossgen2.exe</_Crossgen2ToolFileName>
+      <Crossgen2ToolPath>$([MSBuild]::NormalizePath('%(ResolvedCrossgen2Pack.PackageDirectory)', 'tools', '$(_Crossgen2ToolFileName)'))</Crossgen2ToolPath>
+    </PropertyGroup>
+  </Target>
+
+  <!--
+    ============================================================
                                         _CreateR2RImages
 
     Compiles assemblies in the _ReadyToRunCompileList list into ReadyToRun images

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.CrossGen.targets
@@ -488,29 +488,6 @@ Copyright (c) .NET Foundation. All rights reserved.
 
   <!--
     ============================================================
-                                        ResolveCrossgen2ToolPath
-
-    Reports the crossgen2 executable in $(Crossgen2ToolPath) for builds that use the tool for
-    something other than compiling ReadyToRun images.
-
-    ResolveReadyToRunCompilers derives the same path, but it runs only from CreateReadyToRunImages,
-    which is part of publish, and it reports the result as an item rather than a property. Nothing
-    invokes this target either, so a consumer has to depend on it; it is separate from the
-    ReadyToRun path so that acquiring the pack and compiling images stay independent.
-    ============================================================
-    -->
-  <Target Name="ResolveCrossgen2ToolPath"
-          DependsOnTargets="ResolveFrameworkReferences"
-          Condition="'$(Crossgen2ToolPath)' == '' and '@(ResolvedCrossgen2Pack)' != ''">
-    <PropertyGroup>
-      <_Crossgen2ToolFileName>crossgen2</_Crossgen2ToolFileName>
-      <_Crossgen2ToolFileName Condition="$([MSBuild]::IsOSPlatform('Windows'))">crossgen2.exe</_Crossgen2ToolFileName>
-      <Crossgen2ToolPath>$([MSBuild]::NormalizePath('%(ResolvedCrossgen2Pack.PackageDirectory)', 'tools', '$(_Crossgen2ToolFileName)'))</Crossgen2ToolPath>
-    </PropertyGroup>
-  </Target>
-
-  <!--
-    ============================================================
                                         _CreateR2RImages
 
     Compiles assemblies in the _ReadyToRunCompileList list into ReadyToRun images

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.Sdk.FrameworkReferenceResolution.targets
@@ -130,6 +130,7 @@ Copyright (c) .NET Foundation. All rights reserved.
                                 SelfContained="$(SelfContained)"
                                 ReadyToRunEnabled="$(PublishReadyToRun)"
                                 ReadyToRunUseCrossgen2="$(PublishReadyToRunUseCrossgen2)"
+                                RequiresCrossgen2Pack="$(RequiresCrossgen2Pack)"
                                 PublishAot="$(PublishAot)"
                                 RequiresILLinkPack="$(_RequiresILLinkPack)"
                                 IsAotCompatible="$(IsAotCompatible)"

--- a/test/Microsoft.NET.Build.Tasks.Tests/ProcessFrameworkReferencesTests.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/ProcessFrameworkReferencesTests.cs
@@ -186,6 +186,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             if (config.KnownRuntimePacks != null) task.KnownRuntimePacks = config.KnownRuntimePacks;
             if (config.KnownILLinkPacks != null) task.KnownILLinkPacks = config.KnownILLinkPacks;
             if (config.KnownILCompilerPacks != null) task.KnownILCompilerPacks = config.KnownILCompilerPacks;
+            if (config.KnownCrossgen2Packs != null) task.KnownCrossgen2Packs = config.KnownCrossgen2Packs;
             
             // Set additional AOT/trimming properties
             if (config.PublishAot.HasValue) task.PublishAot = config.PublishAot.Value;
@@ -196,6 +197,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             if (config.EnableSingleFileAnalyzer.HasValue) task.EnableSingleFileAnalyzer = config.EnableSingleFileAnalyzer.Value;
             if (config.ReadyToRunEnabled.HasValue) task.ReadyToRunEnabled = config.ReadyToRunEnabled.Value;
             if (config.ReadyToRunUseCrossgen2.HasValue) task.ReadyToRunUseCrossgen2 = config.ReadyToRunUseCrossgen2.Value;
+            if (config.RequiresCrossgen2Pack.HasValue) task.RequiresCrossgen2Pack = config.RequiresCrossgen2Pack.Value;
             
             if (!string.IsNullOrEmpty(config.NetCoreRoot)) task.NetCoreRoot = config.NetCoreRoot;
             if (!string.IsNullOrEmpty(config.NETCoreSdkVersion)) task.NETCoreSdkVersion = config.NETCoreSdkVersion;
@@ -228,6 +230,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             public MockTaskItem[]? KnownRuntimePacks { get; set; }
             public MockTaskItem[]? KnownILLinkPacks { get; set; }
             public MockTaskItem[]? KnownILCompilerPacks { get; set; }
+            public MockTaskItem[]? KnownCrossgen2Packs { get; set; }
             public bool? PublishAot { get; set; }
             public bool? PublishTrimmed { get; set; }
             public bool? RequiresILLinkPack { get; set; }
@@ -236,9 +239,142 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
             public bool? EnableSingleFileAnalyzer { get; set; }
             public bool? ReadyToRunEnabled { get; set; }
             public bool? ReadyToRunUseCrossgen2 { get; set; }
+            public bool? RequiresCrossgen2Pack { get; set; }
             public string? NetCoreRoot { get; set; }
             public string? NETCoreSdkVersion { get; set; }
             public string? NETCoreSdkPortableRuntimeIdentifier { get; set; }
+        }
+
+        /// <summary>
+        /// A KnownCrossgen2Pack is selected by exact target framework version, so
+        /// TargetFrameworkVersion here has to stay in step with the pack's TargetFramework or the
+        /// task reports an unsupported target framework and the RID never gets looked at.
+        /// </summary>
+        [TestMethod]
+        [DataRow(true, false, true, "RequiresCrossgen2Pack alone acquires the pack")]
+        [DataRow(false, true, true, "PublishReadyToRun still acquires the pack")]
+        [DataRow(false, false, false, "neither asks for it, so it is not downloaded")]
+        public void It_acquires_the_Crossgen2_pack_for_a_build_that_needs_the_tool_without_ReadyToRun(
+            bool requiresCrossgen2Pack, bool readyToRunEnabled, bool expectDownloaded, string scenario)
+        {
+            var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App",
+                ToolsetInfo.CurrentTargetFramework, "11.0.0");
+
+            var crossgen2Pack = new MockTaskItem("Microsoft.NETCore.App.Crossgen2", new Dictionary<string, string>
+            {
+                ["TargetFramework"] = ToolsetInfo.CurrentTargetFramework,
+                ["Crossgen2PackNamePattern"] = "Microsoft.NETCore.App.Crossgen2.**RID**",
+                ["Crossgen2PackVersion"] = "11.0.0",
+                ["Crossgen2PortableRuntimeIdentifiers"] = "win-x64;linux-x64;osx-x64;osx-arm64",
+                ["Crossgen2RuntimeIdentifiers"] = "win-x64;linux-x64;osx-x64;osx-arm64"
+            });
+
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "11.0",
+                EnableRuntimePackDownload = true,
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                NETCoreSdkPortableRuntimeIdentifier = "win-x64",
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                RequiresCrossgen2Pack = requiresCrossgen2Pack,
+                ReadyToRunEnabled = readyToRunEnabled,
+                ReadyToRunUseCrossgen2 = true,
+                FrameworkReferences = new[] {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string> { ["IsImplicitlyDefined"] = "true" })
+                },
+                KnownFrameworkReferences = new[] { netCoreAppRef },
+                KnownCrossgen2Packs = new[] { crossgen2Pack }
+            };
+
+            var task = CreateTask(config);
+
+            task.Execute().Should().BeTrue(scenario);
+
+            var downloadedCrossgen2 = task.PackagesToDownload?
+                .Any(p => p.ItemSpec.Contains("Microsoft.NETCore.App.Crossgen2")) ?? false;
+
+            downloadedCrossgen2.Should().Be(expectDownloaded, scenario);
+        }
+
+        [TestMethod]
+        public void It_reports_the_unsupported_host_when_the_Crossgen2_pack_has_no_RID_for_it()
+        {
+            var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App",
+                ToolsetInfo.CurrentTargetFramework, "11.0.0");
+
+            // Supported everywhere except this build's host, so only the host lookup fails.
+            var crossgen2Pack = new MockTaskItem("Microsoft.NETCore.App.Crossgen2", new Dictionary<string, string>
+            {
+                ["TargetFramework"] = ToolsetInfo.CurrentTargetFramework,
+                ["Crossgen2PackNamePattern"] = "Microsoft.NETCore.App.Crossgen2.**RID**",
+                ["Crossgen2PackVersion"] = "11.0.0",
+                ["Crossgen2PortableRuntimeIdentifiers"] = "linux-x64",
+                ["Crossgen2RuntimeIdentifiers"] = "linux-x64"
+            });
+
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "11.0",
+                EnableRuntimePackDownload = true,
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                NETCoreSdkPortableRuntimeIdentifier = "win-x64",
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                RequiresCrossgen2Pack = true,
+                FrameworkReferences = new[] {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string> { ["IsImplicitlyDefined"] = "true" })
+                },
+                KnownFrameworkReferences = new[] { netCoreAppRef },
+                KnownCrossgen2Packs = new[] { crossgen2Pack }
+            };
+
+            var task = CreateTask(config);
+
+            task.Execute().Should().BeFalse("the build host has no crossgen2 pack");
+
+            var engine = (MockNeverCacheBuildEngine4)task.BuildEngine;
+            var error = engine.Errors.Should().ContainSingle().Subject;
+            error.Code.Should().Be("NETSDK1245");
+            error.Message.Should().Contain("win-x64", "the message names the host it could not find a pack for");
+        }
+
+        [TestMethod]
+        public void It_reports_the_unsupported_target_framework_when_no_Crossgen2_pack_matches()
+        {
+            var netCoreAppRef = CreateKnownFrameworkReference("Microsoft.NETCore.App",
+                ToolsetInfo.CurrentTargetFramework, "11.0.0");
+
+            // The only pack targets net9.0, so the version filter rejects it before any RID lookup.
+            var crossgen2Pack = new MockTaskItem("Microsoft.NETCore.App.Crossgen2", new Dictionary<string, string>
+            {
+                ["TargetFramework"] = "net9.0",
+                ["Crossgen2PackNamePattern"] = "Microsoft.NETCore.App.Crossgen2.**RID**",
+                ["Crossgen2PackVersion"] = "9.0.0",
+                ["Crossgen2PortableRuntimeIdentifiers"] = "win-x64;linux-x64;osx-x64;osx-arm64",
+                ["Crossgen2RuntimeIdentifiers"] = "win-x64;linux-x64;osx-x64;osx-arm64"
+            });
+
+            var config = new TaskConfiguration
+            {
+                TargetFrameworkVersion = "11.0",
+                EnableRuntimePackDownload = true,
+                NETCoreSdkRuntimeIdentifier = "win-x64",
+                NETCoreSdkPortableRuntimeIdentifier = "win-x64",
+                RuntimeGraphPath = CreateRuntimeGraphFile(MultiPlatformRuntimeGraph),
+                RequiresCrossgen2Pack = true,
+                FrameworkReferences = new[] {
+                    new MockTaskItem("Microsoft.NETCore.App", new Dictionary<string, string> { ["IsImplicitlyDefined"] = "true" })
+                },
+                KnownFrameworkReferences = new[] { netCoreAppRef },
+                KnownCrossgen2Packs = new[] { crossgen2Pack }
+            };
+
+            var task = CreateTask(config);
+
+            task.Execute().Should().BeFalse("no crossgen2 pack matches the target framework");
+
+            var engine = (MockNeverCacheBuildEngine4)task.BuildEngine;
+            engine.Errors.Should().ContainSingle()
+                .Which.Code.Should().Be("NETSDK1246");
         }
 
         [TestMethod]

--- a/test/Microsoft.NET.Build.Tasks.Tests/ProcessFrameworkReferencesTests.cs
+++ b/test/Microsoft.NET.Build.Tasks.Tests/ProcessFrameworkReferencesTests.cs
@@ -271,7 +271,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var config = new TaskConfiguration
             {
-                TargetFrameworkVersion = "11.0",
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
                 EnableRuntimePackDownload = true,
                 NETCoreSdkRuntimeIdentifier = "win-x64",
                 NETCoreSdkPortableRuntimeIdentifier = "win-x64",
@@ -314,7 +314,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var config = new TaskConfiguration
             {
-                TargetFrameworkVersion = "11.0",
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
                 EnableRuntimePackDownload = true,
                 NETCoreSdkRuntimeIdentifier = "win-x64",
                 NETCoreSdkPortableRuntimeIdentifier = "win-x64",
@@ -355,7 +355,7 @@ namespace Microsoft.NET.Build.Tasks.UnitTests
 
             var config = new TaskConfiguration
             {
-                TargetFrameworkVersion = "11.0",
+                TargetFrameworkVersion = ToolsetInfo.CurrentTargetFrameworkVersion,
                 EnableRuntimePackDownload = true,
                 NETCoreSdkRuntimeIdentifier = "win-x64",
                 NETCoreSdkPortableRuntimeIdentifier = "win-x64",


### PR DESCRIPTION
## Summary

dotnet/runtime#131877 (merged) gave crossgen2 a second job: alongside compiling ReadyToRun images, a `--generate-portable-callhelpers` mode that generates interop call helpers. A wasm CoreCLR build therefore runs crossgen2 with ReadyToRun not involved at all.

**Acquisition** is what blocks that today. `ProcessFrameworkReferences` requests the pack only under `ReadyToRunEnabled && ReadyToRunUseCrossgen2`, so with R2R off it is never restored. This adds `RequiresCrossgen2Pack` to request it on its own, without changing what a ReadyToRun build does.

`WebAssemblySdk` is acquired the same way a few lines below, so "a build needs a tool pack for its own reasons" is an established shape in this method.

**Discovery needs nothing.** An earlier revision of this PR also added a `ResolveCrossgen2ToolPath` target, on the belief that `ResolveReadyToRunCompilers` was reachable only through `CreateReadyToRunImages` at publish. @akoeplinger pointed out that a consumer can just depend on the existing target — and that is right. It reads `@(ResolvedCrossgen2Pack)` and `@(ResolvedRuntimePack)`, both outputs of `ResolveFrameworkReferences`, which is a build-time target. Measured against a stock 10.0.105 SDK during a plain `dotnet build`, no publish involved:

```
Crossgen2Tool = .../microsoft.netcore.app.crossgen2.osx-arm64/10.0.5/tools/crossgen2
TargetOS      = osx
TargetArch    = arm64
```

The item also carries the target OS and architecture, which the removed target did not compute. So that half is gone, and what is left here is acquisition alone.

## Consuming it

A consumer depends on `ResolveReadyToRunCompilers` and reads `@(Crossgen2Tool)`. Two things it has to condition around, both its own business rather than the SDK's:

- the target **errors** rather than reporting nothing when no pack was resolved — `NETSDK1094`, or `NETSDK1095` if the pack is present but unusable
- it derives the path as `<pack>/tools/crossgen2`, which a repo-local crossgen2 build does not match

So the call belongs behind a condition that skips it whenever the consumer already knows where the tool is.

## Motivation

The CoreCLR WebAssembly interop helpers encode struct sizes and argument lowering that cannot be derived from metadata alone, so a native relink has to run crossgen2 whether or not the app is ReadyToRun. dotnet/runtime#131877 arranges that by declaring the crossgen2 pack in the `wasm-tools` workload manifest, which @akoeplinger questioned in https://github.com/dotnet/runtime/pull/131877#discussion_r3916392624:

> Is there no other way so we can avoid pulling this in via the workload manifest? maybe we should teach the sdk to pull crossgen2 for cases where you need it (I know this means you'd need to get a new SDK first so we might have to go with this approach first....)

This is that change. Nothing sets `RequiresCrossgen2Pack` yet: #131877 has since merged on the workload route, so the runtime side keeps working today, and the workload entry stays until an SDK carrying this flows back into dotnet/runtime. Swapping the runtime targets over to `@(Crossgen2Tool)` and dropping the manifest entry is the follow-up.

Note that if ReadyToRun becomes the default for CoreCLR browser (dotnet/runtime#132466), the existing gate already downloads the pack at restore, since `ProcessFrameworkReferences` runs before `CollectPackageDownloads` for build as well as publish. `RequiresCrossgen2Pack` then covers the narrower case of a user who sets `PublishReadyToRun=false` and still needs their relink to work.

## Diagnostics

The ReadyToRun path keeps `NETSDK1094`, which tells the user to turn `PublishReadyToRun` off — no help to a build that asked for the tool itself. Following the `PublishAot` precedent in the same method, the new path reports whichever lookup failed:

- `NETSDK1245` — The crossgen2 pack is not available for the build host platform '{0}'.
- `NETSDK1246` — The crossgen2 pack is not available for the target framework.

These are the only two results `AddToolPack` can return for `Crossgen2`; the others belong to the `ILLink`/`ILCompiler` branches.

## Testing

Added to `ProcessFrameworkReferencesTests`:

- a theory covering `RequiresCrossgen2Pack` alone, `PublishReadyToRun` alone, and neither — verified to fail when the gate change is reverted
- one test per new diagnostic, asserting the code and the substituted host RID

`Microsoft.NET.Build.Tasks.Tests --filter ProcessFrameworkReferences` passes 44/44 locally. The end-to-end wasm scenario is not exercised, since nothing sets the new property yet.

> [!NOTE]
> This description was drafted with GitHub Copilot.
