### PR TITLE
[release/11.0.1xx] Fix dotnet test device discovery for multi-targeted projects

### DIFF
--- a/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/MSBuildUtility.cs
@@ -89,10 +89,17 @@ internal static class MSBuildUtility
 
         // Pre-build device selection: evaluate the project to select devices BEFORE building,
         // so that device-provided RuntimeIdentifiers are included in the build.
-        var deviceSelection = SolutionAndProjectUtility.SelectDevicesBeforeBuild(
+        var deviceEvaluation = SolutionAndProjectUtility.EvaluateProjectForDeviceSelection(
             projectFilePath,
             buildOptions,
             buildSession);
+        var deviceSelection = deviceEvaluation is not null
+            ? SolutionAndProjectUtility.SelectDevicesBeforeBuild(
+                projectFilePath,
+                buildOptions,
+                buildSession,
+                deviceEvaluation)
+            : null;
 
         if (deviceSelection is not null)
         {
@@ -162,6 +169,8 @@ internal static class MSBuildUtility
 
             var perTfmBuildOptions = buildOptions with
             {
+                HasNoRestore = buildOptions.HasNoRestore ||
+                    (deviceSelection.RestoreWasPerformed && string.IsNullOrEmpty(rid)),
                 MSBuildArgs = perTfmArgs,
                 Device = device,
             };
@@ -423,18 +432,86 @@ internal static class MSBuildUtility
         MSBuildSession buildSession)
     {
         var allProjects = new ConcurrentBag<ParallelizableTestModuleGroupWithSequentialInnerModules>();
-        var nonDeviceProjects = new List<(string ProjectFilePath, string? Configuration, string? Platform)>();
+        var solutionProjects = projects.ToArray();
+        var deviceProjects = new (
+            string ProjectFilePath,
+            string? Configuration,
+            string? Platform,
+            SolutionAndProjectUtility.DeviceSelectionEvaluation Evaluation)?[solutionProjects.Length];
+        var gracefulExceptions = new ConcurrentQueue<GracefulException>();
 
-        // Phase 1: Handle device projects sequentially. Per-TFM builds use in-process MSBuild
-        // (BuildManager.DefaultBuildManager), which is a process-wide singleton and cannot run concurrently.
-        // The shared session may stay open across them, because it owns a build manager of its own.
-        foreach (var project in projects)
+        // Phase 1: Evaluate projects in parallel. Non-device projects are processed immediately
+        // using the same instances, while device projects are retained for the sequential phase.
+        Parallel.For(
+            fromInclusive: 0,
+            toExclusive: solutionProjects.Length,
+            new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
+            index =>
+            {
+                var project = solutionProjects[index];
+                try
+                {
+                    var evaluation = SolutionAndProjectUtility.EvaluateProjectForDeviceSelection(
+                        project.ProjectFilePath,
+                        buildOptions,
+                        buildSession,
+                        evaluationContext,
+                        project.Configuration,
+                        project.Platform);
+
+                    if (evaluation?.SupportsDeviceSelection == true)
+                    {
+                        deviceProjects[index] = (
+                            project.ProjectFilePath,
+                            project.Configuration,
+                            project.Platform,
+                            evaluation);
+                        return;
+                    }
+
+                    IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projectsMetadata =
+                        SolutionAndProjectUtility.GetProjectProperties(
+                            project.ProjectFilePath,
+                            projectCollection,
+                            evaluationContext,
+                            buildOptions,
+                            buildSession,
+                            project.Configuration,
+                            project.Platform,
+                            globalProperties,
+                            preEvaluatedProjects: evaluation?.EvaluatedProjects);
+                    foreach (var projectMetadata in projectsMetadata)
+                    {
+                        allProjects.Add(projectMetadata);
+                    }
+                }
+                catch (GracefulException ex)
+                {
+                    gracefulExceptions.Enqueue(ex);
+                }
+            });
+
+        if (gracefulExceptions.TryDequeue(out GracefulException? gracefulException))
         {
+            throw gracefulException;
+        }
+
+        // Phase 2: Select, build and inspect device projects sequentially. These operations use
+        // in-process MSBuild and may prompt for a device, so they cannot run concurrently.
+        foreach (var deviceProject in deviceProjects)
+        {
+            if (deviceProject is not { } project)
+            {
+                continue;
+            }
+
             var deviceSelection = SolutionAndProjectUtility.SelectDevicesBeforeBuild(
                 project.ProjectFilePath,
                 buildOptions,
                 buildSession,
-                evaluationContext);
+                project.Evaluation,
+                project.Configuration,
+                project.Platform);
 
             if (deviceSelection is not null)
             {
@@ -457,36 +534,8 @@ internal static class MSBuildUtility
             }
             else
             {
-                nonDeviceProjects.Add(project);
+                throw new InvalidOperationException($"Device selection unexpectedly returned no result for '{project.ProjectFilePath}'.");
             }
-        }
-
-        // Phase 2: Handle non-device projects in parallel (existing behavior).
-        var gracefulExceptions = new ConcurrentQueue<GracefulException>();
-        Parallel.ForEach(
-            nonDeviceProjects,
-            // We don't use --max-parallel-test-modules here.
-            // If user wants to limit the test applications run in parallel, we don't want to punish them and force the evaluation to also be limited.
-            new ParallelOptions { MaxDegreeOfParallelism = Environment.ProcessorCount },
-            (project) =>
-            {
-                try
-                {
-                    IEnumerable<ParallelizableTestModuleGroupWithSequentialInnerModules> projectsMetadata = SolutionAndProjectUtility.GetProjectProperties(project.ProjectFilePath, projectCollection, evaluationContext, buildOptions, buildSession, project.Configuration, project.Platform, globalProperties);
-                    foreach (var projectMetadata in projectsMetadata)
-                    {
-                        allProjects.Add(projectMetadata);
-                    }
-                }
-                catch (GracefulException ex)
-                {
-                    gracefulExceptions.Enqueue(ex);
-                }
-            });
-
-        if (gracefulExceptions.TryDequeue(out GracefulException? gracefulException))
-        {
-            throw gracefulException;
         }
 
         return (allProjects, 0);

--- a/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
+++ b/src/Cli/dotnet/Commands/Test/MTP/SolutionAndProjectUtility.cs
@@ -258,10 +258,21 @@ internal static class SolutionAndProjectUtility
         string? configuration,
         string? platform,
         IReadOnlyDictionary<string, string>? additionalGlobalProperties = null,
-        HashSet<string>? visitedTraversalProjects = null)
+        HashSet<string>? visitedTraversalProjects = null,
+        IReadOnlyDictionary<string, ProjectInstance>? preEvaluatedProjects = null)
     {
+        ProjectInstance Evaluate(string? tfm)
+        {
+            if (preEvaluatedProjects is not null &&
+                preEvaluatedProjects.TryGetValue(tfm ?? string.Empty, out ProjectInstance? preEvaluatedProject))
+            {
+                return preEvaluatedProject;
+            }
+
+            return EvaluateProject(projectCollection, evaluationContext, projectFilePath, tfm, configuration, platform, additionalGlobalProperties);
+        }
         var projects = new List<ParallelizableTestModuleGroupWithSequentialInnerModules>();
-        ProjectInstance projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, tfm: null, configuration, platform, additionalGlobalProperties);
+        ProjectInstance projectInstance = Evaluate(tfm: null);
 
         // Traversal projects (e.g. Microsoft.Build.Traversal "dirs.proj") are not test projects themselves.
         // They act as a container that forwards build/test operations to their ProjectReference items.
