### PR TITLE
Use semantic checks and shared registration for CA1825

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidZeroLengthArrayAllocations.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.NetCore.Analyzers.Runtime;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
@@ -15,14 +13,5 @@ namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CSharpAvoidZeroLengthArrayAllocationsAnalyzer : AvoidZeroLengthArrayAllocationsAnalyzer
     {
-        protected override bool IsAttributeSyntax(SyntaxNode node)
-        {
-            return node is AttributeSyntax;
-        }
-
-        protected override bool IsCollectionExpressionSyntax(SyntaxNode node)
-        {
-            return node.IsKind(SyntaxKind.CollectionExpression);
-        }
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.CSharp.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/CSharpAvoidZeroLengthArrayAllocations.cs
@@ -2,15 +2,13 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.NetCore.Analyzers.Runtime;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.NetCore.CSharp.Analyzers.Runtime
 {
     /// <summary>
-    /// RS0007: Avoid zero-length array allocations.
+    /// Compatibility wrapper retained for callers that reference this type directly.
+    /// The shared <see cref="AvoidZeroLengthArrayAllocationsAnalyzer"/> is registered for C# and Visual Basic.
     /// </summary>
-    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class CSharpAvoidZeroLengthArrayAllocationsAnalyzer : AvoidZeroLengthArrayAllocationsAnalyzer
     {
     }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers.sarif.template
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers.sarif.template
@@ -245,25 +245,6 @@
             ]
           }
         },
