### PR TITLE
Only accept web socket requests with allowed origin header & set env variables in agent

### DIFF
--- a/src/Dotnet.Watch/HotReloadAgent.Host/Listener.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/Listener.cs
@@ -95,6 +95,10 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
             var payloadType = (RequestType)await request.Stream.ReadByteAsync(cancellationToken).ConfigureAwait(false);
             switch (payloadType)
             {
+                case RequestType.SetEnvironmentVariables:
+                    await SetEnvironmentVariablesAsync(request.Stream, cancellationToken).ConfigureAwait(false);
+                    break;
+
                 case RequestType.ManagedCodeUpdate:
                     await ReadAndApplyManagedCodeUpdateAsync(request.Stream, cancellationToken).ConfigureAwait(false);
                     break;
@@ -111,6 +115,29 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
                     throw new InvalidOperationException($"Unexpected payload type: {payloadType}");
             }
         }
+    }
+
+    private async Task SetEnvironmentVariablesAsync(Stream stream, CancellationToken cancellationToken)
+    {
+        var environmentVariableCount = await stream.ReadInt32Async(cancellationToken).ConfigureAwait(false);
+
+        log($"Setting environment variables ({environmentVariableCount})");
+
+        for (var i = 0; i < environmentVariableCount; i++)
+        {
+            var name = await stream.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+            var value = await stream.ReadStringAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                Environment.SetEnvironmentVariable(name, value);
+            }
+            catch (Exception e)
+            {
+                log($"Unable to set environment variable '{name}': {e.Message}");
+            }
+        }
+
+        await SendResponseAsync(new SetEnvironmentVariablesResponse(), cancellationToken).ConfigureAwait(false);
     }
 
     private async ValueTask ReadAndApplyManagedCodeUpdateAsync(Stream stream, CancellationToken cancellationToken)

--- a/src/Dotnet.Watch/HotReloadAgent.Host/WebSocketTransport.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/WebSocketTransport.cs
@@ -57,6 +57,8 @@ internal sealed class WebSocketTransport(string serverUrl, string? serverPublicK
                     _webSocket.Options.AddSubProtocol(encryptedSecret);
                 }
 
+                _webSocket.Options.SetRequestHeader("Origin", (serverPublicKey != null ? "wss" : "ws") + "://localhost");
+
                 Log($"Connecting to {serverUrl}...");
                 await _webSocket.ConnectAsync(new Uri(serverUrl), connectCts.Token).ConfigureAwait(false);
                 Log("Connected.");

--- a/src/Dotnet.Watch/HotReloadAgent.PipeRpc/NamedPipeContract.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.PipeRpc/NamedPipeContract.cs
@@ -33,16 +33,26 @@ internal interface IUpdateRequest : IRequest
 
 internal enum RequestType : byte
 {
-    ManagedCodeUpdate = 1,
-    StaticAssetUpdate = 2,
-    InitialUpdatesCompleted = 3,
+    SetEnvironmentVariables = 1,
+    ManagedCodeUpdate = 2,
+    StaticAssetUpdate = 3,
+    InitialUpdatesCompleted = 4,
 }
 
 internal enum ResponseType : byte
 {
     InitializationResponse = 1,
-    UpdateResponse = 2,
-    HotReloadExceptionNotification = 3,
+    EnvironmentVariablesSet = 2,
+    UpdateResponse = 3,
+    HotReloadExceptionNotification = 4,
+}
+
+internal readonly struct SetEnvironmentVariablesResponse() : IResponse
+{
+    public ResponseType Type => ResponseType.EnvironmentVariablesSet;
+
+    public ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
+        => default;
 }
 
 internal readonly struct ManagedCodeUpdateRequest(IReadOnlyList<RuntimeManagedCodeUpdate> updates, ResponseLoggingLevel responseLoggingLevel) : IUpdateRequest

--- a/src/Dotnet.Watch/HotReloadClient/DefaultHotReloadClient.cs
+++ b/src/Dotnet.Watch/HotReloadClient/DefaultHotReloadClient.cs
@@ -35,7 +35,7 @@ internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger
     /// </summary>
     internal ClientTransport Transport => transport;
 
