### PR TITLE
Avoid template engine initialization for generic help

### DIFF
--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.Help.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/NewCommand.Help.cs
@@ -17,8 +17,13 @@ namespace Microsoft.TemplateEngine.Cli.Commands
                     throw new ArgumentException($"{nameof(context)} should be for {nameof(NewCommand)}");
                 }
                 NewCommandArgs args = new(newCommand, context.ParseResult);
-                using IEngineEnvironmentSettings environmentSettings = CreateEnvironmentSettings(args, context.ParseResult);
                 InstantiateCommandArgs instantiateCommandArgs = InstantiateCommandArgs.FromNewCommandArgs(args);
+                if (InstantiateCommand.TryWriteCommandHelp(context, instantiateCommandArgs))
+                {
+                    return;
+                }
+
+                using IEngineEnvironmentSettings environmentSettings = CreateEnvironmentSettings(args, context.ParseResult);
                 InstantiateCommand.WriteHelp(context, instantiateCommandArgs, environmentSettings);
             };
         }

--- a/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.Help.cs
+++ b/src/Cli/Microsoft.TemplateEngine.Cli/Commands/create/InstantiateCommand.Help.cs
@@ -19,12 +19,6 @@ namespace Microsoft.TemplateEngine.Cli.Commands
 
         public static void WriteHelp(HelpContext context, InstantiateCommandArgs instantiateCommandArgs, IEngineEnvironmentSettings environmentSettings)
         {
-            if (string.IsNullOrWhiteSpace(instantiateCommandArgs.ShortName))
-            {
-                WriteCustomInstantiateHelp(context, instantiateCommandArgs.NewOrInstantiateCommand);
-                return;
-            }
-
             using TemplatePackageManager templatePackageManager = new(environmentSettings);
             HostSpecificDataLoader hostSpecificDataLoader = new(environmentSettings);
 
@@ -92,9 +86,25 @@ namespace Microsoft.TemplateEngine.Cli.Commands
             yield return (context) =>
             {
                 InstantiateCommandArgs instantiateCommandArgs = new(this, context.ParseResult);
+                if (TryWriteCommandHelp(context, instantiateCommandArgs))
+                {
+                    return;
+                }
+
                 using IEngineEnvironmentSettings environmentSettings = CreateEnvironmentSettings(instantiateCommandArgs, context.ParseResult);
                 WriteHelp(context, instantiateCommandArgs, environmentSettings);
             };
+        }
+
+        internal static bool TryWriteCommandHelp(HelpContext context, InstantiateCommandArgs instantiateCommandArgs)
+        {
+            if (!string.IsNullOrWhiteSpace(instantiateCommandArgs.ShortName))
+            {
+                return false;
+            }
+
+            WriteCustomInstantiateHelp(context, instantiateCommandArgs.NewOrInstantiateCommand);
+            return true;
         }
 
         internal static bool VerifyMatchingTemplates(

--- a/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.cs
+++ b/test/Microsoft.TemplateEngine.Cli.UnitTests/ParserTests/HelpTests.cs
@@ -3,6 +3,7 @@
 
 using System.CommandLine;
 using FakeItEasy;
+using Microsoft.DotNet.Cli.Commands.New;
 using Microsoft.DotNet.Cli.Help;
 using Microsoft.TemplateEngine.Abstractions;
 using Microsoft.TemplateEngine.Cli.Commands;
@@ -15,6 +16,41 @@ namespace Microsoft.TemplateEngine.Cli.UnitTests.ParserTests
     [TestClass]
     public partial class HelpTests : VerifyBase
     {
+        [TestMethod]
+        [DataRow("")]
+        [DataRow("create")]
+        public void GenericHelpDoesNotCreateHost(string commandLine)
+        {
+            int hostCreationCount = 0;
+            using ICliTemplateEngineHost host = CliTestHostFactory.GetVirtualHost();
+            NewCommand command = (NewCommand)NewCommandFactory.Create(
+                _ =>
+                {
+                    hostCreationCount++;
+                    return host;
+                },
+                new NewCommandDefinition());
+            ParseResult parseResult = command.Parse(commandLine);
+            ICustomHelp helpCommand = (ICustomHelp)parseResult.CommandResult.Command;
+            InstantiateCommandArgs instantiateCommandArgs = helpCommand switch
+            {
+                NewCommand newCommand => InstantiateCommandArgs.FromNewCommandArgs(new NewCommandArgs(newCommand, parseResult)),
+                InstantiateCommand instantiateCommand => new InstantiateCommandArgs(instantiateCommand, parseResult),
+                _ => throw new InvalidOperationException()
+            };
+            Assert.IsNull(instantiateCommandArgs.ShortName);
+            StringWriter output = new();
+            HelpContext helpContext = new(new HelpBuilder(), parseResult.CommandResult.Command, output, parseResult);
+
+            foreach (Action<HelpContext> helpBlock in helpCommand.CustomHelpLayout())
+            {
+                helpBlock(helpContext);
+            }
+
+            Assert.AreNotEqual(string.Empty, output.ToString());
+            Assert.AreEqual(0, hostCreationCount);
+        }
+
         [TestMethod]
 #pragma warning disable SA1117 // Parameters should be on same line or separate lines
         [DataRow("Template Name", "Language", "Me", "Template Description",


### PR DESCRIPTION
## Summary

- handle generic `dotnet new --help` and `dotnet new create --help` before creating the Template Engine host and environment
- preserve the existing Template Engine initialization path for template-specific help
- add coverage proving generic help does not construct the host

## Performance

Measured with a Windows x64 Release ReadyToRun `11.0.100-dev` SDK, alternating fresh processes, isolated CLI homes, and equivalent prepared template state.

- 30/30 paired runs were faster with byte-for-byte equivalent output
- median elapsed time fell from **139.913 ms** to **109.444 ms**: **21.79% faster**
- median sampled allocation across five EventPipe `gc-verbose` pairs fell from **1,915,480 B** to **1,490,776 B**: **424,704 B (22.17%) lower**
- the `CreateEnvironmentSettings` and `NewCommandParser.CreateHost` allocation subtrees were absent from all candidate captures
- GC count remained zero in every capture

`GCAllocationTick` values vary at sampling granularity.

## Testing

- `HelpTests`: 37/37 passed on Release `net11.0`
- product-backed `DotnetNewHelpTests`: 38/38 passed on Release `net11.0`
- mutation check: restoring eager environment creation causes both generic-help host-count cases to fail