-        "CA1825": {
-          "id": "CA1825",
-          "shortDescription": "Avoid zero-length array allocations",
-          "fullDescription": "Avoid unnecessary zero-length array allocations.  Use {0} instead.",
-          "defaultLevel": "note",
-          "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825",
-          "properties": {
-            "category": "Performance",
-            "isEnabledByDefault": true,
-            "typeName": "CSharpAvoidZeroLengthArrayAllocationsAnalyzer",
-            "languages": [
-              "C#"
-            ],
-            "tags": [
-              "Telemetry",
-              "EnabledRuleInAggressiveMode"
-            ]
-          }
-        },
         "CA1841": {
           "id": "CA1841",
           "shortDescription": "Prefer Dictionary.Contains methods",
@@ -2778,6 +2759,26 @@
             ],
             "tags": [
               "PortedFromFxCop",
+              "Telemetry",
+              "EnabledRuleInAggressiveMode"
+            ]
+          }
+        },
+        "CA1825": {
+          "id": "CA1825",
+          "shortDescription": "Avoid zero-length array allocations",
+          "fullDescription": "Avoid unnecessary zero-length array allocations.  Use {0} instead.",
+          "defaultLevel": "note",
+          "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825",
+          "properties": {
+            "category": "Performance",
+            "isEnabledByDefault": true,
+            "typeName": "AvoidZeroLengthArrayAllocationsAnalyzer",
+            "languages": [
+              "C#",
+              "Visual Basic"
+            ],
+            "tags": [
               "Telemetry",
               "EnabledRuleInAggressiveMode"
             ]
@@ -6896,25 +6897,6 @@
             ],
             "tags": [
               "PortedFromFxCop",
-              "Telemetry",
-              "EnabledRuleInAggressiveMode"
-            ]
-          }
-        },
-        "CA1825": {
-          "id": "CA1825",
-          "shortDescription": "Avoid zero-length array allocations",
-          "fullDescription": "Avoid unnecessary zero-length array allocations.  Use {0} instead.",
-          "defaultLevel": "note",
-          "helpUri": "https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1825",
-          "properties": {
-            "category": "Performance",
-            "isEnabledByDefault": true,
-            "typeName": "BasicAvoidZeroLengthArrayAllocationsAnalyzer",
-            "languages": [
-              "Visual Basic"
-            ],
-            "tags": [
               "Telemetry",
               "EnabledRuleInAggressiveMode"
             ]

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -15,9 +15,10 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
     /// <summary>
     /// CA1825: <inheritdoc cref="AvoidZeroLengthArrayAllocationsTitle"/>
-    /// Base type for an analyzer that looks for empty array allocations and recommends their replacement.
+    /// Analyzer that looks for empty array allocations and recommends their replacement.
     /// </summary>
-    public abstract class AvoidZeroLengthArrayAllocationsAnalyzer : DiagnosticAnalyzer
+    [DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+    public class AvoidZeroLengthArrayAllocationsAnalyzer : DiagnosticAnalyzer
     {
         internal const string RuleId = "CA1825";
 

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocations.cs
@@ -1,7 +1,6 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Analyzer.Utilities;
@@ -50,7 +49,7 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
 
             // When compilation begins, check whether Array.Empty<T> is available.
-            // Only if it is, register the syntax node action provided by the derived implementations.
+            // Only if it is, register the array-creation operation action.
             context.RegisterCompilationStartAction(context =>
             {
                 INamedTypeSymbol typeSymbol = context.Compilation.GetSpecialType(SpecialType.System_Array);
@@ -66,25 +65,12 @@ namespace Microsoft.NetCore.Analyzers.Runtime
             });
         }
 
-        private void AnalyzeOperation(OperationAnalysisContext context, IMethodSymbol arrayEmptyMethodSymbol, INamedTypeSymbol? linqExpressionType)
-        {
-            AnalyzeOperation(context, arrayEmptyMethodSymbol, linqExpressionType, IsAttributeSyntax, IsCollectionExpressionSyntax);
-        }
-
-        private static void AnalyzeOperation(OperationAnalysisContext context, IMethodSymbol arrayEmptyMethodSymbol, INamedTypeSymbol? linqExpressionType, Func<SyntaxNode, bool> isAttributeSyntax, Func<SyntaxNode, bool> isCollectionExpressionSyntax)
+        private static void AnalyzeOperation(OperationAnalysisContext context, IMethodSymbol arrayEmptyMethodSymbol, INamedTypeSymbol? linqExpressionType)
         {
             IArrayCreationOperation arrayCreationExpression = (IArrayCreationOperation)context.Operation;
 
-            // Bail out for compiler-generated array creations synthesized
-            // during lowering of collection expressions (e.g. `List<int> x = [1, 2, 3]`).
-            if (isCollectionExpressionSyntax(arrayCreationExpression.Syntax))
-            {
-                return;
-            }
-
             // We can't replace array allocations in attributes, as they're persisted to metadata
-            // TODO: Once we have operation walkers, we can replace this syntactic check with an operation-based check.
-            if (arrayCreationExpression.Syntax.AncestorsAndSelf().Any(isAttributeSyntax))
+            if (arrayCreationExpression.GetAncestor<IAttributeOperation>(OperationKind.Attribute) != null)
             {
                 return;
             }
@@ -100,9 +86,8 @@ namespace Microsoft.NetCore.Analyzers.Runtime
 
                 if (dimensionSize.HasConstantValue(0))
                 {
-                    // Workaround for https://github.com/dotnet/roslyn/issues/10214
-                    // Bail out for compiler generated params array creation.
-                    if (IsCompilerGeneratedParamsArray(arrayCreationExpression, context))
+                    // Compiler-supplied params arrays have no source array expression to replace.
+                    if (arrayCreationExpression.Parent is IArgumentOperation { ArgumentKind: ArgumentKind.ParamArray })
                     {
                         return;
                     }
@@ -124,85 +109,5 @@ namespace Microsoft.NetCore.Analyzers.Runtime
                 }
             }
         }
-
-        private static bool IsCompilerGeneratedParamsArray(IArrayCreationOperation arrayCreationExpression, OperationAnalysisContext context)
-        {
-            var model = arrayCreationExpression.SemanticModel!;
-
-            // Compiler generated array creation seems to just use the syntax from the parent.
-            var parent = model.GetOperation(arrayCreationExpression.Syntax, context.CancellationToken);
-            if (parent == null)
-            {
-                return false;
-            }
-
-            ISymbol? targetSymbol = null;
-            var arguments = ImmutableArray<IArgumentOperation>.Empty;
-            if (parent is IInvocationOperation invocation)
-            {
-                targetSymbol = invocation.TargetMethod;
-                arguments = invocation.Arguments;
-            }
-            else
-            {
-                if (parent is IObjectCreationOperation objectCreation)
-                {
-                    targetSymbol = objectCreation.Constructor;
-                    arguments = objectCreation.Arguments;
-                }
-                else if (parent is IPropertyReferenceOperation propertyReference)
-                {
-                    targetSymbol = propertyReference.Property;
-                    arguments = propertyReference.Arguments;
-                }
-            }
-
-            if (targetSymbol == null)
-            {
-                return false;
-            }
-
-            var parameters = targetSymbol.GetParameters();
-            if (parameters.IsEmpty || !parameters[^1].IsParams)
-            {
-                return false;
-            }
-
-            // At this point the array creation is known to be compiler synthesized as part of a call
-            // to a method with a params parameter, and so it is probably sound to return true at this point.
-            // As a sanity check, verify that the last argument to the call is equivalent to the array creation.
-            // (Comparing for object identity does not work because the semantic model can return a fresh operation tree.)
-            var lastArgument = arguments.LastOrDefault();
-            return lastArgument != null && lastArgument.Value.Syntax == arrayCreationExpression.Syntax && AreEquivalentZeroLengthArrayCreations(arrayCreationExpression, lastArgument.Value as IArrayCreationOperation);
-        }
-
-        private static bool AreEquivalentZeroLengthArrayCreations(IArrayCreationOperation? first, IArrayCreationOperation? second)
-        {
-            if (first == null || second == null)
-            {
-                return false;
-            }
-
-            ImmutableArray<IOperation> sizes = first.DimensionSizes;
-            if (sizes.Length != 1 || !sizes[0].HasConstantValue(0))
-            {
-                return false;
-            }
-
-            sizes = second.DimensionSizes;
-            if (sizes.Length != 1 || !sizes[0].HasConstantValue(0))
-            {
-                return false;
-            }
-
-            return first.Type?.Equals(second.Type) == true;
-        }
-
-        protected abstract bool IsAttributeSyntax(SyntaxNode node);
-
-        /// <summary>
-        /// Checks whether the given syntax node represents a collection expression (e.g. <c>[1, 2, 3]</c> in C#).
-        /// </summary>
-        protected abstract bool IsCollectionExpressionSyntax(SyntaxNode node);
     }
 }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/BasicAvoidZeroLengthArrayAllocationsAnalyzer.vb
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/BasicAvoidZeroLengthArrayAllocationsAnalyzer.vb
@@ -3,7 +3,6 @@
 Imports Microsoft.NetCore.Analyzers.Runtime
 Imports Microsoft.CodeAnalysis
 Imports Microsoft.CodeAnalysis.Diagnostics
