### PR TITLE
Cache dependency-sorted template macros

### DIFF
--- a/src/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunConfig.cs
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/GlobalRunConfig.cs
@@ -9,6 +9,13 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
 {
     internal class GlobalRunConfig
     {
+        private readonly Lazy<IReadOnlyList<IMacroConfig>> _sortedMacros;
+
+        internal GlobalRunConfig()
+        {
+            _sortedMacros = new(() => MacroProcessor.SortMacroConfigsByDependencies(SymbolNames, Macros));
+        }
+
         public IReadOnlyList<IOperationProvider> Operations { get; init; } = [];
 
         public IVariableConfig VariableSetup { get; init; } = VariableConfig.Default;
@@ -20,5 +27,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
         public IReadOnlyList<string> SymbolNames { get; init; } = [];
 
         public IReadOnlyList<IMacroConfig> Macros { get; init; } = [];
+
+        internal IReadOnlyList<IMacroConfig> SortedMacros => _sortedMacros.Value;
     }
 }

--- a/src/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
+++ b/src/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects/RunnableProjectGenerator.cs
@@ -131,8 +131,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             IVariableCollection variables = SetupVariables(parameters, templateConfig.GlobalOperationConfig.VariableSetup);
             await templateConfig.EvaluateBindSymbolsAsync(environmentSettings, variables, cancellationToken).ConfigureAwait(false);
             cancellationToken.ThrowIfCancellationRequested();
-            IReadOnlyList<IMacroConfig> sortedMacroConfigs = MacroProcessor.SortMacroConfigsByDependencies(templateConfig.GlobalOperationConfig.SymbolNames, templateConfig.GlobalOperationConfig.Macros);
-            MacroProcessor.ProcessMacros(environmentSettings, sortedMacroConfigs, variables);
+            MacroProcessor.ProcessMacros(environmentSettings, templateConfig.GlobalOperationConfig.SortedMacros, variables);
             templateConfig.Evaluate(variables);
 
             IOrchestrator basicOrchestrator = new Core.Util.Orchestrator(environmentSettings.Host.Logger, environmentSettings.Host.FileSystem);
@@ -308,8 +307,7 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects
             await runnableProjectConfig.EvaluateBindSymbolsAsync(environmentSettings, variables, cancellationToken).ConfigureAwait(false);
 
             cancellationToken.ThrowIfCancellationRequested();
-            IReadOnlyList<IMacroConfig> sortedMacroConfigs = MacroProcessor.SortMacroConfigsByDependencies(runnableProjectConfig.GlobalOperationConfig.SymbolNames, runnableProjectConfig.GlobalOperationConfig.Macros);
-            MacroProcessor.ProcessMacros(environmentSettings, sortedMacroConfigs, variables);
+            MacroProcessor.ProcessMacros(environmentSettings, runnableProjectConfig.GlobalOperationConfig.SortedMacros, variables);
             runnableProjectConfig.Evaluate(variables);
 
             IOrchestrator basicOrchestrator = new Core.Util.Orchestrator(environmentSettings.Host.Logger, environmentSettings.Host.FileSystem);

--- a/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroProcessorTests.cs
+++ b/test/TemplateEngine/Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests/MacroProcessorTests.cs
@@ -241,6 +241,23 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
         }
 
         [TestMethod]
