### PR TITLE
Fix hosted webassembly hot reload

### DIFF
--- a/src/Dotnet.Watch/HotReloadClient/Web/StaticWebAssetUpdateBuilder.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/StaticWebAssetUpdateBuilder.cs
@@ -94,9 +94,19 @@ internal abstract class StaticWebAssetUpdateBuilder
 
                         if (!manifest.TryGetBundleFilePath(bundleFileName, out var bundleFilePath))
                         {
-                            // Shouldn't happen.
-                            applicationProjectLogger.Log(LogEvents.ScopedCssBundleFileNotFound, bundleFileName);
-                            continue;
+                            // A hosted Blazor WebAssembly client exposes its application bundle even though
+                            // it is referenced by the running server project.
+                            var applicationBundleFileName = StaticWebAsset.GetScopedCssBundleFileName(
+                                applicationProjectFilePath: containingProjectInstanceInfo.Id.ProjectPath,
+                                containingProjectFilePath: containingProjectInstanceInfo.Id.ProjectPath);
+
+                            if (!manifest.TryGetBundleFilePath(applicationBundleFileName, out bundleFilePath))
+                            {
+                                applicationProjectLogger.Log(LogEvents.ScopedCssBundleFileNotFound, bundleFileName);
+                                continue;
+                            }
+
+                            bundleFileName = applicationBundleFileName;
                         }
 
                         filePath = bundleFilePath;

--- a/test/Microsoft.DotNet.HotReload.Client.Tests/StaticWebAssetUpdateBuilderTests.cs
+++ b/test/Microsoft.DotNet.HotReload.Client.Tests/StaticWebAssetUpdateBuilderTests.cs
@@ -326,4 +326,66 @@ public class StaticWebAssetUpdateBuilderTests
         Assert.IsFalse(logger.HasWarning);
         Assert.IsFalse(logger.HasError);
     }
+
+    [TestMethod]
+    [DataRow("Client.styles.css")]
+    [DataRow("client/Client.styles.css")]
+    public void HostedWebAssemblyScopedCss(string bundleUrl)
+    {
+        var logger = new TestLogger(TestContext);
+        var builder = new TestUpdateBuilder(logger);
+        var bundlePath = Asset("Client", "obj", "scopedcss", "bundle", "Client.styles.css");
+
+        builder.AddProject("Server", running: true, hasScopedCssTargets: true, manifest: Manifest((bundleUrl, bundlePath)));
+        builder.AddProject("Client", running: false, hasScopedCssTargets: true);
+        builder.AddReference("Server", "Client");
+
+        builder.AddAssets(Asset("Client", "Pages", "Index.razor.css"), [ProjPath("Client")], staticWebAssetRelativeUrl: null);
+        builder.AddAssets(Asset("Client", "Pages", "Counter.razor.css"), [ProjPath("Client")], staticWebAssetRelativeUrl: null);
+
+        VerifyAssets(builder,
+            ("Server", [$"{bundlePath} | wwwroot/Client.styles.css | Client | app=False"]));
+        AssertRegenerate(builder, "Client", "Server");
+        Assert.IsFalse(logger.HasWarning);
+        Assert.IsFalse(logger.HasError);
+    }
+
+    [TestMethod]
+    public void ReferencedProjectPrefersProjectBundle()
+    {
+        var logger = new TestLogger(TestContext);
+        var builder = new TestUpdateBuilder(logger);
+        var bundlePath = Bundle("Server", "Client");
+
+        builder.AddProject("Server", running: true, hasScopedCssTargets: true, manifest: Manifest(
+            ("Client.bundle.scp.css", bundlePath),
+            ("Client.styles.css", Asset("Client", "obj", "Client.styles.css"))));
+        builder.AddProject("Client", running: false, hasScopedCssTargets: true);
+        builder.AddReference("Server", "Client");
+
+        builder.AddAssets(Asset("Client", "Pages", "Index.razor.css"), [ProjPath("Client")], staticWebAssetRelativeUrl: null);
+
+        VerifyAssets(builder,
+            ("Server", [$"{bundlePath} | wwwroot/Client.bundle.scp.css | Client | app=False"]));
+        AssertRegenerate(builder, "Client", "Server");
+        Assert.IsFalse(logger.HasWarning);
+        Assert.IsFalse(logger.HasError);
+    }
+
+    [TestMethod]
+    public void MissingScopedCssBundle()
+    {
+        var logger = new TestLogger(TestContext);
+        var builder = new TestUpdateBuilder(logger);
+
+        builder.AddProject("Server", running: true, hasScopedCssTargets: true, manifest: Manifest());
+        builder.AddProject("Client", running: false, hasScopedCssTargets: true);
+        builder.AddReference("Server", "Client");
+
+        builder.AddAssets(Asset("Client", "Pages", "Index.razor.css"), [ProjPath("Client")], staticWebAssetRelativeUrl: null);
+
+        VerifyAssets(builder);
+        AssertRegenerate(builder, "Client", "Server");
+        SequenceEqual(["[Warning] Scoped CSS bundle file 'Client.bundle.scp.css' not found."], logger.GetAndClearMessages());
+    }
 }