@@ -324,7 +335,7 @@ internal static class SolutionAndProjectUtility
             {
                 foreach (var framework in frameworks)
                 {
-                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform, additionalGlobalProperties);
+                    projectInstance = Evaluate(framework);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
                     if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
@@ -338,7 +349,7 @@ internal static class SolutionAndProjectUtility
                 List<TestModule>? innerModules = null;
                 foreach (var framework in frameworks)
                 {
-                    projectInstance = EvaluateProject(projectCollection, evaluationContext, projectFilePath, framework, configuration, platform, additionalGlobalProperties);
+                    projectInstance = Evaluate(framework);
                     Logger.LogTrace($"Loaded inner project '{Path.GetFileName(projectFilePath)}' has '{ProjectProperties.IsTestingPlatformApplication}' = '{projectInstance.GetPropertyValue(ProjectProperties.IsTestingPlatformApplication)}' (TFM: '{framework}').");
 
                     if (GetModuleFromProject(projectInstance, buildOptions, buildSession) is { } module)
@@ -413,17 +424,18 @@ internal static class SolutionAndProjectUtility
     }
 
     /// <summary>
-    /// RuntimeIdentifiers are included in the build. Returns a result with device mappings
-    /// and TestTfmsInParallel setting, or null if no device selection is needed.
+    /// Evaluates the project and its inner builds before device selection.
     /// The evaluation happens in the collection of <paramref name="buildSession"/>, which is the one
     /// every project of the run has to share; pass an <paramref name="evaluationContext"/> to reuse an
     /// existing one and avoid redundant evaluation.
     /// </summary>
-    internal static DeviceSelectionResult? SelectDevicesBeforeBuild(
+    internal static DeviceSelectionEvaluation? EvaluateProjectForDeviceSelection(
         string projectFilePath,
         BuildOptions buildOptions,
         MSBuildSession buildSession,
-        EvaluationContext? evaluationContext = null)
+        EvaluationContext? evaluationContext = null,
+        string? configuration = null,
+        string? platform = null)
     {
         // --device is already handled by HandleDeviceWithTargetFrameworkSelection
         if (!string.IsNullOrWhiteSpace(buildOptions.Device))
@@ -444,18 +456,14 @@ internal static class SolutionAndProjectUtility
         var collection = buildSession.ProjectCollection;
         evaluationContext ??= EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
 
-        var projectInstance = ProjectInstance.FromFile(projectFilePath, new ProjectOptions
-        {
-            GlobalProperties = globalProperties,
-            EvaluationContext = evaluationContext,
-            ProjectCollection = collection,
-        });
-
-        // If the project doesn't support device selection, skip entirely
-        if (!projectInstance.Targets.ContainsKey(Constants.ComputeAvailableDevices))
-        {
-            return null;
-        }
+        var projectInstance = EvaluateProject(
+            collection,
+            evaluationContext,
+            projectFilePath,
+            tfm: null,
+            configuration,
+            platform,
+            globalProperties);
 
         var targetFramework = projectInstance.GetPropertyValue(ProjectProperties.TargetFramework);
         var targetFrameworks = projectInstance.GetPropertyValue(ProjectProperties.TargetFrameworks);
@@ -467,8 +475,6 @@ internal static class SolutionAndProjectUtility
         {
             testTfmsInParallel = parsed;
         }
-
-        bool isInteractive = !Console.IsOutputRedirected && !new Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment();
 
         IEnumerable<string> frameworks;
         if (!string.IsNullOrEmpty(targetFramework) || string.IsNullOrEmpty(targetFrameworks))
@@ -484,34 +490,119 @@ internal static class SolutionAndProjectUtility
                 .Where(f => !string.IsNullOrEmpty(f));
         }
 
-        var devicesByTfm = new Dictionary<string, (string? Device, string? RuntimeIdentifier)>();
+        var evaluatedProjects = new Dictionary<string, ProjectInstance>(StringComparer.OrdinalIgnoreCase)
+        {
+            [string.Empty] = projectInstance,
+        };
+
         foreach (var framework in frameworks)
         {
-            var (device, rid) = SelectDeviceForTfm(projectFilePath, buildOptions, framework, isInteractive, buildSession);
+            ProjectInstance frameworkProject = projectInstance;
+            if (!string.IsNullOrEmpty(framework) &&
+                !string.Equals(framework, targetFramework, StringComparison.OrdinalIgnoreCase))
+            {
+                frameworkProject = EvaluateProject(
+                    collection,
+                    evaluationContext,
+                    projectFilePath,
+                    framework,
+                    configuration,
+                    platform,
+                    globalProperties);
+            }
+            evaluatedProjects[framework] = frameworkProject;
+        }
+
+        return new DeviceSelectionEvaluation(evaluatedProjects, testTfmsInParallel);
+    }
+
+    /// <summary>
+    /// Selects devices from previously evaluated target-framework-specific project instances.
+    /// Returns a result with device mappings and TestTfmsInParallel setting, or null if no
+    /// device selection is needed.
+    /// </summary>
+    internal static DeviceSelectionResult? SelectDevicesBeforeBuild(
+        string projectFilePath,
+        BuildOptions buildOptions,
+        MSBuildSession buildSession,
+        DeviceSelectionEvaluation evaluation,
+        string? configuration = null,
+        string? platform = null)
+    {
+        bool isInteractive = !Console.IsOutputRedirected && !new Telemetry.CIEnvironmentDetectorForTelemetry().IsCIEnvironment();
+        var devicesByTfm = new Dictionary<string, (string? Device, string? RuntimeIdentifier)>();
+        bool restoreWasPerformed = false;
+
+        foreach (var (framework, frameworkProject) in evaluation.ProjectsByFramework)
+        {
+            // Workload-specific targets are imported only by inner builds, so probe the
+            // TFM-specific evaluation before constructing the selector that executes the target.
+            (string? Device, string? RuntimeIdentifier, bool RestoreWasPerformed) selection =
+                frameworkProject.Targets.ContainsKey(Constants.ComputeAvailableDevices)
+                    ? SelectDeviceForTfm(
+                        projectFilePath,
+                        buildOptions,
+                        framework,
+                        isInteractive,
+                        configuration,
+                        platform,
+                        noRestore: restoreWasPerformed,
+                        buildSession)
+                    : (null, null, false);
+
+            var (device, rid, selectionRestoreWasPerformed) = selection;
+            restoreWasPerformed |= selectionRestoreWasPerformed;
             devicesByTfm[framework] = (device, rid);
         }
 
         return devicesByTfm.Values.Any(v => v.Device is not null)
-            ? new DeviceSelectionResult(devicesByTfm, testTfmsInParallel)
+            ? new DeviceSelectionResult(devicesByTfm, evaluation.TestTfmsInParallel, restoreWasPerformed)
             : null;
+    }
+
+    internal sealed record DeviceSelectionEvaluation(
+        Dictionary<string, ProjectInstance> EvaluatedProjects,
+        bool TestTfmsInParallel)
+    {
+        public IEnumerable<KeyValuePair<string, ProjectInstance>> ProjectsByFramework
+            => EvaluatedProjects.Count == 1
+                ? EvaluatedProjects
+                : EvaluatedProjects.Where(project => !string.IsNullOrEmpty(project.Key));
+
+        public bool SupportsDeviceSelection
+            => ProjectsByFramework.Any(project => project.Value.Targets.ContainsKey(Constants.ComputeAvailableDevices));
     }
 
     internal sealed record DeviceSelectionResult(
         Dictionary<string, (string? Device, string? RuntimeIdentifier)> DevicesByTfm,
-        bool TestTfmsInParallel);
+        bool TestTfmsInParallel,
+        bool RestoreWasPerformed);
 
     /// <summary>
     /// Selects a device for a specific TFM using RunCommandSelector.