-    public override void InitiateConnection(CancellationToken cancellationToken)
+    public override void InitiateConnection(IReadOnlyCollection<(string name, string value)> environmentVariables, CancellationToken cancellationToken)
     {
         // It is important to establish the connection (WaitForConnectionAsync) before we return,
         // otherwise the client wouldn't be able to connect.
@@ -72,6 +72,9 @@ internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger
                 var result = AddImplicitCapabilities(capabilities.Split(' '));
 
                 Logger.Log(LogEvents.Capabilities, string.Join(" ", result));
+
+                // Initialize process:
+                await SetEnvironmentVariablesAsync(environmentVariables, cancellationToken);
 
                 // fire and forget:
                 _ = ListenForResponsesAsync(cancellationToken);
@@ -163,6 +166,33 @@ internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger
 
     private ResponseLoggingLevel ResponseLoggingLevel
         => Logger.IsEnabled(LogLevel.Debug) ? ResponseLoggingLevel.Verbose : ResponseLoggingLevel.WarningsAndErrors;
+
+    public async ValueTask SetEnvironmentVariablesAsync(IReadOnlyCollection<(string name, string value)> environmentVariables, CancellationToken cancellationToken)
+    {
+        if (environmentVariables.Count == 0)
+        {
+            return;
+        }
+
+        // Send a request to set environment variables:
+        await transport.WriteAsync((byte)RequestType.SetEnvironmentVariables, async (stream, cancellationToken) =>
+        {
+            await stream.WriteAsync(environmentVariables.Count, cancellationToken);
+
+            foreach (var (name, value) in environmentVariables)
+            {
+                await stream.WriteAsync(name, cancellationToken);
+                await stream.WriteAsync(value, cancellationToken);
+            }
+        }, cancellationToken);
+
+        // Wait until the environment variables are set in the target process:
+        using var response = await transport.ReadAsync(cancellationToken);
+        if (response != null && response.Value.Type != ResponseType.EnvironmentVariablesSet)
+        {
+            throw new InvalidOperationException($"Unexpected response received from the agent: {response.Value.Type}");
+        }
+    }
 
     public async override Task<Task<bool>> ApplyManagedCodeUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, CancellationToken applyOperationCancellationToken, CancellationToken cancellationToken)
     {

--- a/src/Dotnet.Watch/HotReloadClient/HotReloadClient.cs
+++ b/src/Dotnet.Watch/HotReloadClient/HotReloadClient.cs
@@ -53,8 +53,9 @@ internal abstract class HotReloadClient(ILogger logger, ILogger agentLogger) : I
     /// <summary>
     /// Initiates connection with the agent in the target process.
     /// </summary>
+    /// <param name="environmentVariables">Environment variable to be set by the agent in the target process.</param>
     /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
-    public abstract void InitiateConnection(CancellationToken cancellationToken);
+    public abstract void InitiateConnection(IReadOnlyCollection<(string name, string value)> environmentVariables, CancellationToken cancellationToken);
 
     /// <summary>
     /// Waits until the connection with the agent is established.

--- a/src/Dotnet.Watch/HotReloadClient/HotReloadClients.cs
+++ b/src/Dotnet.Watch/HotReloadClient/HotReloadClients.cs
@@ -93,12 +93,13 @@ internal sealed class HotReloadClients(
         browserRefreshServer?.ConfigureLaunchEnvironment(environmentBuilder, enableHotReload: true);
     }
 
+    /// <param name="environmentVariables">Environment variable to be set by the agent in the target process.</param>
     /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
-    internal void InitiateConnection(CancellationToken cancellationToken)
+    internal void InitiateConnection(IReadOnlyCollection<(string name, string value)> environmentVariables, CancellationToken cancellationToken)
     {
         foreach (var client in clients)
         {
-            client.InitiateConnection(cancellationToken);
+            client.InitiateConnection(environmentVariables, cancellationToken);
         }
     }
 

--- a/src/Dotnet.Watch/HotReloadClient/Web/BrowserRefreshServer.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/BrowserRefreshServer.cs
@@ -14,6 +14,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
 
 namespace Microsoft.DotNet.HotReload;
 
@@ -52,7 +53,15 @@ internal sealed class BrowserRefreshServer(
     {
         if (!context.WebSockets.IsWebSocketRequest)
         {
-            context.Response.StatusCode = 400;
+            context.Response.StatusCode = StatusCodes.Status400BadRequest;
+            return;
+        }
+
+        // check the domain of the Origin header:
+        if (!Uri.TryCreate(context.Request.Headers.Origin.FirstOrDefault(), UriKind.Absolute, out var originUri) ||
+            !webSocketConfig.GetAllowedOriginDomains().Contains(originUri.Host, StringComparer.OrdinalIgnoreCase))
+        {
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
             return;
         }
 

--- a/src/Dotnet.Watch/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
@@ -82,7 +82,7 @@ internal sealed class WebAssemblyHotReloadClient(
         // the environment is configued via browser refesh server
     }
 
-    public override void InitiateConnection(CancellationToken cancellationToken)
+    public override void InitiateConnection(IReadOnlyCollection<(string name, string value)> environmentVariables, CancellationToken cancellationToken)
     {
     }
 

--- a/src/Dotnet.Watch/HotReloadClient/Web/WebSocketConfig.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/WebSocketConfig.cs
@@ -4,10 +4,11 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.DotNet.HotReload;
 
-internal readonly struct WebSocketConfig(int port, int? securePort, string? hostName)
+internal readonly struct WebSocketConfig(int port, int? securePort, string? hostName, ImmutableArray<string> additionalAllowedOrigins)
 {
     /// <summary>
     /// 0 to auto-assign.
@@ -34,6 +35,23 @@ internal readonly struct WebSocketConfig(int port, int? securePort, string? host
         }
     }
 
+    public IEnumerable<string> GetAllowedOriginDomains()
+    {
+        yield return "localhost";
+        yield return "127.0.0.1";
+        yield return "[::1]";
+
+        foreach (var origin in additionalAllowedOrigins)
+        {
+            yield return origin;
+        }
+
+        if (hostName != null)
+        {
+            yield return hostName;
+        }
+    }
+
     public WebSocketConfig WithSecurePort(int? value)
-        => new(port, value, hostName);
+        => new(port, value, hostName, additionalAllowedOrigins);
 }

--- a/src/Dotnet.Watch/HotReloadClient/WebSocketClientTransport.cs
+++ b/src/Dotnet.Watch/HotReloadClient/WebSocketClientTransport.cs
@@ -53,7 +53,7 @@ internal sealed class WebSocketClientTransport : ClientTransport
     /// </summary>
     public static async Task<WebSocketClientTransport> CreateAsync(WebSocketConfig config, ILogger logger, CancellationToken cancellationToken)
     {
-        var handler = new RequestHandler(logger);
+        var handler = new RequestHandler(config, logger);
         var server = await KestrelWebSocketServer.StartServerAsync(config, handler.HandleRequestAsync, cancellationToken);
         var transport = new WebSocketClientTransport(server, handler);
 
@@ -81,7 +81,7 @@ internal sealed class WebSocketClientTransport : ClientTransport
     public override ValueTask<ClientTransportResponse?> ReadAsync(CancellationToken cancellationToken)
         => _handler.ReadAsync(cancellationToken);
 
-    private sealed class RequestHandler(ILogger logger) : IDisposable
+    private sealed class RequestHandler(WebSocketConfig webSocketConfig, ILogger logger) : IDisposable
     {
         public SharedSecretProvider SharedSecretProvider { get; } = new();
         public TaskCompletionSource<WebSocket?> ClientConnectedSource { get; } = new();
@@ -89,7 +89,7 @@ internal sealed class WebSocketClientTransport : ClientTransport
         private WebSocket? _clientSocket;
 
         public bool IsClientSocketAborted
-            => _clientSocket?.State is System.Net.WebSockets.WebSocketState.Aborted;
+            => _clientSocket?.State is WebSocketState.Aborted;
 
         // Reused across WriteAsync calls to avoid allocations.
         // WriteAsync is invoked under a semaphore in DefaultHotReloadClient.
@@ -118,7 +118,15 @@ internal sealed class WebSocketClientTransport : ClientTransport
         {
             if (!context.WebSockets.IsWebSocketRequest)
             {
-                context.Response.StatusCode = 400;
+                context.Response.StatusCode = StatusCodes.Status400BadRequest;
+                return;
+            }
+
+            // check the domain of the Origin header:
+            if (!Uri.TryCreate(context.Request.Headers.Origin.FirstOrDefault(), UriKind.Absolute, out var originUri) ||
+                !webSocketConfig.GetAllowedOriginDomains().Contains(originUri.Host, StringComparer.OrdinalIgnoreCase))
+            {
+                context.Response.StatusCode = StatusCodes.Status403Forbidden;
                 return;
             }
 
@@ -128,7 +136,7 @@ internal sealed class WebSocketClientTransport : ClientTransport
             if (subProtocol == null)
             {
                 logger.LogWarning("WebSocket connection rejected: missing subprotocol (shared secret)");
-                context.Response.StatusCode = 401;
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                 return;
             }
 
@@ -140,7 +148,7 @@ internal sealed class WebSocketClientTransport : ClientTransport
             catch (Exception ex)
             {
                 logger.LogWarning("WebSocket connection rejected: invalid shared secret - {Message}", ex.Message);
-                context.Response.StatusCode = 401;
+                context.Response.StatusCode = StatusCodes.Status401Unauthorized;
                 return;
             }
 

--- a/src/Dotnet.Watch/Watch/Context/EnvironmentOptions.cs
+++ b/src/Dotnet.Watch/Watch/Context/EnvironmentOptions.cs
@@ -60,8 +60,16 @@ internal sealed record EnvironmentOptions(
         RestartOnRudeEdit: EnvironmentVariables.RestartOnRudeEdit,
         CliLogLevel: EnvironmentVariables.CliLogLevel,
         BrowserPath: EnvironmentVariables.BrowserPath,
-        BrowserWebSocketConfig: new(EnvironmentVariables.BrowserWebSocketPort, EnvironmentVariables.BrowserWebSocketSecurePort, EnvironmentVariables.BrowserWebSocketHostName),
-        AgentWebSocketConfig: new(EnvironmentVariables.AgentWebSocketPort, EnvironmentVariables.AgentWebSocketSecurePort, hostName: null),
+        BrowserWebSocketConfig: new(
+            port: EnvironmentVariables.BrowserWebSocketPort,
+            securePort: EnvironmentVariables.BrowserWebSocketSecurePort,
+            hostName: EnvironmentVariables.BrowserWebSocketHostName,
+            additionalAllowedOrigins: EnvironmentVariables.DotNetWatchWebSocketAllowedOrigins),
+        AgentWebSocketConfig: new(
+            port: EnvironmentVariables.AgentWebSocketPort,
+            securePort: EnvironmentVariables.AgentWebSocketSecurePort,
+            hostName: null,
+            additionalAllowedOrigins: []),
         TestFlags: EnvironmentVariables.TestFlags,
         TestOutput: EnvironmentVariables.TestOutputDir
     );

--- a/src/Dotnet.Watch/Watch/Context/EnvironmentVariables.cs
+++ b/src/Dotnet.Watch/Watch/Context/EnvironmentVariables.cs
@@ -1,6 +1,7 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.Watch;
@@ -62,6 +63,13 @@ internal static class EnvironmentVariables
     public static string? BrowserWebSocketHostName => Environment.GetEnvironmentVariable("DOTNET_WATCH_AUTO_RELOAD_WS_HOSTNAME");
 
     /// <summary>
+    /// A list of additional domains, other than localhost and <see cref="BrowserWebSocketHostName"/>,
+    /// allowed as origins of connections to the broser refresh web socket.
+    /// Use when the browser opens the app on a custom domain.
+    /// </summary>
+    public static ImmutableArray<string> DotNetWatchWebSocketAllowedOrigins => ReadList("DOTNET_WATCH_AUTO_RELOAD_WS_ORIGINS", separators: [';', ',']);
+
+    /// <summary>
     /// Port used for browser WebSocket communication. Defaults to 0 (auto-assign) if not specified.
     /// </summary>
     public static int BrowserWebSocketPort => ReadInt("DOTNET_WATCH_AUTO_RELOAD_WS_PORT") ?? 0;
@@ -97,6 +105,11 @@ internal static class EnvironmentVariables
 
     private static int? ReadInt(string variableName)
         => Environment.GetEnvironmentVariable(variableName) is var value && int.TryParse(value, out var intValue) ? intValue : null;
+
+    private static ImmutableArray<string> ReadList(string variableName, char[] separators)
+        => Environment.GetEnvironmentVariable(variableName) is { } value
+            ? [.. value.Split(separators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)]
+            : [];
 
     private static bool ParseBool(string? value)
         => value == "1" || bool.TryParse(value, out var boolValue) && boolValue;

--- a/src/Dotnet.Watch/Watch/HotReload/RunningProjectsManager.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/RunningProjectsManager.cs
@@ -70,7 +70,13 @@ internal sealed class RunningProjectsManager(ProcessRunner processRunner, ILogge
 
         // It is important to first create the named pipe connection (Hot Reload client is the named pipe server)
         // and then start the process (named pipe client). Otherwise, the connection would fail.
-        clients.InitiateConnection(processCommunicationCancellationToken);
+        //
+        // Send project defined environment variables through RPC to avoid leaking potentially sensitive data.
+        // On Linux the command line of a process can be read by other users via `/proc/<pid>/cmdline`.
+        // Only environment variables that are necessary to establish communication with the agent are passed through command line (`-e` switch).
+        // The agent variables can't be set directly on `dotnet run` process as Hot Reload should not be enabled for that process. 
+        // Other variables are not set directly either to avoid leakage to `dotnet build` or other processes that `dotnet run` might execute.
+        clients.InitiateConnection(projectOptions.LaunchEnvironmentVariables, processCommunicationCancellationToken);
 
         RunningProject? publishedRunningProject = null;
 

--- a/src/Dotnet.Watch/Watch/Process/ProjectLauncher.cs
+++ b/src/Dotnet.Watch/Watch/Process/ProjectLauncher.cs
@@ -62,13 +62,6 @@ internal sealed class ProjectLauncher(
 
         var environmentBuilder = new Dictionary<string, string>();
 
-        // initialize with project settings:
-        foreach (var (name, value) in projectOptions.LaunchEnvironmentVariables)
-        {
-            environmentBuilder[name] = value;
-        }
-
-        // override any project settings:
         environmentBuilder[EnvironmentVariables.Names.DotnetWatch] = "1";
         environmentBuilder[EnvironmentVariables.Names.DotnetWatchIteration] = (Iteration + 1).ToString(CultureInfo.InvariantCulture);
 

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientTests.cs
@@ -26,7 +26,7 @@ public class HotReloadClientTests
 
             _cancellationSource = new CancellationTokenSource();
 
-            Client.InitiateConnection(CancellationToken.None);
+            Client.InitiateConnection(environmentVariables: [], CancellationToken.None);
             var agentTransport = new NamedPipeTransport(clientTransport.NamedPipeName, log: _ => { }, timeoutMS: Timeout.Infinite);
             var listener = new Listener(agentTransport, agent, log: _ => { });
             _listenerTaskFactory = Task.Run<Task>(() => listener.Listen(_cancellationSource.Token), testContext.CancellationToken);

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestHotReloadClient.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestHotReloadClient.cs
@@ -15,7 +15,7 @@ internal sealed class TestHotReloadClient() : HotReloadClient(new TestLogger(), 
     {
     }
 
-    public override void InitiateConnection(CancellationToken cancellationToken)
+    public override void InitiateConnection(IReadOnlyCollection<(string name, string value)> environmentVariables, CancellationToken cancellationToken)
     {
     }
 

--- a/test/Microsoft.NET.TestFramework/SdkTestContext.cs
+++ b/test/Microsoft.NET.TestFramework/SdkTestContext.cs
@@ -346,8 +346,7 @@ namespace Microsoft.NET.TestFramework
 
             while (directory is not null)
             {
-                var gitPath = Path.Combine(directory, ".git");
-                if (Directory.Exists(gitPath) || File.Exists(gitPath))
+                if (File.Exists(Path.Combine(directory, "sdk.slnx")))
                 {
                     // Found the repo root, which should either have a .git folder or, if the repo
                     // is part of a Git worktree, a .git file.
@@ -359,17 +358,7 @@ namespace Microsoft.NET.TestFramework
 
             return null;
         }
-        private static string FindOrCreateFolderInTree(string relativePath, string startPath)
-        {
-            string? ret = FindFolderInTree(relativePath, startPath, throwIfNotFound: false);
-            if (ret != null)
-            {
-                return ret;
-            }
-            ret = Path.Combine(startPath, relativePath);
-            Directory.CreateDirectory(ret);
-            return ret;
-        }
+
         private static string? FindFolderInTree(string relativePath, string startPath, bool throwIfNotFound = true)
         {
             string currentPath = startPath;

--- a/test/dotnet-watch-test-browser/Program.cs
+++ b/test/dotnet-watch-test-browser/Program.cs
@@ -12,16 +12,17 @@ if (args is not [var urlArg])
     return -1;
 }
 
-Log($"Test browser opened at '{urlArg}'.");
-
 var url = new Uri(urlArg, UriKind.Absolute);
+var origin = Environment.GetEnvironmentVariable("TEST_BROWSER_ORIGIN_HEADER") ?? urlArg;
+
+Log($"Setting Origin header to '{origin}'.");
 
 var (webSocketUrls, publicKey) = await GetWebSocketUrlsAndPublicKey(url);
 
 var secret = RandomNumberGenerator.GetBytes(32);
 var encryptedSecret = GetEncryptedSecret(publicKey, secret);
 
-using var webSocket = await OpenWebSocket(webSocketUrls, encryptedSecret);
+using var webSocket = await OpenWebSocket(origin, webSocketUrls, encryptedSecret);
 var buffer = new byte[8 * 1024];
 
 while (await TryReceiveMessageAsync(webSocket, message => Log($"Received: {Encoding.UTF8.GetString(message)}")))
@@ -32,7 +33,7 @@ Log("WebSocket closed");
 
 return 0;
 
-static async Task<WebSocket> OpenWebSocket(string[] urls, string encryptedSecret)
+static async Task<WebSocket> OpenWebSocket(string origin, string[] urls, string encryptedSecret)
 {
     foreach (var url in urls)
     {
@@ -40,6 +41,12 @@ static async Task<WebSocket> OpenWebSocket(string[] urls, string encryptedSecret
         {
             var webSocket = new ClientWebSocket();
             webSocket.Options.AddSubProtocol(Uri.EscapeDataString(encryptedSecret));
+
+            if (origin != "")
+            {
+                webSocket.Options.SetRequestHeader("Origin", origin);
+            }
+
             await webSocket.ConnectAsync(new Uri(url), CancellationToken.None);
             return webSocket;
         }
@@ -90,7 +97,7 @@ static async Task<(string[] url, string key)> GetWebSocketUrlsAndPublicKey(Uri b
 {
     var refreshScriptUrl = new Uri(baseUrl, "/_framework/aspnetcore-browser-refresh.js");
 
-    Log($"Fetching: {refreshScriptUrl}");
+    Log($"Fetching '{refreshScriptUrl}'");
 
     using var httpClient = new HttpClient();
     var content = await httpClient.GetStringAsync(refreshScriptUrl);

--- a/test/dotnet-watch.Tests/Browser/BrowserTests.cs
+++ b/test/dotnet-watch.Tests/Browser/BrowserTests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Text.Json;
+using System.Text.RegularExpressions;
 
 namespace Microsoft.DotNet.Watch.UnitTests;
 
@@ -27,6 +28,48 @@ public class BrowserTests : DotNetWatchTestBase
 
     [TestMethod]
     [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)] // https://github.com/dotnet/sdk/issues/53061
+    [DataRow("")]
+    [DataRow("https://nonlocal")]
+    public async Task OriginValidation(string origin)
+    {
+        var testAsset = TestAssets.CopyTestAsset("WatchRazorWithDeps", identifier: origin)
+            .WithSource();
+
+        App.UseTestBrowser();
+        App.EnvironmentVariables.Add("TEST_BROWSER_ORIGIN_HEADER", origin);
+
+        var url = $"http://localhost:{TestOptions.GetTestPort()}";
+        App.Start(testAsset, ["--urls", url], relativeProjectDirectory: "RazorApp", testFlags: TestFlags.ReadKeyFromStdin);
+
+        // Verify that the connection has been rejected:
+        await App.WaitUntilOutputContains(new Regex("🧪 Error connecting to 'ws://localhost:.*': The server returned status code '403' when status code '101' was expected."));
+    }
+
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)] // https://github.com/dotnet/sdk/issues/53061
+    public async Task OriginValidation_Environment()
+    {
+        var testAsset = TestAssets.CopyTestAsset("WatchRazorWithDeps")
+            .WithSource();
+
+        var kestrelUrl = $"http://localhost:{TestOptions.GetTestPort()}";
+        var browserUrl = $"http://myhost:1234";
+
+        App.UseTestBrowser();
+        App.EnvironmentVariables.Add("DOTNET_WATCH_AUTO_RELOAD_WS_ORIGINS", "myhost");
+        App.EnvironmentVariables.Add("TEST_BROWSER_ORIGIN_HEADER", browserUrl);
+
+        App.Start(testAsset, ["--urls", kestrelUrl], relativeProjectDirectory: "RazorApp", testFlags: TestFlags.ReadKeyFromStdin);
+
+        // Verify that the connection has been rejected:
+        await App.WaitUntilOutputContains($"🧪 Fetching '{kestrelUrl}/_framework/aspnetcore-browser-refresh.js'");
+        await App.WaitUntilOutputContains($"🧪 Setting Origin header to '{browserUrl}'.");
+
+        await App.WaitUntilOutputContains(MessageDescriptor.ConnectedToRefreshServer, "Browser #1");
+    }
+
+    [TestMethod]
+    [OSCondition(ConditionMode.Exclude, OperatingSystems.OSX)] // https://github.com/dotnet/sdk/issues/53061
     public async Task BrowserDiagnostics()
     {
         var testAsset = TestAssets.CopyTestAsset("WatchRazorWithDeps")
@@ -34,17 +77,18 @@ public class BrowserTests : DotNetWatchTestBase
 
         App.UseTestBrowser();
 
-        var url = $"http://localhost:{TestOptions.GetTestPort()}";
+        var kestrelUrl = $"http://localhost:{TestOptions.GetTestPort()}";
         var projectDisplay = $"RazorApp ({ToolsetInfo.CurrentTargetFramework})";
 
-        App.Start(testAsset, ["--urls", url], relativeProjectDirectory: "RazorApp", testFlags: TestFlags.ReadKeyFromStdin);
+        App.Start(testAsset, ["--urls", kestrelUrl], relativeProjectDirectory: "RazorApp", testFlags: TestFlags.ReadKeyFromStdin);
 
         await App.WaitUntilOutputContains(MessageDescriptor.UsingBrowserRefreshMiddleware);
         await App.WaitUntilOutputContains(MessageDescriptor.ConfiguredToLaunchBrowser);
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
         // Verify the browser has been launched.
-        await App.WaitUntilOutputContains($"🧪 Test browser opened at '{url}'.");
+        await App.WaitUntilOutputContains($"🧪 Fetching '{kestrelUrl}/_framework/aspnetcore-browser-refresh.js'");
+        await App.WaitUntilOutputContains($"🧪 Setting Origin header to '{kestrelUrl}'.");
 
         // Verify the browser connected to the refresh server.
         await App.WaitUntilOutputContains(MessageDescriptor.ConnectedToRefreshServer, "Browser #1");
@@ -80,8 +124,8 @@ public class BrowserTests : DotNetWatchTestBase
             🧪 Received: {"type":"Reload"}
             """);
 
-        // no other browser message sent:
-        Assert.AreEqual(2, App.Process.Output.Count(line => line.Contains("🧪")));
+        // no other browser refresh messages sent:
+        Assert.AreEqual(2, App.Process.Output.Count(line => line.Contains("🧪 Received:")));
 
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
@@ -104,9 +148,6 @@ public class BrowserTests : DotNetWatchTestBase
             🧪 Received: {"type":"Reload"}
             """);
 
-        // no other browser message sent:
-        Assert.AreEqual(2, App.Process.Output.Count(line => line.Contains("🧪")));
-
         App.Process.ClearOutput();
 
         // valid edit:
@@ -122,7 +163,7 @@ public class BrowserTests : DotNetWatchTestBase
             🧪 Received: {"type":"RefreshBrowser"}
             """);
 
-        // no other browser message sent:
-        Assert.AreEqual(2, App.Process.Output.Count(line => line.Contains("🧪")));
+        // no other browser refresh messages sent:
+        Assert.AreEqual(2, App.Process.Output.Count(line => line.Contains("🧪 Received:")));
     }
 }

--- a/test/dotnet-watch.Tests/HotReload/AspireHotReloadTests.cs
+++ b/test/dotnet-watch.Tests/HotReload/AspireHotReloadTests.cs
@@ -20,6 +20,7 @@ public class AspireHotReloadTests : DotNetWatchTestBase
         var serviceProjectDisplay = $"WatchAspire.ApiService ({ToolsetInfo.CurrentTargetFramework})";
         var webProjectDisplay = $"WatchAspire.Web ({ToolsetInfo.CurrentTargetFramework})";
         var hostProjectDisplay = $"WatchAspire.AppHost ({ToolsetInfo.CurrentTargetFramework})";
+        var migrationProjectDisplay = $"WatchAspire.MigrationService ({ToolsetInfo.CurrentTargetFramework})";
 
         var serviceSourcePath = Path.Combine(testAsset.Path, "WatchAspire.ApiService", "Program.cs");
         var serviceProjectPath = Path.Combine(testAsset.Path, "WatchAspire.ApiService", "WatchAspire.ApiService.csproj");
@@ -30,10 +31,17 @@ public class AspireHotReloadTests : DotNetWatchTestBase
 
         App.Start(testAsset, ["-lp", "http"], relativeProjectDirectory: "WatchAspire.AppHost", testFlags: TestFlags.ReadKeyFromStdin);
 
+        // DEBUG_* environment variables should be set for app host process:
+        await App.WaitUntilOutputContains($"dotnet watch 🕵️ [{hostProjectDisplay}] Setting environment variables (3)");
         await App.WaitUntilOutputContains(MessageDescriptor.WaitingForChanges);
 
         // check that Aspire server output is logged via dotnet-watch reporter:
         await App.WaitUntilOutputContains("dotnet watch ⭐ Now listening on:");
+        
+        // environment variables should be set for all resource processes:
+        await App.WaitUntilOutputContains($"dotnet watch 🕵️ [{migrationProjectDisplay}] Setting environment variables");
+        await App.WaitUntilOutputContains($"dotnet watch 🕵️ [{serviceProjectDisplay}] Setting environment variables");
+        await App.WaitUntilOutputContains($"dotnet watch 🕵️ [{webProjectDisplay}] Setting environment variables");
 
         // wait until after all DCP sessions have started:
         await App.WaitUntilOutputContains("dotnet watch ⭐ [#1] Session started");


### PR DESCRIPTION
[CVE-2026-58649](https://github.com/dotnet/sdk/issues/56166)

Only accept web socket requests with allowed origin header to prevent remote access to the web socket connection.
By default we allow localhost and `DOTNET_WATCH_AUTO_RELOAD_WS_HOSTNAME`. In case someone uses custom domain mapping for their application they can set `DOTNET_WATCH_AUTO_RELOAD_WS_ORIGINS` to include the host name in addition to the defaults.

[CVE-2026-69806](https://github.com/dotnet/sdk/issues/56167)

Pass project specified environment variables via RPC to the agent to set them in the target process, instead of passing them via command line (`-e`) variable.