--- a/test/dotnet-watch.Tests/HotReload/RazorHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/RazorHotReloadTests.cs
@@ -127,6 +127,46 @@ public class RazorHotReloadTests : DotNetWatchTestBase
 
     [TestMethod]
     [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/53114
+    public async Task BlazorWasmHosted_ScopedCss()
+    {
+        var testAsset = TestAssets.CopyTestAsset("WatchBlazorWasmHosted")
+            .WithSource();
+
+        WriteAllText(Path.Combine(testAsset.Path, "blazorhosted", "Program.cs"), """
+            using Microsoft.AspNetCore.Builder;
+
+            var builder = WebApplication.CreateBuilder(args);
+            var app = builder.Build();
+            app.UseStaticFiles();
+            app.MapFallbackToFile("index.html");
+            app.Run();
+            """);
+
+        var scopedCssPath = Path.Combine(testAsset.Path, "blazorwasm", "Pages", "Index.razor.css");
+        WriteAllText(scopedCssPath, "h1 { color: red; }");
+
+        var port = TestOptions.GetTestPort();
+        App.Start(testAsset, ["--urls", "http://localhost:" + port], "blazorhosted", testFlags: TestFlags.MockBrowser);
+
+        await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
+        await App.WaitUntilOutputContains(MessageDescriptor.LaunchingBrowser.GetMessage($"http://localhost:{port}"));
+        App.Process.ClearOutput();
+
+        UpdateSourceFile(scopedCssPath, "h1 { color: blue; }");
+
+        await App.WaitUntilOutputContains(MessageDescriptor.StaticAssetsChangesApplied);
+        await App.WaitUntilOutputContains(MessageDescriptor.NoManagedCodeChangesToApply);
+        await App.WaitUntilOutputContains(MessageDescriptor.SendingStaticAssetUpdateRequest.GetMessage("wwwroot/blazorwasm.styles.css"));
+        App.AssertOutputDoesNotContain(MessageDescriptor.ScopedCssBundleFileNotFound);
+
+        using var client = new System.Net.Http.HttpClient();
+        var css = await client.GetStringAsync($"http://localhost:{port}/blazorwasm.styles.css", TestContext.CancellationToken);
+        Assert.Contains("color: blue;", css);
+        Assert.DoesNotContain("color: red;", css);
+    }
+
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.Linux)] // https://github.com/dotnet/sdk/issues/53114
     public async Task Razor_Component_ScopedCssAndStaticAssets()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchRazorWithDeps")


### PR DESCRIPTION
Reported the issue https://github.com/dotnet/sdk/issues/56147 for this problem but thought there might be a simple fix for it and this seems isolated enough.

Might be a better fix to change the assumption of how the client project has been run since there could be other similar issues around