-    /// Returns (null, null) if no device support or no devices available for this TFM.
+    /// Returns the selected device, its runtime identifier, and whether restore was performed.
     /// </summary>
-    private static (string? device, string? runtimeIdentifier) SelectDeviceForTfm(
+    private static (string? device, string? runtimeIdentifier, bool restoreWasPerformed) SelectDeviceForTfm(
         string projectFilePath,
         BuildOptions buildOptions,
         string? tfm,
         bool isInteractive,
+        string? configuration,
+        string? platform,
+        bool noRestore,
         MSBuildSession buildSession)
     {
         var msbuildArgsToAppend = buildOptions.MSBuildArgs;
+        if (!string.IsNullOrEmpty(configuration))
+        {
+            msbuildArgsToAppend = msbuildArgsToAppend.Append($"-p:{ProjectProperties.Configuration}={configuration}");
+        }
+
+        if (!string.IsNullOrEmpty(platform))
+        {
+            msbuildArgsToAppend = msbuildArgsToAppend.Append($"-p:{ProjectProperties.Platform}={platform}");
+        }
+
         if (!string.IsNullOrEmpty(tfm))
         {
             msbuildArgsToAppend = msbuildArgsToAppend.Append($"-p:{ProjectProperties.TargetFramework}={tfm}");
@@ -532,16 +623,16 @@ internal static class SolutionAndProjectUtility
         {
             if (!selector.TrySelectDevice(
                 listDevices: false,
-                noRestore: buildOptions.HasNoRestore || buildOptions.HasNoBuild,
+                noRestore: noRestore || buildOptions.HasNoRestore || buildOptions.HasNoBuild,
                 out var selectedDevice,
                 out var runtimeIdentifier,
-                out _))
+                out var restoreWasPerformed))
             {
                 throw new GracefulException(
                     string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"));
             }
 
-            return (selectedDevice, runtimeIdentifier);
+            return (selectedDevice, runtimeIdentifier, restoreWasPerformed);
         }
     }
 

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.Device.targets
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.Device.targets
@@ -1,0 +1,21 @@
+<Project>
+  <Target Name="ComputeAvailableDevices" Returns="@(Devices)">
+    <Error Condition="'$(ExpectedDeviceConfiguration)' != '' and '$(Configuration)' != '$(ExpectedDeviceConfiguration)'"
+           Text="Expected device configuration '$(ExpectedDeviceConfiguration)', but found '$(Configuration)'." />
+    <Error Condition="'$(ExpectedDevicePlatform)' != '' and '$(Platform)' != '$(ExpectedDevicePlatform)'"
+           Text="Expected device platform '$(ExpectedDevicePlatform)', but found '$(Platform)'." />
+    <!-- If SingleDevice property is set, return only one device -->
+    <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' == 'true'">
+      <Devices Include="single-device" Description="Single Device" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />
+    </ItemGroup>
+    <!-- Otherwise return multiple devices based on target framework -->
+    <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' != 'true' and '$(TargetFramework)' != 'net9.0'">
+      <Devices Include="test-device-1" Description="Test Device 1" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />
+      <Devices Include="test-device-2" Description="Test Device 2" Type="Device" Status="Online" />
+    </ItemGroup>
+    <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' != 'true' and '$(TargetFramework)' == 'net9.0'">
+      <Devices Include="test-device-downlevel-1" Description="Test Device Downlevel 1" Type="Emulator" Status="Online" />
+      <Devices Include="test-device-downlevel-2" Description="Test Device Downlevel 2" Type="Simulator" Status="Booted" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
+++ b/test/TestAssets/TestProjects/DotnetTestDevices/DotnetTestDevices.csproj
@@ -28,21 +28,8 @@
     <PackageReference Include="Microsoft.Testing.Platform" Version="$(MicrosoftTestingPlatformVersion)" />
   </ItemGroup>
 
-  <Target Name="ComputeAvailableDevices" Returns="@(Devices)">
-    <!-- If SingleDevice property is set, return only one device -->
-    <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' == 'true'">
-      <Devices Include="single-device" Description="Single Device" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />
-    </ItemGroup>
-    <!-- Otherwise return multiple devices based on target framework -->
-    <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' != 'true' and '$(TargetFramework)' != 'net9.0'">
-      <Devices Include="test-device-1" Description="Test Device 1" Type="Emulator" Status="Online" RuntimeIdentifier="$(NETCoreSdkRuntimeIdentifier)" />
-      <Devices Include="test-device-2" Description="Test Device 2" Type="Device" Status="Online" />
-    </ItemGroup>
-    <ItemGroup Condition="'$(NoDevices)' != 'true' and '$(SingleDevice)' != 'true' and '$(TargetFramework)' == 'net9.0'">
-      <Devices Include="test-device-downlevel-1" Description="Test Device Downlevel 1" Type="Emulator" Status="Online" />
-      <Devices Include="test-device-downlevel-2" Description="Test Device Downlevel 2" Type="Simulator" Status="Booted" />
-    </ItemGroup>
-  </Target>
+  <Import Project="DotnetTestDevices.Device.targets"
+          Condition="'$(TargetFramework)' != '' and ('$(DeviceTargetFramework)' == '' or '$(TargetFramework)' == '$(DeviceTargetFramework)')" />
 
   <!-- ResolveFrameworkReferences mimics Android -->
   <Target Name="DeployToDevice" DependsOnTargets="ResolveFrameworkReferences">

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestProducesBinaryLog.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestProducesBinaryLog.cs
@@ -152,6 +152,9 @@ public class GivenDotnetTestProducesBinaryLog : SdkTest
             File.Copy(
                 Path.Combine(testInstance.Path, "DotnetTestDevices.csproj"),
                 Path.Combine(dir, Path.GetFileName(dir) + ".csproj"));
+            File.Copy(
+                Path.Combine(testInstance.Path, "DotnetTestDevices.Device.targets"),
+                Path.Combine(dir, "DotnetTestDevices.Device.targets"));
         }
 
         File.Delete(Path.Combine(testInstance.Path, "DotnetTestDevices.csproj"));

