### PR TITLE
Update MSTest templates to 4.4

### DIFF
--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-CSharp/Company.TestProject1.csproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.2.3">
+<Project Sdk="MSTest.Sdk/4.4.0">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net11.0</TargetFramework>
@@ -49,7 +49,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="4.2.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
 <!--#if (csharpFeature_ImplicitUsings)-->

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-FSharp/Company.TestProject1.fsproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-FSharp/Company.TestProject1.fsproj
@@ -1,5 +1,5 @@
 <!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.2.3">
+<Project Sdk="MSTest.Sdk/4.4.0">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net11.0</TargetFramework>
@@ -65,7 +65,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="4.2.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/MSTest-VisualBasic/Company.TestProject1.vbproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.2.3">
+<Project Sdk="MSTest.Sdk/4.4.0">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net11.0</TargetFramework>
@@ -45,7 +45,7 @@
 <!--#if (CoverageTool == "coverlet")-->
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
-    <PackageReference Include="MSTest" Version="4.2.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
 </Project>

--- a/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
+++ b/template_feed/Microsoft.DotNet.Common.ProjectTemplates.11.0/content/Playwright-MSTest-CSharp/Company.TestProject1.csproj
@@ -1,5 +1,5 @@
 ﻿<!--#if (UseMSTestSdk)-->
-<Project Sdk="MSTest.Sdk/4.2.3">
+<Project Sdk="MSTest.Sdk/4.4.0">
 
   <PropertyGroup>
     <TargetFramework Condition="'$(TargetFrameworkOverride)' == ''">net11.0</TargetFramework>
@@ -45,7 +45,7 @@
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
 <!--#endif-->
     <PackageReference Include="Microsoft.Playwright.MSTest.v4" Version="1.55.0" />
-    <PackageReference Include="MSTest" Version="4.2.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
 <!--#if (csharpFeature_ImplicitUsings)-->


### PR DESCRIPTION
Updates the MSTest project templates to reference MSTest.Sdk and MSTest 4.4.0 so newly created test projects use the current MSTest release.

The C#, Visual Basic, F#, and Playwright MSTest templates keep their SDK-style and package-reference paths aligned.