### PR TITLE
Use retry orchestrator handshake in dotnet test

### DIFF
--- a/eng/vendored-files.json
+++ b/eng/vendored-files.json
@@ -21,14 +21,14 @@
     {
       "id": "dotnet-test-wire-contract-constants",
       "local_path": "src/Cli/dotnet/Commands/Test/CliConstants.cs",
-      "notes": "Handshake/session/state string constants for the 'dotnet test' named-pipe protocol. Upstream lives in testfx IPC/Constants.cs; the SDK inlines the same constants into CliConstants.cs (TestStates, SessionEventTypes, HandshakeMessagePropertyNames, HandshakeMessageExecutionModes, HandshakeMessageHostTypes, ProtocolConstants). Watch the upstream file for added/changed wire constants. Reconciled at f935d2d3: the upstream additions since the previous baseline (SupportedPostProcessorKinds/SupportedPostProcessorExtensionsLegacy, the ArtifactPostProcessor host type and the 'tool' execution mode) are already mirrored in CliConstants.cs, so this was a baseline bump only. Intentional divergences: the SDK does not mirror TestStates.InProgress or HandshakeMessagePropertyNames.OrchestratorFeature (it consumes neither), and ProtocolConstants.SupportedVersions deliberately stops at 1.3.0 because the SDK does not implement the 1.4.0 reverse server-control channel.",
+      "notes": "Handshake/session/state string constants for the 'dotnet test' named-pipe protocol. Upstream lives in testfx IPC/Constants.cs; the SDK inlines the same constants into CliConstants.cs (TestStates, SessionEventTypes, HandshakeMessagePropertyNames, HandshakeMessageExecutionModes, HandshakeMessageHostTypes, ProtocolConstants). Watch the upstream file for added/changed wire constants. Reconciled at 868da4b6: the SDK mirrors the ArtifactPostProcessor and TestHostOrchestrator host types, the OrchestratorFeature property, and the 'tool' execution mode. The SDK consumes the retry orchestrator feature to enable retry UX before the first TestHost handshake. Intentional divergences: the SDK does not mirror TestStates.InProgress, and ProtocolConstants.SupportedVersions deliberately stops at 1.3.0 because the SDK does not implement the 1.4.0 reverse server-control channel.",
       "sources": [
         {
           "repo": "microsoft/testfx",
           "ref": "main",
           "path": "src/Platform/Microsoft.Testing.Platform/ServerMode/DotnetTest/IPC/Constants.cs",
-          "baseline_ref_sha": "f935d2d3f9ce1ab831a361041b0ceaf92ff73363",
-          "baseline_blob_sha": "8e11c4ba1b8472a4d28178f28ef088c0c0948580",
+          "baseline_ref_sha": "868da4b6752d5818d8f1c2c54ae27ee5b5f61852",
+          "baseline_blob_sha": "54dff700b3f69da76605d4707b60ba7c67d21d20",
           "scope": "wire constants (TestStates, SessionEventTypes, HandshakeMessage*, ProtocolConstants)"
         }
       ]

--- a/src/Cli/dotnet/Commands/Test/CliConstants.cs
+++ b/src/Cli/dotnet/Commands/Test/CliConstants.cs
@@ -85,6 +85,11 @@ internal static class HandshakeMessagePropertyNames
     // it, in which case the SDK falls back to its previous (no-validation) behavior.
     internal const byte ExecutionMode = 10;
 
+    // Identifies the extension responsible for a test-host orchestrator. Optional and
+    // additive so older consumers can ignore it and newer consumers can recognize known
+    // orchestrators without rejecting unknown ones.
+    internal const byte OrchestratorFeature = 11;
+
     // Reply-only capability that tells Microsoft.Testing.Platform where to open
     // the reverse channel used for server-initiated session cancellation.
     internal const byte ServerControlPipeName = 12;
@@ -120,6 +125,7 @@ internal static class HandshakeMessageExecutionModes
 internal static class HandshakeMessageHostTypes
 {
     internal const string TestHost = "TestHost";
+    internal const string TestHostOrchestrator = "TestHostOrchestrator";
     internal const string ArtifactPostProcessor = "ArtifactPostProcessor";
 }
 

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -661,11 +661,16 @@ internal partial class MicrosoftTestingPlatformTestCommand
         // a second press can force-kill running test app child processes and exit with
         // ExitCode.TestSessionAborted (see issue https://github.com/dotnet/sdk/issues/50732).
 
-        // Retry-specific rendering is enabled by the retry orchestrator handshake. Older platform
-        // versions that do not send it still fall back to instance-based inference from attempt 2.
-        output.TestExecutionStarted(DateTimeOffset.Now, degreeOfParallelism, testOptions.IsDiscovery, testOptions.IsHelp, isRetry: false);
+        // Retry-specific rendering is enabled authoritatively by the retry orchestrator handshake.
+        // Keep the raw option check only for older platform versions that support retries but do not
+        // send that handshake, so they can still label attempt 1.
+        bool isRetry = IsLegacyRetryOptionEnabled(parseResult.GetArguments());
+        output.TestExecutionStarted(DateTimeOffset.Now, degreeOfParallelism, testOptions.IsDiscovery, testOptions.IsHelp, isRetry);
         return output;
     }
