### PR TITLE
File-based apps: improve legacy artifact support

### DIFF
--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/VirtualProjectBuilder.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/VirtualProjectBuilder.cs
@@ -503,13 +503,13 @@ sealed class VirtualProjectBuilder
 
             lastProject = (projectFileText, project, projectRoot);
 
-            // Preserve the legacy artifacts behavior when the .NET SDK imported its artifacts props but selected no layout.
+            // Preserve the legacy artifacts behavior when the .NET SDK imported its artifacts props but does not support FileBasedAppArtifactsPath.
             // dotnet CLI has the latest SDK imported but other hosts like MSBuildWorkspace may not.
             if (_useLegacyArtifactsPath is null)
             {
-                var defaultArtifactsPathPropsImported = await project.GetPropertyValueAsync("_SupportsFileBasedAppArtifactsPath").ConfigureAwait(false);
+                var supportsFileBasedAppArtifactsPath = await project.GetPropertyValueAsync("_SupportsFileBasedAppArtifactsPath").ConfigureAwait(false);
 
-                _useLegacyArtifactsPath = !string.Equals(defaultArtifactsPathPropsImported, bool.TrueString, StringComparison.OrdinalIgnoreCase);
+                _useLegacyArtifactsPath = !string.Equals(supportsFileBasedAppArtifactsPath, bool.TrueString, StringComparison.OrdinalIgnoreCase);
 
                 if (_useLegacyArtifactsPath == true)
                 {

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/VirtualProjectBuilder.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/VirtualProjectBuilder.cs
@@ -507,12 +507,9 @@ sealed class VirtualProjectBuilder
             // dotnet CLI has the latest SDK imported but other hosts like MSBuildWorkspace may not.
             if (_useLegacyArtifactsPath is null)
             {
-                var defaultArtifactsPathPropsImported = await project.GetPropertyValueAsync("_DefaultArtifactsPathPropsImported").ConfigureAwait(false);
-                var artifactsPathLocationType = await project.GetPropertyValueAsync("_ArtifactsPathLocationType").ConfigureAwait(false);
+                var defaultArtifactsPathPropsImported = await project.GetPropertyValueAsync("_SupportsFileBasedAppArtifactsPath").ConfigureAwait(false);
 
-                _useLegacyArtifactsPath =
-                    string.Equals(defaultArtifactsPathPropsImported, bool.TrueString, StringComparison.OrdinalIgnoreCase) &&
-                    string.IsNullOrEmpty(artifactsPathLocationType);
+                _useLegacyArtifactsPath = !string.Equals(defaultArtifactsPathPropsImported, bool.TrueString, StringComparison.OrdinalIgnoreCase);
 
                 if (_useLegacyArtifactsPath == true)
                 {

--- a/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultArtifactsPath.props
+++ b/src/Tasks/Microsoft.NET.Build.Tasks/targets/Microsoft.NET.DefaultArtifactsPath.props
@@ -17,6 +17,7 @@ Copyright (c) .NET Foundation. All rights reserved.
        Set a property to indicate it was imported, so we can avoid a duplicate import. -->
   <PropertyGroup>
     <_DefaultArtifactsPathPropsImported>true</_DefaultArtifactsPathPropsImported>
+    <_SupportsFileBasedAppArtifactsPath>true</_SupportsFileBasedAppArtifactsPath>
   </PropertyGroup>
   
   <!-- Setting ArtifactsPath automatically opts in to the artifacts output format -->

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_CscOnlyAndApi.cs
@@ -1861,14 +1861,9 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
         (await result.Project.GetPropertyValueAsync("TargetFramework")).Should().Be(ToolsetInfo.CurrentTargetFramework);
     }
 
-    [TestMethod]
-    [DataRow(true, "", true)]
-    [DataRow(true, "FileBasedApp", false)]
-    [DataRow(false, "", false)]
+    [TestMethod, CombinatorialData]
     public async Task Api_VirtualProjectBuilder_ArtifactsPathCompatibility(
-        bool defaultArtifactsPathPropsImported,
-        string artifactsPathLocationType,
-        bool expectLegacyArtifactsPath)
+        bool supportsFileBasedAppArtifactsPath)
     {
         var testInstance = TestAssetsManager.CreateTestDirectory();
         var programPath = Path.Join(testInstance.Path, "Program.cs");
@@ -1887,14 +1882,13 @@ public sealed class RunFileTests_CscOnlyAndApi : RunFileTestBase
             VirtualProjectBuildingCommand.ThrowingReporter,
             additionalGlobalProperties: new Dictionary<string, string>
             {
-                ["_DefaultArtifactsPathPropsImported"] = defaultArtifactsPathPropsImported.ToString(),
-                ["_ArtifactsPathLocationType"] = artifactsPathLocationType,
+                ["_SupportsFileBasedAppArtifactsPath"] = supportsFileBasedAppArtifactsPath.ToString(),
             });
 
         var xml = result.ProjectRootElement.GetRawXml();
         Log.WriteLine(xml);
 
-        if (expectLegacyArtifactsPath)
+        if (!supportsFileBasedAppArtifactsPath)
         {
             xml.Should()
                 .Contain("<IncludeProjectNameInArtifactsPaths>false</IncludeProjectNameInArtifactsPaths>")


### PR DESCRIPTION
A better version of https://github.com/dotnet/sdk/pull/55970.
Should fix the issue reported in https://github.com/dotnet/vscode-csharp/pull/9734#issuecomment-5565499317.
See roslyn counterpart for more details: https://github.com/dotnet/roslyn/pull/85204