--- a/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
+++ b/test/dotnet.Tests/CommandTests/Test/GivenDotnetTestSelectsDevice.cs
@@ -49,6 +49,23 @@ public class GivenDotnetTestSelectsDevice : SdkTest
     }
 
     [TestMethod]
+    public void ItFindsDevicesForSingleEntryTargetFrameworksWithoutFramework()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+
+        var result = new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute($"-p:TargetFrameworks={ToolsetInfo.CurrentTargetFramework}");
+
+        result.Should().Fail()
+            .And.HaveStdErrContaining(string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"))
+            .And.HaveStdErrContaining("test-device-1")
+            .And.HaveStdErrContaining("test-device-2");
+    }
+
+    [TestMethod]
     [DataRow("test-device-1")]
     [DataRow("test-device-2")]
     public void ItRunsTestsWithSpecifiedDevice(string deviceId)
@@ -197,19 +214,97 @@ public class GivenDotnetTestSelectsDevice : SdkTest
     }
 
     [TestMethod]
-    public void ItAutoSelectsSingleDevicePerTfm()
+    public void ItFindsDevicesForProjectWithoutTargetFramework()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+        string projectPath = Path.Combine(testInstance.Path, "DotnetTestDevices.csproj");
+        File.WriteAllText(
+            projectPath,
+            File.ReadAllText(projectPath)
+                .Replace(
+                    $"    <TargetFrameworks>net9.0;{ToolsetInfo.CurrentTargetFramework}</TargetFrameworks>{Environment.NewLine}",
+                    string.Empty)
+                .Replace(
+                    "</Project>",
+                    """
+                      <Target Name="ComputeAvailableDevices" Returns="@(Devices)">
+                        <ItemGroup>
+                          <Devices Include="test-device-1" />
+                          <Devices Include="test-device-2" />
+                        </ItemGroup>
+                      </Target>
+                    </Project>
+                    """));
+
+        new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .WithEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
+            .Execute("--no-restore")
+            .Should().Fail()
+            .And.HaveStdErrContaining(string.Format(CliCommandStrings.RunCommandExceptionUnableToRunSpecifyDevice, "--device"))
+            .And.HaveStdErrContaining("test-device-1")
+            .And.HaveStdErrContaining("test-device-2");
+    }
+
+    [TestMethod]
+    public void ItSelectsDevicesFromTargetsImportedOnlyByInnerBuilds()
     {
         var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
             .WithSource();
 
-        // Run without -f to test all TFMs. SingleDevice=true means one device per TFM
-        // is auto-selected. Device selection happens BEFORE the build so that any
-        // device-provided RuntimeIdentifier is included in the build output.
+        // Workloads import device targets only after TargetFramework is set. Run without -f
+        // to verify the outer cross-targeting evaluation does not skip device selection.
         var result = new DotnetTestCommand(Log, disableNewOutput: false)
             .WithWorkingDirectory(testInstance.Path)
-            .Execute("-p:SingleDevice=true");
+            .Execute("-p:SingleDevice=true", "-bl");
 
         result.Should().Pass();
+        AssertTargetInBinlog(
+            Path.Combine(testInstance.Path, "msbuild-dotnet-test.binlog"),
+            "DeployToDevice",
+            targets =>
+            {
+                targets.Should().HaveCount(2, "both target frameworks should be deployed");
+                targets.SelectMany(target => target.FindChildrenRecursive<Message>())
+                    .Where(message => message.Text.Contains("DeployToDevice: Deployed"))
+                    .Should().OnlyContain(message => message.Text.Contains("to device single-device"));
+            });
+        AssertTargetInBinlog(
+            Path.Combine(testInstance.Path, "msbuild-dotnet-test.binlog"),
+            "Restore",
+            targets => targets.Should().ContainSingle("device selection should restore once for all target frameworks"));
+    }
+
+    [TestMethod]
+    public void ItSelectsDevicesOnlyForTargetFrameworksThatSupportThem()
+    {
+        var testInstance = TestAssetsManager.CopyTestAsset("DotnetTestDevices")
+            .WithSource();
+
+        new DotnetTestCommand(Log, disableNewOutput: false)
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute(
+                "-p:SingleDevice=true",
+                $"-p:DeviceTargetFramework={ToolsetInfo.CurrentTargetFramework}",
+                "-bl")
+            .Should().Pass();
+
+        AssertTargetInBinlog(
+            Path.Combine(testInstance.Path, "msbuild-dotnet-test.binlog"),
+            "DeployToDevice",
+            targets =>
+            {
+                var deployMessages = targets.SelectMany(target => target.FindChildrenRecursive<Message>())
+                    .Where(message => message.Text.Contains("DeployToDevice: Deployed"))
+                    .Select(message => message.Text)
+                    .ToArray();
+
+                deployMessages.Should().Contain(message =>
+                    message.Contains($"Deployed {ToolsetInfo.CurrentTargetFramework} to device single-device"));
+                deployMessages.Should().Contain(message =>
+                    message.Contains("Deployed net9.0 to device  with RuntimeIdentifier"));
+            });
     }
 
     [TestMethod]
