### PR TITLE
Avoid dependency injection for template host logging

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/CliTemplateEngineHost.cs
@@ -1,10 +1,9 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Edge;
 
@@ -26,18 +25,7 @@ namespace Microsoft.TemplateEngine.Cli
                   preferences,
                   builtIns,
                   fallbackHostNames,
-                  loggerFactory: Microsoft.Extensions.Logging.LoggerFactory.Create(builder =>
-                  {
-                      builder
-                          .SetMinimumLevel(logLevel)
-                          .AddConsole(config => config.FormatterName = nameof(CliConsoleFormatter));
-                      builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<ConsoleFormatter, CliConsoleFormatter>());
-                      builder.Services.Configure<ConsoleFormatterOptions>(config =>
-                      {
-                          config.IncludeScopes = true;
-                          config.TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff";
-                      });
-                  }))
+                  loggerFactory: CreateLoggerFactory(logLevel))
         {
             string workingPath = FileSystem.GetCurrentDirectory();
             IsCustomOutputPath = outputPath != null;
@@ -48,6 +36,37 @@ namespace Microsoft.TemplateEngine.Cli
 
         public bool IsCustomOutputPath { get; }
 
+        private static ILoggerFactory CreateLoggerFactory(LogLevel logLevel)
+        {
+            // Construct logging directly to avoid building a dependency injection container for every host.
+            ConsoleLoggerProvider provider = new(
+                new StaticOptionsMonitor<ConsoleLoggerOptions>(new()
+                {
+                    FormatterName = nameof(CliConsoleFormatter)
+                }),
+                [
+                    new CliConsoleFormatter(new StaticOptionsMonitor<ConsoleFormatterOptions>(new()
+                    {
+                        IncludeScopes = true,
+                        TimestampFormat = "yyyy-MM-dd HH:mm:ss.fff"
+                    }))
+                ]);
+
+            LoggerFactory loggerFactory = new([], new LoggerFilterOptions { MinLevel = logLevel });
+            loggerFactory.AddProvider(provider);
+            return loggerFactory;
+        }
+
+        private sealed class StaticOptionsMonitor<TOptions>(TOptions options)
+            : IOptionsMonitor<TOptions> where TOptions : new()
+        {
+            public TOptions CurrentValue => options;
+
+            public TOptions Get(string? name) => options;
+
+            public IDisposable? OnChange(Action<TOptions, string?> listener) => null;
+        }
+
         private bool GlobalJsonFileExistsInPath
         {
             get
@@ -57,7 +76,7 @@ namespace Microsoft.TemplateEngine.Cli
                 bool found;
                 do
                 {
-                    string checkPath = Path.Combine(workingPath, fileName);
+                    string checkPath = Path.Join(workingPath, fileName);
                     found = FileSystem.FileExists(checkPath);
                     if (!found)
                     {
@@ -69,7 +88,7 @@ namespace Microsoft.TemplateEngine.Cli
                         }
                     }
                 }
-                while (!found && (workingPath != null));
+                while (!found && (workingPath is not null));
 
                 return found;
             }

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/CliTemplateEngineHostTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/CliTemplateEngineHostTests.cs
@@ -1,0 +1,118 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Extensions.Logging;
+
+namespace Microsoft.TemplateEngine.Cli.UnitTests
+{
+    [TestClass]
+    [ResourceLock(WellKnownResources.Console)]
+    public class CliTemplateEngineHostTests
+    {
+        [TestMethod]
+        [DataRow(LogLevel.Trace)]
+        [DataRow(LogLevel.Debug)]
+        [DataRow(LogLevel.Information)]
+        [DataRow(LogLevel.Warning)]
+        [DataRow(LogLevel.Error)]
+        [DataRow(LogLevel.Critical)]
+        [DataRow(LogLevel.None)]
+        public void LoggerFactory_MinimumLevel_FiltersEverySeverity(LogLevel minimumLevel)
+        {
+            TextWriter originalOut = Console.Out;
+            TextWriter originalError = Console.Error;
+            using var outputWriter = new StringWriter();
+            using var errorWriter = new StringWriter();
+            LogLevel[] messageLevels = [LogLevel.Trace, LogLevel.Debug, LogLevel.Information, LogLevel.Warning, LogLevel.Error, LogLevel.Critical];
+
+            try
+            {
+                Console.SetOut(outputWriter);
+                Console.SetError(errorWriter);
+                using var host = CreateHost(minimumLevel);
+                foreach (LogLevel messageLevel in messageLevels)
+                {
+                    host.Logger.Log(messageLevel, "matrix-{Level}", messageLevel);
+                }
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalError);
+            }
+
+            Assert.IsEmpty(errorWriter.ToString());
+            string output = outputWriter.ToString();
+            foreach (LogLevel messageLevel in messageLevels)
+            {
+                Assert.AreEqual(
+                    minimumLevel != LogLevel.None && messageLevel >= minimumLevel,
+                    output.Contains($"matrix-{messageLevel}", StringComparison.Ordinal));
+            }
+        }
+
+        [TestMethod]
+        public void LoggerFactory_PreservesFilteringFormatterAndDrainOnDispose()
+        {
+            const int hostCount = 5;
+            TextWriter originalOut = Console.Out;
+            TextWriter originalError = Console.Error;
+            using var outputWriter = new StringWriter();
+            using var errorWriter = new StringWriter();
+
+            try
+            {
+                Console.SetOut(outputWriter);
+                Console.SetError(errorWriter);
+
+                using (var host = CreateHost(LogLevel.Warning))
+                {
+                    host.Logger.LogInformation("filtered information");
+                    host.Logger.LogWarning("visible warning");
+                }
+
+                for (int index = 0; index < hostCount; index++)
+                {
+                    using var host = CreateHost(LogLevel.Debug);
+                    using (host.Logger.BeginScope($"scope-{index}"))
+                    {
+                        host.Logger.LogDebug(new InvalidOperationException($"debug details {index}"), $"debug message {index}");
+                    }
+                    host.Logger.LogInformation($"information message {index}");
+                    host.Logger.LogWarning(new InvalidOperationException($"warning details {index}"), $"warning message {index}");
+                    host.Logger.LogError(new InvalidOperationException($"error details {index}"), $"error message {index}");
+                    host.Logger.LogInformation($"final queued message {index}");
+                }
+            }
+            finally
+            {
+                Console.SetOut(originalOut);
+                Console.SetError(originalError);
+            }
+
+            string output = outputWriter.ToString();
+            Assert.IsEmpty(errorWriter.ToString());
+            output.Should().NotContain("filtered information");
+            output.Should().Contain("Warning: visible warning");
+            for (int index = 0; index < hostCount; index++)
+            {
+                output.Should().Contain($"[Debug] [Template Engine] => [scope-{index}]: debug message {index}");
+                output.Should().Contain($"Details: System.InvalidOperationException: debug details {index}");
+                output.Should().Contain($"information message {index}");
+                output.Should().Contain($"Warning: warning message {index}");
+                output.Should().Contain($"Details: warning details {index}");
+                output.Should().Contain($"Error: error message {index}");
+                output.Should().Contain($"Details: error details {index}");
+                output.Should().Contain($"final queued message {index}");
+            }
+        }
+
+        private static CliTemplateEngineHost CreateHost(LogLevel logLevel)
+            => new(
+                "test-host",
+                "1.0.0",
+                [],
+                [],
+                logLevel: logLevel);
+    }
+}