-Imports Microsoft.CodeAnalysis.VisualBasic.Syntax
 
 Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
     ''' <summary>
@@ -12,13 +11,5 @@ Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
     <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public NotInheritable Class BasicAvoidZeroLengthArrayAllocationsAnalyzer
         Inherits AvoidZeroLengthArrayAllocationsAnalyzer
-
-        Protected Overrides Function IsAttributeSyntax(node As SyntaxNode) As Boolean
-            Return TypeOf node Is AttributeSyntax
-        End Function
-
-        Protected Overrides Function IsCollectionExpressionSyntax(node As SyntaxNode) As Boolean
-            Return False
-        End Function
     End Class
 End Namespace

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/BasicAvoidZeroLengthArrayAllocationsAnalyzer.vb
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers/Microsoft.NetCore.Analyzers/Runtime/BasicAvoidZeroLengthArrayAllocationsAnalyzer.vb
@@ -1,14 +1,12 @@
 ' Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 Imports Microsoft.NetCore.Analyzers.Runtime
-Imports Microsoft.CodeAnalysis
-Imports Microsoft.CodeAnalysis.Diagnostics
 
 Namespace Microsoft.NetCore.VisualBasic.Analyzers.Runtime
     ''' <summary>
-    ''' RS0007: Avoid zero-length array allocations.
+    ''' Compatibility wrapper retained for callers that reference this type directly.
+    ''' The shared <see cref="AvoidZeroLengthArrayAllocationsAnalyzer"/> is registered for C# and Visual Basic.
     ''' </summary>
