### PR TITLE
Size template buffers from archive entries

### DIFF
--- a/src/TemplateEngine/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Abstractions/Microsoft.TemplateEngine.Abstractions.csproj
@@ -27,4 +27,11 @@
     <Compile Include="..\Shared\IsExternalInit.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Microsoft.TemplateEngine.Core" Key="$(TemplateEnginePublicKey)" />
+    <InternalsVisibleTo Include="Microsoft.TemplateEngine.Core.UnitTests" Key="$(TemplateEnginePublicKey)" />
+    <InternalsVisibleTo Include="Microsoft.TemplateEngine.Edge" Key="$(TemplateEnginePublicKey)" />
+    <InternalsVisibleTo Include="Microsoft.TemplateEngine.Edge.UnitTests" Key="$(TemplateEnginePublicKey)" />
+  </ItemGroup>
+
 </Project>

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Abstractions/Mount/IKnownLengthFile.cs
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Abstractions/Mount/IKnownLengthFile.cs
@@ -1,0 +1,10 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.TemplateEngine.Abstractions.Mount
+{
+    internal interface IKnownLengthFile : IFile
+    {
+        long Length { get; }
+    }
+}

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Core/Util/Orchestrator.cs
@@ -74,6 +74,23 @@ namespace Microsoft.TemplateEngine.Core.Util
 
         protected virtual bool TryGetBufferSize(IFile sourceFile, out int bufferSize)
         {
+            if (sourceFile is IKnownLengthFile knownLengthFile)
+            {
+                try
+                {
+                    long length = knownLengthFile.Length;
+                    if (length >= 0 && length < Processor.DefaultBufferSize)
+                    {
+                        bufferSize = Math.Max(4, (int)length);
+                        return true;
+                    }
+                }
+                catch
+                {
+                    // Fall back to the default when the source cannot report a stable length.
+                }
+            }
+
             bufferSize = -1;
             return false;
         }

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Core/Util/Processor.cs
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Core/Util/Processor.cs
@@ -8,7 +8,7 @@ namespace Microsoft.TemplateEngine.Core.Util
 {
     public class Processor : IProcessor
     {
-        private const int DefaultBufferSize = 8 * 1024 * 1024;
+        internal const int DefaultBufferSize = 8 * 1024 * 1024;
         private const int DefaultFlushThreshold = 8 * 1024 * 1024;
         private readonly IReadOnlyList<IOperationProvider> _operations;
 

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileFile.cs
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Edge/Mount/Archive/ZipFileFile.cs
@@ -2,11 +2,12 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.IO.Compression;
+using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Abstractions.Mount;
 
 namespace Microsoft.TemplateEngine.Edge.Mount.Archive
 {
-    internal class ZipFileFile : FileBase
+    internal class ZipFileFile : FileBase, IKnownLengthFile
     {
         private readonly ZipFileMountPoint _mountPoint;
         private ZipArchiveEntry? _entry;
@@ -20,7 +21,14 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
 
         public override bool Exists => _entry != null || (_mountPoint.Universe.TryGetValue(FullPath, out var info) && info.Kind == FileSystemInfoKind.File);
 
+        long IKnownLengthFile.Length => GetEntry().Length;
+
         public override Stream OpenRead()
+        {
+            return GetEntry().Open();
+        }
+
+        private ZipArchiveEntry GetEntry()
         {
             if (_entry == null)
             {
@@ -41,7 +49,7 @@ namespace Microsoft.TemplateEngine.Edge.Mount.Archive
                 _entry = self._entry;
             }
 
-            return _entry.Open();
+            return _entry;
         }
     }
 }

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/OrchestratorTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Core.UnitTests/OrchestratorTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
 using Microsoft.TemplateEngine.Mocks;
 using Microsoft.TemplateEngine.TestHelper;
 
@@ -35,6 +36,91 @@ namespace Microsoft.TemplateEngine.Core.UnitTests
             MockMountPoint mnt = new MockMountPoint(_engineEnvironmentSettings);
             mnt.MockRoot.AddDirectory("subdir").AddFile("test.file", []);
             orchestrator.Run(new MockGlobalRunSpec(), mnt.Root, @"c:\temp");
+        }
+
+        [TestMethod]
+        public void TryGetBufferSize_KnownLengthFile_UsesLengthBelowDefault()
+        {
+            TestOrchestrator orchestrator = new(_logger, new MockFileSystem());
+
+            bool found = orchestrator.TryGetBufferSize(new KnownLengthFile(32), out int bufferSize);
+
+            Assert.IsTrue(found);
+            Assert.AreEqual(32, bufferSize);
+        }
+
+        [TestMethod]
+        public void TryGetBufferSize_KnownLengthFile_DoesNotIncreaseDefault()
+        {
+            TestOrchestrator orchestrator = new(_logger, new MockFileSystem());
+
+            bool found = orchestrator.TryGetBufferSize(new KnownLengthFile(Util.Processor.DefaultBufferSize), out int bufferSize);
+
+            Assert.IsFalse(found);
+            Assert.AreEqual(-1, bufferSize);
+        }
+
+        [TestMethod]
+        [DataRow(0)]
+        [DataRow(1)]
+        [DataRow(3)]
+        public void TryGetBufferSize_KnownLengthFile_UsesMinimumBufferSize(long length)
+        {
+            TestOrchestrator orchestrator = new(_logger, new MockFileSystem());
+
+            bool found = orchestrator.TryGetBufferSize(new KnownLengthFile(length), out int bufferSize);
+
+            Assert.IsTrue(found);
+            Assert.AreEqual(4, bufferSize);
+        }
+
+        [TestMethod]
+        [DataRow(-1)]
+        [DataRow(Util.Processor.DefaultBufferSize + 1L)]
+        public void TryGetBufferSize_KnownLengthFile_InvalidLengthUsesDefault(long length)
+        {
+            TestOrchestrator orchestrator = new(_logger, new MockFileSystem());
+
+            bool found = orchestrator.TryGetBufferSize(new KnownLengthFile(length), out int bufferSize);
+
+            Assert.IsFalse(found);
+            Assert.AreEqual(-1, bufferSize);
+        }
+
+        [TestMethod]
+        public void TryGetBufferSize_KnownLengthFile_ThrowingLengthUsesDefault()
+        {
+            TestOrchestrator orchestrator = new(_logger, new MockFileSystem());
+
+            bool found = orchestrator.TryGetBufferSize(new KnownLengthFile(throwOnAccess: true), out int bufferSize);
+
+            Assert.IsFalse(found);
+            Assert.AreEqual(-1, bufferSize);
+        }
+
+        private sealed class TestOrchestrator(ILogger logger, MockFileSystem fileSystem) : Util.Orchestrator(logger, fileSystem)
+        {
+            public new bool TryGetBufferSize(IFile sourceFile, out int bufferSize)
+                => base.TryGetBufferSize(sourceFile, out bufferSize);
+        }
+
+        private sealed class KnownLengthFile(long length = 0, bool throwOnAccess = false) : IKnownLengthFile
+        {
+            public bool Exists => true;
+
+            public string FullPath => "/test";
+
+            public FileSystemInfoKind Kind => FileSystemInfoKind.File;
+
+            public IDirectory? Parent => null;
+
+            public string Name => "test";
+
+            public IMountPoint MountPoint => null!;
+
+            public long Length => throwOnAccess ? throw new IOException() : length;
+
+            public Stream OpenRead() => Stream.Null;
         }
     }
 }

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/ZipFileFileTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/ZipFileFileTests.cs
@@ -31,7 +31,19 @@ namespace Microsoft.TemplateEngine.Edge.UnitTests
             Assert.AreEqual(data.Length, ((IKnownLengthFile)file).Length);
             using Stream stream = file.OpenRead();
             byte[] actual = new byte[data.Length];