@@ -230,6 +325,9 @@ public class GivenDotnetTestSelectsDevice : SdkTest
             File.Copy(
                 Path.Combine(testInstance.Path, "DotnetTestDevices.csproj"),
                 Path.Combine(dir, Path.GetFileName(dir) + ".csproj"));
+            File.Copy(
+                Path.Combine(testInstance.Path, "DotnetTestDevices.Device.targets"),
+                Path.Combine(dir, "DotnetTestDevices.Device.targets"));
         }
 
         File.Delete(Path.Combine(testInstance.Path, "DotnetTestDevices.csproj"));
@@ -238,14 +336,29 @@ public class GivenDotnetTestSelectsDevice : SdkTest
         File.WriteAllText(Path.Combine(testInstance.Path, "TestSolution.slnx"),
             """
             <Solution>
-              <Project Path="Project1\Project1.csproj" />
-              <Project Path="Project2\Project2.csproj" />
+              <Configurations>
+                <BuildType Name="Debug" />
+                <Platform Name="Any CPU" />
+              </Configurations>
+              <Project Path="Project1\Project1.csproj">
+                <BuildType Solution="Debug|*" Project="Release" />
+                <Platform Solution="*|Any CPU" Project="AnyCPU" />
+              </Project>
+              <Project Path="Project2\Project2.csproj">
+                <BuildType Solution="Debug|*" Project="Release" />
+                <Platform Solution="*|Any CPU" Project="AnyCPU" />
+              </Project>
             </Solution>
             """);
 
         var result = new DotnetTestCommand(Log, disableNewOutput: false)
             .WithWorkingDirectory(testInstance.Path)
-            .Execute("--solution", "TestSolution.slnx", "-p:SingleDevice=true", "-bl");
+            .Execute(
+                "--solution", "TestSolution.slnx",
+                "-p:SingleDevice=true",
+                "-p:ExpectedDeviceConfiguration=Release",
+                "-p:ExpectedDevicePlatform=AnyCPU",
+                "-bl");
 
         result.Should().Pass();
 


### PR DESCRIPTION
## Summary

Backport of #56054 to `release/11.0.1xx`.

Fixes `dotnet test` device discovery for multi-targeted Microsoft.Testing.Platform projects when workload-provided device targets are imported only by target-framework-specific inner builds.

## Backport details

- Manually resolved the conflict in `SolutionAndProjectUtility.cs` against the release-specific implementation.
- Preserves the original product and test coverage from #56054.
- Contains a single commit on top of `release/11.0.1xx`.