-    <DiagnosticAnalyzer(LanguageNames.VisualBasic)>
     Public NotInheritable Class BasicAvoidZeroLengthArrayAllocationsAnalyzer
         Inherits AvoidZeroLengthArrayAllocationsAnalyzer
     End Class

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -6,10 +6,10 @@ using System.Reflection;
 using System.Threading.Tasks;
 using Test.Utilities;
 using VerifyCS = Test.Utilities.CSharpCodeFixVerifier<
-    Microsoft.NetCore.CSharp.Analyzers.Runtime.CSharpAvoidZeroLengthArrayAllocationsAnalyzer,
+    Microsoft.NetCore.Analyzers.Runtime.AvoidZeroLengthArrayAllocationsAnalyzer,
     Microsoft.NetCore.Analyzers.Runtime.AvoidZeroLengthArrayAllocationsFixer>;
 using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
-    Microsoft.NetCore.VisualBasic.Analyzers.Runtime.BasicAvoidZeroLengthArrayAllocationsAnalyzer,
+    Microsoft.NetCore.Analyzers.Runtime.AvoidZeroLengthArrayAllocationsAnalyzer,
     Microsoft.NetCore.Analyzers.Runtime.AvoidZeroLengthArrayAllocationsFixer>;
 
 namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Runtime/AvoidZeroLengthArrayAllocationsTests.cs
@@ -462,6 +462,48 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await VerifyCS.VerifyAnalyzerAsync(source);
         }
 
+        [TestMethod]
+        public async Task EmptyArrayCSharp_UsedInAttributeNamedArgument_NoDiagnosticsAsync()
+        {
+            const string source = """
+                using System;
+
+                [AttributeUsage(AttributeTargets.All)]
+                class CustomAttribute : Attribute
+                {
+                    public int[] Field;
+                    public int[] Property { get; set; }
+                }
+
+                [Custom(Field = new int[0], Property = new int[0])]
+                class C
+                {
+                }
+                """;
+            await VerifyCS.VerifyAnalyzerAsync(source);
+        }
+
+        [TestMethod]
+        public async Task EmptyArrayVisualBasic_UsedInAttributeNamedArgument_NoDiagnosticsAsync()
+        {
+            const string source = """
+                Imports System
+
+                <AttributeUsage(AttributeTargets.All)>
+                Class CustomAttribute
+                    Inherits Attribute
+
+                    Public Field As Integer()
+                    Public Property [Property] As Integer()
+                End Class
+
+                <Custom(Field:=New Integer(-1) {}, [Property]:=New Integer(-1) {})>
+                Class C
+                End Class
+                """;
+            await VerifyVB.VerifyAnalyzerAsync(source);
+        }
+
         [WorkItem(1298, "https://github.com/dotnet/roslyn-analyzers/issues/1298")]
         [TestMethod]
         public async Task EmptyArrayCSharp_FieldOrPropertyInitializerAsync()
@@ -774,6 +816,54 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
         }
 
         [TestMethod]