-            Assert.AreEqual(data.Length, stream.Read(actual, 0, actual.Length));
+            int totalRead = 0;
+            while (totalRead < actual.Length)
+            {
+                int bytesRead = stream.Read(actual, totalRead, actual.Length - totalRead);
+                if (bytesRead == 0)
+                {
+                    break;
+                }
+
+                totalRead += bytesRead;
+            }
+
+            Assert.AreEqual(data.Length, totalRead);
             Assert.AreSequenceEqual(data, actual);
         }
     }

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/ZipFileFileTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Edge.UnitTests/ZipFileFileTests.cs
@@ -1,0 +1,38 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.IO.Compression;
+using FakeItEasy;
+using Microsoft.TemplateEngine.Abstractions;
+using Microsoft.TemplateEngine.Abstractions.Mount;
+using Microsoft.TemplateEngine.Edge.Mount.Archive;
+
+namespace Microsoft.TemplateEngine.Edge.UnitTests
+{
+    [TestClass]
+    public class ZipFileFileTests
+    {
+        [TestMethod]
+        public void Length_ReportsUncompressedEntryLength()
+        {
+            byte[] data = [1, 2, 3, 4, 5];
+            using MemoryStream archiveStream = new();
+            using (ZipArchive archive = new(archiveStream, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                using Stream entryStream = archive.CreateEntry("test.txt").Open();
+                entryStream.Write(data, 0, data.Length);
+            }
+
+            archiveStream.Position = 0;
+            using ZipArchive readArchive = new(archiveStream, ZipArchiveMode.Read, leaveOpen: true);
+            using ZipFileMountPoint mountPoint = new(A.Fake<IEngineEnvironmentSettings>(), null, "test.zip", readArchive);
+            IFile file = mountPoint.FileInfo("/test.txt");
+
+            Assert.AreEqual(data.Length, ((IKnownLengthFile)file).Length);
+            using Stream stream = file.OpenRead();
+            byte[] actual = new byte[data.Length];
+            Assert.AreEqual(data.Length, stream.Read(actual, 0, actual.Length));
+            Assert.AreSequenceEqual(data, actual);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #56185 and #56163.

- expose archive-entry length through an internal `IKnownLengthFile`
- size processing buffers before opening non-seekable ZIP entry streams
- retain the existing 8 MiB fallback for unknown, invalid, oversized, or throwing lengths
- keep `IFile`, `IProcessorState`, and `ProcessorState` unchanged
- add boundary and real ZIP-entry tests

The source changes are independent from #56185. Performance was measured on top of its exact head.

## Performance

Windows x64 Release ReadyToRun measurements used initialized `dotnet new console --no-restore` operations.

### Delta from #56185

| Metric | #56185 | This change | Difference |
| --- | ---: | ---: | ---: |
| Reported allocation | 40,011,904 B | 23,264,064 B | **-41.86%** |
| Peak heap | 25.06 MB | 5.89 MB | **-19.17 MB** |
| Promoted memory | 16.40 MB | 3.72 MB | **-12.68 MB** |
| GC count | 2 | 1 | **-1** |
| Console latency | 227.53 ms | 225.15 ms | **0.99% paired improvement** |
| Sampled CPU | 330.50 ms/op | 324.41 ms/op | **-1.84%** |

The latency comparison used 15 alternating pairs; 11/15 candidate operations were faster with zero semantic mismatches.

### Three-PR breakdown

| PR | Change | Allocation result | Time result |
| --- | --- | --- | --- |
| #56163 | Remove template-host logging DI construction | Host construction: 93,191 B to 9,801 B (**-89.5%**) | Host CPU: 15.15 ms to 4.44 ms; console creation **5.32% faster** |
| #56185 | Store the common trie child inline | Command allocation: 49,401,248 B to 40,047,344 B (**-18.93%**) | Console latency effectively neutral; list **4.08% faster** |
| This PR | Size buffers from ZIP entry lengths | Command allocation: 40,011,904 B to 23,264,064 B (**-41.86%**) | Console creation **0.99% faster**; sampled CPU **1.84% lower** |

## Validation

- `Microsoft.TemplateEngine.Core.UnitTests`
  - Debug and Release
  - `net11.0` and `net481`
  - 370 passed, 0 failed per run
- `Microsoft.TemplateEngine.Edge.UnitTests`
  - Debug and Release
  - `net11.0` and `net481`
  - 269 passed, 0 failed per run
- full Release ReadyToRun SDK build
- exact measured SDK trees differed only in ReadyToRun Abstractions, Core, and Edge assemblies
- all measured commands and semantic comparisons passed
