### PR TITLE
Fix template authoring verification outside test runners

### DIFF
--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.CLI/Microsoft.TemplateEngine.Authoring.CLI.csproj
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.CLI/Microsoft.TemplateEngine.Authoring.CLI.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="System.CommandLine" />
-    <PackageReference Include="Verify.XunitV3" />
+    <PackageReference Include="Verify" VersionOverride="28.12.0" />
     <PackageReference Include="Verify.DiffPlex" />
   </ItemGroup>
 

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.CLI/Program.cs
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.CLI/Program.cs
@@ -5,6 +5,7 @@ using System.CommandLine;
 using Microsoft.TemplateEngine.Authoring.CLI.Commands;
 using Microsoft.TemplateEngine.Authoring.CLI.Commands.Verify;
 using Microsoft.TemplateEngine.Authoring.TemplateVerifier;
+using VerifyTests;
 
 namespace Microsoft.TemplateEngine.Authoring.CLI
 {
@@ -13,11 +14,8 @@ namespace Microsoft.TemplateEngine.Authoring.CLI
         internal static Task<int> Main(string[] args)
         {
             // TemplateVerifier no longer ships with a built-in verifier, so the hosting application must
-            // supply one. Route snapshot directory verification through the xUnit (v3) Verify integration,
-            // which is the verifier this tool has always used.
-            VerificationEngine.DirectoryVerifier ??=
-                (path, include, pattern, options, settings, info, fileScrubber, sourceFile)
-                    => VerifyXunit.Verifier.VerifyDirectory(path, include, pattern, options, settings, info, fileScrubber, sourceFile);
+            // supply one. The CLI runs outside a test framework, so it supplies the Verify context directly.
+            VerificationEngine.DirectoryVerifier ??= VerifyDirectory;
 
             RootCommand rootCommand = new("dotnet-template-authoring");
             rootCommand.Subcommands.Add(new LocalizeCommand());
@@ -25,6 +23,37 @@ namespace Microsoft.TemplateEngine.Authoring.CLI
             rootCommand.Subcommands.Add(new ValidateCommand());
 
             return rootCommand.Parse(args, new() { EnablePosixBundling = false }).InvokeAsync();
+        }
+
+        private static SettingsTask VerifyDirectory(
+            string path,
+            Func<string, bool>? include,
+            string? pattern,
+            EnumerationOptions? options,
+            VerifySettings? settings,
+            object? info,
+            FileScrubber? fileScrubber,
+            string sourceFile)
+        {
+            return new(
+                settings,
+                async configuredSettings =>
+                {
+                    configuredSettings.UseUniqueDirectory();
+                    VerifierSettings.AssignTargetAssembly(typeof(Program).Assembly);
+
+                    string sourceDirectory = Path.GetDirectoryName(sourceFile)!;
+                    PathInfo pathInfo = new(sourceDirectory, nameof(Program), nameof(Main));
+                    using InnerVerifier verifier = new(
+                        sourceFile,
+                        configuredSettings,
+                        nameof(Program),
+                        nameof(Main),
+                        methodParameters: null,
+                        pathInfo);
+
+                    return await verifier.VerifyDirectory(path, include, pattern, options, info, fileScrubber).ConfigureAwait(false);
+                });
         }
     }
 }

--- a/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.Shared.props
+++ b/src/TemplateEngine/Tools/Microsoft.TemplateEngine.Authoring.TemplateVerifier/Microsoft.TemplateEngine.Authoring.TemplateVerifier.Shared.props
@@ -13,12 +13,12 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" />
     <PackageReference Include="Verify.DiffPlex" />
     <!-- Verify core is used directly (VerifySettings, SettingsTask, FileScrubber). It is intentionally NOT
-         centrally managed: the repo needs two different Verify versions side by side - 28.12.0 (pulled in via
-         Verify.XunitV3 by the Authoring.CLI/TemplateSearch toolchain) and 31.19.0 (pulled in via Verify.MSTest
-         by the test projects). A single CPM version can't satisfy both (it produces NU1109 downgrade errors),
-         so VersionOverride is used here to pin just this shipping project to 28.12.0. That matches the version
-         Authoring.CLI resolves transitively, so the two projects don't contribute different EmptyFiles versions
-         to the CLI's publish output, which would otherwise fail with NETSDK1152. -->
+         centrally managed: the repo needs two different Verify versions side by side - 28.12.0 (used by the
+         Authoring.CLI/TemplateSearch toolchain) and 31.19.0 (pulled in via Verify.MSTest by the test projects).
+         A single CPM version can't satisfy both (it produces NU1109 downgrade errors), so VersionOverride is
+         used here to pin just this shipping project to 28.12.0. That matches the version Authoring.CLI uses,
+         so the two projects don't contribute different EmptyFiles versions to the CLI's publish output, which
+         would otherwise fail with NETSDK1152. -->
     <PackageReference Include="Verify" VersionOverride="28.12.0" />
   </ItemGroup>
 

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/VerifyCommandTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests/VerifyCommandTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
         private ILogger Log => new TestContextLogger(TestContext);
 
         [TestMethod]
-        [Ignore("https://github.com/dotnet/sdk/issues/53889")]
         public void VerifyCommandFullDevLoop()
         {
             // dots issue https://github.com/VerifyTests/Verify/issues/658
@@ -121,7 +120,6 @@ namespace Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests
         }
 
         [TestMethod]
-        [Ignore("https://github.com/dotnet/sdk/issues/53889")]
         public void VerifyCommandFullDevLoopWithNotInstalledTemplate()
         {
             // dots issue https://github.com/VerifyTests/Verify/issues/658


### PR DESCRIPTION
🤖 This PR is part of the weekly test issue cleanup effort.

Fixes #53889.

The Template Authoring CLI was wiring directory verification through `Verify.XunitV3`, but the standalone CLI has no xUnit test context. Use Verify's framework-neutral `InnerVerifier` API with explicit path metadata instead, remove the xUnit adapter dependency, and re-enable the two CLI integration tests that covered the full verification loop.

## Validation

- `build.cmd`
- `scripts\RunTests.cs -- --project test\TemplateEngine\Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests\Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj --filter "FullyQualifiedName~VerifyCommandTests"`
- `scripts\RunTests.cs -- --project test\TemplateEngine\Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests\Microsoft.TemplateEngine.Authoring.CLI.IntegrationTests.csproj`