### PR TITLE
[release/10.0.4xx] Decode captured test output as UTF-8

### DIFF
--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -188,14 +188,6 @@ namespace Microsoft.NET.TestFramework.Commands
                     command.OnOutputLine(CommandOutputHandler);
                 }
 
-                // Decode captured stdout as UTF-8 by default so non-ASCII output (e.g. localized
-                // strings such as the French "Bienvenue à .Net!") is not corrupted by the host
-                // console's active code page. Child dotnet/MSBuild processes emit UTF-8; when
-                // StandardOutputEncoding is left null, Process decodes the redirected stream using
-                // Console.OutputEncoding, which on Windows is the OEM code page (e.g. CP437/850) and
-                // turns UTF-8 bytes like 0xC3 0xA0 ('à') into mojibake ('├á'). Because the active code
-                // page varies by agent, tests asserting on non-ASCII output failed intermittently. On
-                // non-Windows the default capture encoding is already UTF-8, so this is a no-op there.
                 command.StandardOutputEncoding(StandardOutputEncoding ?? Encoding.UTF8);
             }
 

--- a/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
+++ b/test/Microsoft.NET.TestFramework/Commands/TestCommand.cs
@@ -188,10 +188,15 @@ namespace Microsoft.NET.TestFramework.Commands
                     command.OnOutputLine(CommandOutputHandler);
                 }
 
-                if (StandardOutputEncoding is not null)
-                {
-                    command.StandardOutputEncoding(StandardOutputEncoding);
-                }
+                // Decode captured stdout as UTF-8 by default so non-ASCII output (e.g. localized
+                // strings such as the French "Bienvenue à .Net!") is not corrupted by the host
+                // console's active code page. Child dotnet/MSBuild processes emit UTF-8; when
+                // StandardOutputEncoding is left null, Process decodes the redirected stream using
+                // Console.OutputEncoding, which on Windows is the OEM code page (e.g. CP437/850) and
+                // turns UTF-8 bytes like 0xC3 0xA0 ('à') into mojibake ('├á'). Because the active code
+                // page varies by agent, tests asserting on non-ASCII output failed intermittently. On
+                // non-Windows the default capture encoding is already UTF-8, so this is a no-op there.
+                command.StandardOutputEncoding(StandardOutputEncoding ?? Encoding.UTF8);
             }
 
             string fileToShow = Path.GetFileNameWithoutExtension(spec.FileName!).Equals("dotnet", StringComparison.OrdinalIgnoreCase) ?


### PR DESCRIPTION
## Summary

- decode redirected test command output as UTF-8 by default
- preserve explicit per-command encoding overrides
- prevent Windows OEM code pages from corrupting localized `dotnet` output such as `äÄßöÖüÜ`

This backports dotnet/sdk#55428 commit `134c632529a66109e0571d985ca4f4e4871f25dd`. The missing change caused the two `DotnetNewLocaleTests` failures observed in dotnet/sdk#56141.

## Testing

- built `test/Microsoft.NET.TestFramework/Microsoft.NET.TestFramework.csproj` on `release/10.0.4xx`

> [!NOTE]
> This pull request was created with GitHub Copilot assistance.