### PR TITLE
Increase SDL pipeline job timeout

### DIFF
--- a/.vsts-sdl.yml
+++ b/.vsts-sdl.yml
@@ -1,4 +1,4 @@
-# This yml is used by the dotnet-sdk-sdl-checks pipeline.
+# https://dev.azure.com/dnceng/internal/_build?definitionId=1675
 
 trigger: none
 

--- a/.vsts-sdl.yml
+++ b/.vsts-sdl.yml
@@ -75,6 +75,7 @@ extends:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
           runTests: false
+          timeoutInMinutes: 90
           populateInternalRuntimeVariables: true
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
           locBranch: release/10.0.3xx
@@ -104,6 +105,7 @@ extends:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
           runTests: false
+          timeoutInMinutes: 90
           populateInternalRuntimeVariables: true
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)
 
@@ -119,5 +121,6 @@ extends:
             templateFolderName: templates-official
             publishTaskPrefix: 1ES.
           runTests: false
+          timeoutInMinutes: 90
           populateInternalRuntimeVariables: true
           runtimeSourceProperties: /p:DotNetRuntimeSourceFeed=https://ci.dot.net/internal /p:DotNetRuntimeSourceFeedKey=$(dotnetbuilds-internal-container-read-token-base64)

--- a/eng/pipelines/templates/jobs/sdk-job-matrix.yml
+++ b/eng/pipelines/templates/jobs/sdk-job-matrix.yml
@@ -3,6 +3,7 @@ parameters:
     templateFolderName: templates
   locBranch: ''
   runTests: true
+  timeoutInMinutes: ''
   additionalWindowsJobParameterSets: []
   ### WINDOWS ###
   windowsJobParameterSets:


### PR DESCRIPTION
I made the pipeline in AzDo. 

But, https://dev.azure.com/dnceng/internal/_build?definitionId=1675&_a=summary was failing because the SDL checks take over 60 minutes to run so I had to increase the timeout. I cannot try to validate this completely on my own branch due to branch protections but I did confirm it passed checks with this change, shown by the most recent run.