### PR TITLE
[release/11.0.1xx] Aggregate and send build/tasks/msbuild-subclassed telemetry in MSBuildLogger

### DIFF
--- a/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
+++ b/src/Cli/dotnet/Commands/MSBuild/MSBuildLogger.cs
@@ -59,10 +59,11 @@ public sealed class MSBuildLogger : INodeLogger
     internal const string BuildcheckRunEventName = "buildcheck/run";
     internal const string BuildcheckRuleStatsEventName = "buildcheck/rule";
 
-    // These two events are aggregated and sent at the end of the build.
+    // These events are aggregated and sent at the end of the build.
     internal const string TaskFactoryTelemetryAggregatedEventName = "build/tasks/taskfactory";
     internal const string TasksTelemetryAggregatedEventName = "build/tasks";
     internal const string TasksDetailsTelemetryEventName = "build/tasks/details";
+    internal const string MSBuildTaskSubclassedTelemetryAggregatedEventName = "build/tasks/msbuild-subclassed";
 
     internal const string SdkTaskBaseCatchExceptionTelemetryEventName = "taskBaseCatchException";
     internal const string PublishPropertiesTelemetryEventName = "PublishProperties";
@@ -242,20 +243,20 @@ public sealed class MSBuildLogger : INodeLogger
     internal void SendAggregatedEventsOnBuildFinished(ITelemetryClient? telemetry)
     {
         if (telemetry is null) return;
-        if (_aggregatedEvents.TryGetValue(TaskFactoryTelemetryAggregatedEventName, out var taskFactoryData))
+
+        SendAggregatedEvent(telemetry, TaskFactoryTelemetryAggregatedEventName);
+        SendAggregatedEvent(telemetry, TasksTelemetryAggregatedEventName);
+        SendAggregatedEvent(telemetry, MSBuildTaskSubclassedTelemetryAggregatedEventName);
+    }
+
+    private void SendAggregatedEvent(ITelemetryClient telemetry, string eventName)
+    {
+        if (_aggregatedEvents.TryGetValue(eventName, out var eventData))
         {
-            Dictionary<string, string?> taskFactoryProperties = ConvertToStringDictionary(taskFactoryData);
+            Dictionary<string, string?> properties = ConvertToStringDictionary(eventData);
 
-            TrackEvent(telemetry, $"msbuild/{TaskFactoryTelemetryAggregatedEventName}", taskFactoryProperties, toBeHashed: []);
-            _aggregatedEvents.Remove(TaskFactoryTelemetryAggregatedEventName);
-        }
-
-        if (_aggregatedEvents.TryGetValue(TasksTelemetryAggregatedEventName, out var tasksData))
-        {
-            Dictionary<string, string?> tasksProperties = ConvertToStringDictionary(tasksData);
-
-            TrackEvent(telemetry, $"msbuild/{TasksTelemetryAggregatedEventName}", tasksProperties, toBeHashed: []);
-            _aggregatedEvents.Remove(TasksTelemetryAggregatedEventName);
+            TrackEvent(telemetry, $"msbuild/{eventName}", properties, toBeHashed: []);
+            _aggregatedEvents.Remove(eventName);
         }
     }
 
@@ -385,7 +386,9 @@ public sealed class MSBuildLogger : INodeLogger
 
     private void OnTelemetryLogged(object sender, TelemetryEventArgs args)
     {
-        if (args.EventName == TaskFactoryTelemetryAggregatedEventName || args.EventName == TasksTelemetryAggregatedEventName)
+        if (args.EventName == TaskFactoryTelemetryAggregatedEventName ||
+            args.EventName == TasksTelemetryAggregatedEventName ||
+            args.EventName == MSBuildTaskSubclassedTelemetryAggregatedEventName)
         {
             AggregateEvent(args);
         }

--- a/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
+++ b/test/dotnet.Tests/CommandTests/MSBuild/GivenMSBuildLogger.cs
@@ -167,14 +167,35 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
                 }
             };
 
+            var event5 = new TelemetryEventArgs
+            {
+                EventName = MSBuildLogger.MSBuildTaskSubclassedTelemetryAggregatedEventName,
+                Properties = new Dictionary<string, string>
+                {
+                    { "Microsoft_Build_Tasks_Copy", "2" },
+                    { "Microsoft_Build_Utilities_Task", "1" }
+                }
+            };
+
+            var event6 = new TelemetryEventArgs
+            {
+                EventName = MSBuildLogger.MSBuildTaskSubclassedTelemetryAggregatedEventName,
+                Properties = new Dictionary<string, string>
+                {
+                    { "Microsoft_Build_Tasks_Copy", "3" }
+                }
+            };
+
             logger.AggregateEvent(event1);
             logger.AggregateEvent(event2);
             logger.AggregateEvent(event3);
             logger.AggregateEvent(event4);
+            logger.AggregateEvent(event5);
+            logger.AggregateEvent(event6);
 
             logger.SendAggregatedEventsOnBuildFinished(fakeTelemetry);
 
-            fakeTelemetry.LogEntries.Should().HaveCount(2);
+            fakeTelemetry.LogEntries.Should().HaveCount(3);
 
             var taskFactoryEntry = fakeTelemetry.LogEntries.FirstOrDefault(e => e.EventName == $"msbuild/{MSBuildLogger.TaskFactoryTelemetryAggregatedEventName}");
             taskFactoryEntry.Should().NotBeNull();
@@ -186,6 +207,11 @@ namespace Microsoft.DotNet.Cli.MSBuild.Tests
             tasksEntry.Should().NotBeNull();
             tasksEntry.Properties["TasksExecutedCount"].Should().Be("8"); // 3 + 5
             tasksEntry.Properties["TaskHostTasksExecutedCount"].Should().Be("2"); // 2 + 0
+
+            var subclassedEntry = fakeTelemetry.LogEntries.FirstOrDefault(e => e.EventName == $"msbuild/{MSBuildLogger.MSBuildTaskSubclassedTelemetryAggregatedEventName}");
+            subclassedEntry.Should().NotBeNull();
+            subclassedEntry.Properties["Microsoft_Build_Tasks_Copy"].Should().Be("5"); // 2 + 3
+            subclassedEntry.Properties["Microsoft_Build_Utilities_Task"].Should().Be("1"); // 1 + 0
         }
 
         [TestMethod]


### PR DESCRIPTION
Backport of https://github.com/dotnet/sdk/pull/55054 to release/11.0.1xx