+
+    internal static bool IsLegacyRetryOptionEnabled(IReadOnlyList<string> arguments)
+        => arguments.Contains("--retry-failed-tests");
 
     /// <summary>
     /// Reads the Microsoft.Testing.Platform <c>--show-slowest-tests N</c> option out of the raw command line.

--- a/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MicrosoftTestingPlatformTestCommand.cs
@@ -661,10 +661,9 @@ internal partial class MicrosoftTestingPlatformTestCommand
         // a second press can force-kill running test app child processes and exit with
         // ExitCode.TestSessionAborted (see issue https://github.com/dotnet/sdk/issues/50732).
 
-        // This is ugly, and we need to replace it by passing out some info from testing platform to inform us that some process level retry plugin is active.
-        var isRetry = parseResult.GetArguments().Contains("--retry-failed-tests");
-
-        output.TestExecutionStarted(DateTimeOffset.Now, degreeOfParallelism, testOptions.IsDiscovery, testOptions.IsHelp, isRetry);
+        // Retry-specific rendering is enabled by the retry orchestrator handshake. Older platform
+        // versions that do not send it still fall back to instance-based inference from attempt 2.
+        output.TestExecutionStarted(DateTimeOffset.Now, degreeOfParallelism, testOptions.IsDiscovery, testOptions.IsHelp, isRetry: false);
         return output;
     }
 
@@ -675,8 +674,8 @@ internal partial class MicrosoftTestingPlatformTestCommand
     /// The option belongs to the test application, not to the 'dotnet test' CLI, so it is forwarded verbatim. Under
     /// the pipe protocol the test host's own terminal reporter is not plugged in (the SDK owns user-facing output),
     /// so the section has to be rendered by the SDK's reporter instead — which means the SDK has to observe the