+        public async Task ExplicitZeroLengthArrayArgumentToParams_CSharpAsync()
+        {
+            const string source = """
+                class C
+                {
+                    public C(params int[] values)
+                    {
+                    }
+
+                    void Direct(params int[] values)
+                    {
+                    }
+
+                    void Object(params object[] values)
+                    {
+                    }
+
+                    void Jagged(params int[][] values)
+                    {
+                    }
+
+                    int this[params int[] values] => 0;
+
+                    void M()
+                    {
+                        Direct({|#0:new int[0]|});
+                        Object({|#1:new int[0]|});
+                        Jagged({|#2:new int[0]|});
+                        _ = new C({|#3:new int[0]|});
+                        _ = this[{|#4:new int[0]|}];
+                        int[] values = {|#5:{}|};
+                    }
+                }
+                """;
+
+            await VerifyCS.VerifyAnalyzerAsync(
+                source,
+#pragma warning disable RS0030 // Do not use banned APIs
+                VerifyCS.Diagnostic(AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor).WithLocation(0).WithArguments("Array.Empty<int>()"),
+                VerifyCS.Diagnostic(AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor).WithLocation(1).WithArguments("Array.Empty<int>()"),
+                VerifyCS.Diagnostic(AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor).WithLocation(2).WithArguments("Array.Empty<int>()"),
+                VerifyCS.Diagnostic(AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor).WithLocation(3).WithArguments("Array.Empty<int>()"),
+                VerifyCS.Diagnostic(AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor).WithLocation(4).WithArguments("Array.Empty<int>()"),
+                VerifyCS.Diagnostic(AvoidZeroLengthArrayAllocationsAnalyzer.UseArrayEmptyDescriptor).WithLocation(5).WithArguments("Array.Empty<int>()"));
+#pragma warning restore RS0030 // Do not use banned APIs
+        }
+
+        [TestMethod]
         [WorkItem(4665, "https://github.com/dotnet/roslyn-analyzers/issues/4665")]
         public async Task NoDiagnosticInExpressionTree_CSharpAsync()
         {
@@ -822,6 +912,82 @@ namespace Microsoft.NetCore.Analyzers.Runtime.UnitTests
             await new VerifyCS.Test
             {
                 LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.CSharp12,
+                TestCode = source,
+            }.RunAsync(CancellationToken.None);
+        }
+
+        [TestMethod]
+        [WorkItem(82484, "https://github.com/dotnet/roslyn/issues/82484")]
+        public async Task NoDiagnosticForCollectionExpression_ParamsArrayConstructor_CSharpAsync()
+        {
+            const string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+
+                class Collection : IEnumerable<int>
+                {
+                    public Collection(params int[] values)
+                    {
+                    }
+
+                    public void Add(int value)
+                    {
+                    }
+
+                    public IEnumerator<int> GetEnumerator()
+                    {
+                        yield break;
+                    }
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+
+                class C
+                {
+                    Collection first = [1, 2];
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
+                TestCode = source,
+            }.RunAsync(CancellationToken.None);
+        }
+
+        [TestMethod]
+        [WorkItem(82484, "https://github.com/dotnet/roslyn/issues/82484")]
+        public async Task NoDiagnosticForCollectionExpression_WithElement_ParamsArrayConstructor_CSharpAsync()
+        {
+            const string source = """
+                using System.Collections;
+                using System.Collections.Generic;
+
+                class Collection : IEnumerable<int>
+                {
+                    public Collection(params int[] values)
+                    {
+                    }
+
+                    public void Add(int value)
+                    {
+                    }
+
+                    public IEnumerator<int> GetEnumerator()
+                    {
+                        yield break;
+                    }
+
+                    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+                }
+
+                class C
+                {
+                    Collection collection = [with(), 1, 2];
+                }
+                """;
+            await new VerifyCS.Test
+            {
+                LanguageVersion = CodeAnalysis.CSharp.LanguageVersion.Preview,
                 TestCode = source,
             }.RunAsync(CancellationToken.None);
         }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/MiscellaneousAnalyzerTests.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/MiscellaneousAnalyzerTests.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Microsoft.CodeAnalysis.NetAnalyzers.UnitTests
@@ -59,6 +60,40 @@ namespace Microsoft.CodeAnalysis.NetAnalyzers.UnitTests
                         Debug.Assert(!isAbstractGlobalizationDiagnosticAnalyzer, $"Analyzer {analyzerType.Name} wasn't expected to inherit AbstractGlobalizationDiagnosticAnalyzer.");
                     }
                 }