+        public void GlobalRunConfigCachesSortedMacros()
+        {
+            DependencyMacroConfig macroConfig = new("dependent", "source");
+            GlobalRunConfig runConfig = new()
+            {
+                Macros = [macroConfig],
+                SymbolNames = ["source", "dependent"]
+            };
+            IReadOnlyList<IMacroConfig>[] sortedMacros = new IReadOnlyList<IMacroConfig>[16];
+
+            Parallel.For(0, sortedMacros.Length, iteration => sortedMacros[iteration] = runConfig.SortedMacros);
+
+            Assert.IsTrue(sortedMacros.All(sorted => ReferenceEquals(sortedMacros[0], sorted)));
+            Assert.AreEqual(1, macroConfig.ResolveCount);
+        }
+
+        [TestMethod]
         public void CanThrowErrorOnSortWhenMacrosHaveDepsCircle()
         {
             var switchMacroName = "switchMacro";
@@ -278,18 +295,21 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 
             IEngineEnvironmentSettings engineEnvironmentSettings = s_environmentSettingsHelper.CreateEnvironment(virtualize: true, environment: environment, additionalComponents: new[] { (typeof(IMacro), (IIdentifiedComponent)macro) });
 
-            IReadOnlyList<IMacroConfig> macros = new[] { (IMacroConfig)new UndeterministicMacroConfig("test"), new GuidMacroConfig("test-guid", "string", "Nn", "n") };
+            GlobalRunConfig runConfig = new()
+            {
+                Macros = [(IMacroConfig)new UndeterministicMacroConfig("test"), new GuidMacroConfig("test-guid", "string", "Nn", "n")]
+            };
 
             IVariableCollection collection = new VariableCollection();
 
-            MacroProcessor.ProcessMacros(engineEnvironmentSettings, macros, collection);
+            MacroProcessor.ProcessMacros(engineEnvironmentSettings, runConfig.SortedMacros, collection);
             Assert.AreEqual("deterministic", collection["test"]);
             Assert.AreEqual(new Guid("12345678-1234-1234-1234-1234567890AB").ToString("n"), collection["test-guid"]);
 
             A.CallTo(() => environment.GetEnvironmentVariable("TEMPLATE_ENGINE_ENABLE_DETERMINISTIC_MODE")).Returns("false");
             collection = new VariableCollection();
 
-            MacroProcessor.ProcessMacros(engineEnvironmentSettings, macros, collection);
+            MacroProcessor.ProcessMacros(engineEnvironmentSettings, runConfig.SortedMacros, collection);
             Assert.AreEqual("undeterministic", collection["test"]);
             Assert.AreNotEqual(new Guid("12345678-1234-1234-1234-1234567890AB").ToString("n"), collection["test-guid"]);
         }
@@ -481,13 +501,18 @@ namespace Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests
 
             public HashSet<string> Dependencies { get; private set; } = new HashSet<string>();
 
+            public int ResolveCount => _resolveCount;
+
             public void ResolveSymbolDependencies(IReadOnlyList<string> symbols)
             {
+                Interlocked.Increment(ref _resolveCount);
                 Dependencies = new HashSet<string>()
                 {
                     DependentSymbolName
                 };
             }
+
+            private int _resolveCount;
         }
     }
 }


### PR DESCRIPTION
## Summary

- compute the dependency-sorted macro list lazily once per `GlobalRunConfig`
- reuse that order for dry-run and creation while continuing to evaluate macro values on every pass
- use `Lazy<T>` publication semantics to make concurrent first access safe
- cover concurrent access and repeated nondeterministic macro evaluation

## Performance

Measured as a direct same-HEAD inverse-patch pair with Windows x64 Release ReadyToRun `11.0.100-dev` SDKs. Binary manifests differed only in the expected Template Engine/CLI assemblies. Processes alternated between arms with isolated CLI homes and subject-bound template state; all timed comparisons had zero semantic mismatches.

| Scenario (15 pairs) | Control median | Changed median | Median paired improvement |
| --- | ---: | ---: | ---: |
| `dotnet new web` (template-fresh) | 343.420 ms | 336.878 ms | 2.21% |
| CLI help (initialized) | 139.219 ms | 137.057 ms | 1.42% |
| `dotnet new webapp` (template-fresh) | 394.069 ms | 388.641 ms | 1.19% |

The other timed scenarios were effectively flat: classlib -0.02%, template help -0.75%, and list -0.95% by median paired ratio.

Across 16 valid paired operations in four same-session ETW captures at a 0.25 ms sampling interval, sampled CPU fell from **301.234 ms/op** to **299.563 ms/op** (**0.56%**); 11 of 16 pairs were faster.

For `dotnet new console --no-restore`, median sampled allocation across three EventPipe `gc-verbose` captures fell from **19,322,792 B** to **17,550,512 B**: **1,772,280 B (9.17%) less**. Allocation under the macro-sort stack ancestry fell from 3,395,920 B to 1,805,264 B (46.84% less). Neither arm recorded a GC.

`GCAllocationTick` values vary at sampling granularity. Inclusive stack rows overlap and were not added together.

## Testing

- `MacroProcessorTests`: 10/10 passed on Debug `net11.0` and `net481`
- complete `Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests`: 510 passed, 2 skipped, 0 failed on Release `net11.0`
- complete `Microsoft.TemplateEngine.Orchestrator.RunnableProjects.UnitTests`: 499 passed, 2 skipped, 0 failed on Release `net481`