-    /// option. Same approach as the '--retry-failed-tests' detection above. A missing, non-numeric or non-positive
-    /// argument leaves the section off, mirroring the upstream option validator.
+    /// option. A missing, non-numeric or non-positive argument leaves the section off, mirroring the upstream
+    /// option validator.
     /// </remarks>
     internal static int GetSlowestTestsCount(IReadOnlyList<string> arguments)
     {

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -154,9 +154,9 @@ internal sealed partial class TerminalTestReporter : IDisposable
 
         int currentAttemptNumber = assemblyRun.GetAttemptNumber(instanceId);
 
-        // If we fail to parse out the parameter correctly this will enable retry on re-run of the assembly within the same execution.
-        // Not good enough for general use, because we want to show (try 1) even on the first try, but this will at
-        // least show (try 2) etc. So user is still aware there is retry going on, and counts of tests won't break.
+        // If no retry orchestrator handshake or legacy option signal was available, infer retry
+        // from a later assembly instance. This cannot label attempt 1, but it still labels attempt 2
+        // and later while preserving retry accounting.
         if (assemblyRun.TryCount > 1)
         {
             EnableRetry();

--- a/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/Terminal/TerminalTestReporter.cs
@@ -61,7 +61,7 @@ internal sealed partial class TerminalTestReporter : IDisposable
     private readonly uint? _originalConsoleMode;
     private bool _isDiscovery;
     private bool _isHelp;
-    private bool _isRetry;
+    private volatile bool _isRetry;
     private DateTimeOffset? _testExecutionStartTime;
 
     private DateTimeOffset? _testExecutionEndTime;
@@ -127,6 +127,13 @@ internal sealed partial class TerminalTestReporter : IDisposable
         _terminalWithProgress.StartShowingProgress(workerCount);
     }
 
+    /// <summary>
+    /// Enables retry-specific rendering for the current execution. This is a monotonic transition
+    /// because orchestrator and test-host handshakes can arrive on different connections.
+    /// </summary>
+    internal void EnableRetry()
+        => _isRetry = true;
+
     public void AssemblyRunStarted(string assembly, string? targetFramework, string? architecture, string executionId, string instanceId)
         => AssemblyRunStarted(assembly, targetFramework, architecture, executionId, instanceId, attemptNumber: null);
 
@@ -150,7 +157,10 @@ internal sealed partial class TerminalTestReporter : IDisposable
         // If we fail to parse out the parameter correctly this will enable retry on re-run of the assembly within the same execution.
         // Not good enough for general use, because we want to show (try 1) even on the first try, but this will at
         // least show (try 2) etc. So user is still aware there is retry going on, and counts of tests won't break.
-        _isRetry |= assemblyRun.TryCount > 1;
+        if (assemblyRun.TryCount > 1)
+        {
+            EnableRetry();
+        }
 
         if (_options.ShowAssembly && _options.ShowAssemblyStartAndComplete)
         {

--- a/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/TestApplicationHandler.cs
@@ -8,6 +8,8 @@ namespace Microsoft.DotNet.Cli.Commands.Test;
 
 internal sealed class TestApplicationHandler
 {
+    private const string RetryOrchestratorFeature = "RetryOrchestrator";
+
     private readonly TerminalTestReporter _output;
     private readonly TestModule _module;
     private readonly TestOptions _options;
@@ -143,6 +145,17 @@ internal sealed class TestApplicationHandler
             return false;
         }
 
+        // Orchestrators are capability-style participants: recognize the retry orchestrator,
+        // but accept missing or unknown feature values so older and future peers remain compatible.
+        // This handshake arrives before the first child TestHost handshake, which lets the reporter
+        // render attempt 1 as a retry attempt without relying on command-line inspection.
+        if (hostType == HandshakeMessageHostTypes.TestHostOrchestrator &&
+            handshakeMessage.Properties.TryGetValue(HandshakeMessagePropertyNames.OrchestratorFeature, out string? orchestratorFeature) &&
+            string.Equals(orchestratorFeature, RetryOrchestratorFeature, StringComparison.Ordinal))
+        {
+            _output.EnableRetry();
+        }
+
         if (!_options.IsArtifactPostProcessing)
         {
             _artifactPostProcessingManager?.RecordCapabilities(
@@ -239,6 +252,7 @@ internal sealed class TestApplicationHandler
             HandshakeMessagePropertyNames.InstanceId => nameof(HandshakeMessagePropertyNames.InstanceId),
             HandshakeMessagePropertyNames.IsIDE => nameof(HandshakeMessagePropertyNames.IsIDE),
             HandshakeMessagePropertyNames.ExecutionMode => nameof(HandshakeMessagePropertyNames.ExecutionMode),
+            HandshakeMessagePropertyNames.OrchestratorFeature => nameof(HandshakeMessagePropertyNames.OrchestratorFeature),
             HandshakeMessagePropertyNames.AttemptNumber => nameof(HandshakeMessagePropertyNames.AttemptNumber),
             HandshakeMessagePropertyNames.SupportedPostProcessorKinds => nameof(HandshakeMessagePropertyNames.SupportedPostProcessorKinds),
             HandshakeMessagePropertyNames.SupportedPostProcessorExtensionsLegacy => nameof(HandshakeMessagePropertyNames.SupportedPostProcessorExtensionsLegacy),

--- a/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
@@ -318,6 +318,32 @@ public class TerminalTestReporterTests
         assemblyLine.Should().Contain("[+1/x0/?0/r1]");
     }
 
+    [TestMethod]
+    public void EnableRetry_BeforeFirstAssemblyRun_RendersTryOne()
+    {
+        var capturingConsole = new CapturingConsole();
+
+        using var reporter = new TerminalTestReporter(capturingConsole, new TerminalTestReporterOptions
+        {
+            AnsiMode = AnsiMode.SimpleAnsi,
+            ShowProgress = false,
+            ShowAssembly = true,
+            ShowAssemblyStartAndComplete = true,
+        });
+
+        reporter.TestExecutionStarted(DateTimeOffset.UtcNow, workerCount: 1, isDiscovery: false, isHelp: false, isRetry: false);
+        reporter.EnableRetry();
+        reporter.AssemblyRunStarted(
+            "/repo/bin/Debug/net9.0/Retry.Tests.dll",
+            targetFramework: "net9.0",
+            architecture: "x64",
+            executionId: "exec-retry",
+            instanceId: "inst-1",
+            attemptNumber: 1);
+
+        StripAnsi(capturingConsole.GetOutput()).Should().Contain("(try 1) Running tests from");
+    }
+
     /// <summary>
     /// Output that fits within the summary budget must be echoed verbatim (no truncation marker).
     /// </summary>

--- a/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TerminalTestReporterTests.cs
@@ -789,6 +789,13 @@ public class TerminalTestReporterTests
     public void GetShowFlakyTests_ParsesForwardedOption(string[] arguments, bool expected)
         => MicrosoftTestingPlatformTestCommand.GetShowFlakyTests(arguments).Should().Be(expected);
 
+    [TestMethod]
+    [DataRow(new string[0], false)]
+    [DataRow(new[] { "--retry-failed-tests", "3" }, true)]
+    [DataRow(new[] { "test", "--", "--retry-failed-tests", "3" }, true)]
+    public void IsLegacyRetryOptionEnabled_ParsesForwardedOption(string[] arguments, bool expected)
+        => MicrosoftTestingPlatformTestCommand.IsLegacyRetryOptionEnabled(arguments).Should().Be(expected);
+
     /// <summary>
     /// Finds the per-assembly summary line for the given assembly. Multiple lines may mention the
     /// assembly (e.g. the "Running tests from ..." banner and the summary line). The summary line

--- a/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
+++ b/test/dotnet.Tests/CommandTests/Test/TestApplicationHandlerTests.cs
@@ -158,6 +158,58 @@ public class TestApplicationHandlerTests : IDisposable
     }
 
     [TestMethod]
+    public void OnHandshakeReceived_WithRetryOrchestrator_EnablesRetryBeforeFirstTestHost()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(
+            isHelp: false,
+            isDiscovery: false,
+            showAssembly: true);
+
+        bool orchestratorAccepted = handler.OnHandshakeReceived(
+            BuildHandshake(
+                executionMode: HandshakeMessageExecutionModes.Run,
+                hostType: HandshakeMessageHostTypes.TestHostOrchestrator,
+                orchestratorFeature: "RetryOrchestrator"),
+            gotSupportedVersion: true);
+        bool testHostAccepted = handler.OnHandshakeReceived(
+            BuildHandshake(
+                executionMode: HandshakeMessageExecutionModes.Run,
+                attemptNumber: 1),
+            gotSupportedVersion: true);
+
+        orchestratorAccepted.Should().BeTrue();
+        testHostAccepted.Should().BeTrue();
+        reporter.HasHandshakeFailure.Should().BeFalse();
+        console.GetOutput().Should().Contain("(try 1)");
+    }
+
+    [TestMethod]
+    public void OnHandshakeReceived_WithUnknownOrchestrator_AcceptsWithoutEnablingRetry()
+    {
+        (TestApplicationHandler handler, TerminalTestReporter reporter, CapturingConsole console) = CreateHandler(
+            isHelp: false,
+            isDiscovery: false,
+            showAssembly: true);
+
+        bool orchestratorAccepted = handler.OnHandshakeReceived(
+            BuildHandshake(
+                executionMode: HandshakeMessageExecutionModes.Run,
+                hostType: HandshakeMessageHostTypes.TestHostOrchestrator,
+                orchestratorFeature: "FutureOrchestrator"),
+            gotSupportedVersion: true);
+        bool testHostAccepted = handler.OnHandshakeReceived(
+            BuildHandshake(
+                executionMode: HandshakeMessageExecutionModes.Run,
+                attemptNumber: 1),
+            gotSupportedVersion: true);
+
+        orchestratorAccepted.Should().BeTrue();
+        testHostAccepted.Should().BeTrue();
+        reporter.HasHandshakeFailure.Should().BeFalse();
+        console.GetOutput().Should().NotContain("(try 1)");
+    }
+
+    [TestMethod]
     public void OnHandshakeReceived_WithArtifactPostProcessingCapabilities_RecordsApplication()
     {
         var manager = new ArtifactPostProcessingManager();
@@ -577,6 +629,7 @@ public class TestApplicationHandlerTests : IDisposable
         string hostType = "TestHost",
         bool includeInstanceId = true,
         int? attemptNumber = null,
+        string? orchestratorFeature = null,
         string? supportedPostProcessorKinds = null,
         string? supportedPostProcessorExtensions = null,
         string? supportedTruncatedRunPostProcessorKinds = null,
@@ -607,6 +660,11 @@ public class TestApplicationHandlerTests : IDisposable
         if (attemptNumber.HasValue)
         {
             properties[HandshakeMessagePropertyNames.AttemptNumber] = attemptNumber.Value.ToString(CultureInfo.InvariantCulture);
+        }
+
+        if (orchestratorFeature is not null)
+        {
+            properties[HandshakeMessagePropertyNames.OrchestratorFeature] = orchestratorFeature;
         }
 
         if (supportedPostProcessorKinds is not null)


### PR DESCRIPTION
`dotnet test` currently enables retry-specific terminal output by inspecting the forwarded `--retry-failed-tests` argument. Newer Microsoft.Testing.Platform versions now identify the retry orchestrator through the handshake before launching the first test host, so the SDK can use the protocol signal instead of depending primarily on raw command-line parsing.

This change:

- mirrors the `OrchestratorFeature` property and `TestHostOrchestrator` host type from the shared protocol constants;
- recognizes `RetryOrchestrator` handshakes and enables retry rendering before attempt 1 starts;
- accepts missing and unknown orchestrator features for backward and forward compatibility;
- retains a clearly named command-line fallback for older supported MTP packages that do not send the orchestrator handshake;
- adds focused handler, reporter, and fallback parsing coverage and updates the vendored-source divergence note.

The protocol handshake is authoritative when available. The legacy fallback remains intentionally because older MTP packages can support `--retry-failed-tests` without advertising the orchestrator capability.

Related: microsoft/testfx#5361