+            }
+
+            static void AnalyzerFileReference_AnalyzerLoadFailed(object sender, AnalyzerLoadFailureEventArgs e)
+            => throw e.Exception ?? new NotSupportedException(e.Message);
+        }
+
+        [TestMethod]
+        public void CA1825IsDiscoveredExactlyOncePerLanguageFromShippedAssemblies()
+        {
+            var testsAssemblyPath = typeof(MiscellaneousAnalyzerTests).Assembly.Location;
+            var directory = Path.GetDirectoryName(testsAssemblyPath);
+            var assemblyNames = new[] { "Microsoft.CodeAnalysis.NetAnalyzers.dll", "Microsoft.CodeAnalysis.CSharp.NetAnalyzers.dll", "Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.dll" };
+            var analyzerFileReferences = new AnalyzerFileReference[assemblyNames.Length];
+
+            for (int i = 0; i < assemblyNames.Length; i++)
+            {
+                var path = Path.Combine(directory, assemblyNames[i]);
+                Assert.IsTrue(File.Exists(path), $"File {path} doesn't exist.");
+
+                var analyzerFileReference = new AnalyzerFileReference(path, AnalyzerAssemblyLoader.Instance);
+                analyzerFileReference.AnalyzerLoadFailed += AnalyzerFileReference_AnalyzerLoadFailed;
+                analyzerFileReferences[i] = analyzerFileReference;
+            }
+
+            foreach (var language in new[] { LanguageNames.CSharp, LanguageNames.VisualBasic })
+            {
+                var ca1825Analyzers = analyzerFileReferences
+                    .SelectMany(reference => reference.GetAnalyzers(language))
+                    .Where(analyzer => analyzer.SupportedDiagnostics.Any(descriptor => descriptor.Id == "CA1825"))
+                    .ToArray();
+
+                Assert.HasCount(1, ca1825Analyzers, $"Expected exactly one CA1825 analyzer for {language}.");
+                Assert.AreEqual("Microsoft.NetCore.Analyzers.Runtime.AvoidZeroLengthArrayAllocationsAnalyzer", ca1825Analyzers[0].GetType().FullName);
+                Assert.AreEqual("Microsoft.CodeAnalysis.NetAnalyzers", ca1825Analyzers[0].GetType().Assembly.GetName().Name);
             }
 
             static void AnalyzerFileReference_AnalyzerLoadFailed(object sender, AnalyzerLoadFailureEventArgs e)


### PR DESCRIPTION
Follow-up to #53521. @akhera99 @JoeRobich

Fixes one additional missing case: `[with(), ...]` can trigger CA1825 for the compiler-created params array passed to a collection constructor.

Following @333fred's [point that `IOperation` reflects semantics](https://github.com/dotnet/sdk/pull/53521#issuecomment-4239415098), the analyser now uses `ArgumentKind.ParamArray` and attribute operation ancestry directly. That removes the syntax-specific edge cases and the separate C# and VB checks. Any future syntax exposing those same semantic markers is handled without another special case.

Register the shared analyzer for C# and VB directly, removing the redundant language-specific analyzer classes.

Regression tests cover collection construction, explicit arrays that must still be diagnosed, attribute arguments, and exactly one discovered CA1825 analyzer per language.

Local validation on macOS arm64 with .NET 11: the new collection-construction regression failed before the fix. After merging current main, all 17,694 tests in the full `Microsoft.CodeAnalysis.NetAnalyzers.UnitTests` project passed, with 35 documented skips. Both collection-construction cases and analyzer discovery passed. The build had no warnings or errors.