### PR DESCRIPTION
## Summary

`CliTemplateEngineHost` currently builds a dependency injection container each time it creates its logger factory. Construct the existing console provider and formatter directly instead.

- Preserve the requested minimum log level, scopes, timestamp format, exception formatting, and console-provider defaults.
- Register the provider with `LoggerFactory.AddProvider` so disposing the host continues to own and drain the asynchronous console provider.
- Use fixed options monitors because this host has no configuration source capable of changing these options after construction.
- Add focused tests for every minimum log level, formatter behavior, scopes, exception output, repeated host lifetimes, and queued-output drain on disposal.

## Performance

The host constructor's sampled CPU cost fell from 15.15 ms to 4.44 ms per invocation, a reduction of 10.71 ms. A separate host construction/disposal allocation measurement fell from 93,191 to 9,801 bytes per host (89.5%).

Windows x64 Release ReadyToRun measurements used 15 alternating before/after pairs per command:

| Command | Before median | After median | Median paired improvement |
| --- | ---: | ---: | ---: |
| `dotnet new --help` | 151.21 ms | 137.23 ms | 9.23% |
| `dotnet new list` | 196.71 ms | 178.56 ms | 8.56% |
| `dotnet new console --help` | 188.56 ms | 176.99 ms | 5.47% |
| `dotnet new console --no-restore` | 248.86 ms | 238.03 ms | 5.32% |

Percentages are medians of paired changes rather than ratios of the separately reported arm medians.

## Testing

- `CliTemplateEngineHostTests`: 8 passed in Debug
- `CliTemplateEngineHostTests`: 8 passed in Release
- Focused `dotnet-new.IntegrationTests` list/help/create slice: 6 passed in Release
- `build.cmd -c Release`