### PR TITLE
Add cross-module inlining for Roslyn assemblies

### DIFF
--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -40,6 +40,7 @@
       <DefaultToolTfm>$(SdkTargetFramework)</DefaultToolTfm>
 
       <NetSdkAnalyzers>$(InstallerOutputDirectory)Sdks\Microsoft.NET.Sdk\analyzers\</NetSdkAnalyzers>
+      <NetSdkCodeStyle>$(InstallerOutputDirectory)Sdks\Microsoft.NET.Sdk\codestyle\</NetSdkCodeStyle>
       <NetSdkTools>$(InstallerOutputDirectory)Sdks\Microsoft.NET.Sdk\tools\$(DefaultToolTfm)\</NetSdkTools>
       <BlazorWasmTools>$(InstallerOutputDirectory)Sdks\Microsoft.NET.Sdk.BlazorWebAssembly\tools\$(DefaultToolTfm)\</BlazorWasmTools>
       <RazorSourceGenerators>$(InstallerOutputDirectory)Sdks\Microsoft.NET.Sdk.Razor\source-generators\</RazorSourceGenerators>
@@ -71,6 +72,7 @@
 
       <!-- Add back the .NET Core assemblies in the Sdks folder -->
       <RemainingFiles Include="$(NetSdkAnalyzers)**\*" />
+      <RemainingFiles Include="$(NetSdkCodeStyle)**\*" />
       <RemainingFiles Include="$(NetSdkTools)**\*" />
       <RemainingFiles Include="$(BlazorWasmTools)**\*" />
       <RemainingFiles Include="$(RazorSourceGenerators)**\*" />
@@ -83,7 +85,8 @@
 
       <!-- Don't crossgen VB since the usage doesn't justify the size cost for everyone -->
       <RoslynFiles Remove="$(InstallerOutputDirectory)**\Microsoft.CodeAnalysis.VisualBasic*.dll" />
-      <RemainingFiles Remove="$(InstallerOutputDirectory)**\Microsoft.CodeAnalysis.VisualBasic*.dll" />
+      <RemainingFiles Remove="$(InstallerOutputDirectory)**\Microsoft.CodeAnalysis.VisualBasic*.dll;
+                              $(NetSdkCodeStyle)vb\**\*" />
 
       <!-- Don't try to CrossGen .NET Framework support assemblies for .NET Standard -->
       <RemainingFiles Remove="$(InstallerOutputDirectory)Microsoft\Microsoft.NET.Build.Extensions\net*\**\*" />
@@ -127,6 +130,19 @@
     <!-- Remove DotnetTools-unique assemblies from crossgen -->
     <ItemGroup>
       <RemainingFiles Remove="@(_DotnetToolsUniqueFiles)" />
+
+    </ItemGroup>
+
+    <ItemGroup>
+
+      <RemainingRoslynOptimizationFiles Include="$(InstallerOutputDirectory)Microsoft.CodeAnalysis*.dll;
+                                                       $(NetSdkAnalyzers)**\*;
+                                                       $(NetSdkCodeStyle)**\*;
+                                                       $(RazorSourceGenerators)**\*" />
+      <RemainingRoslynOptimizationFiles Remove="$(NetSdkAnalyzers)Microsoft.CodeAnalysis.VisualBasic.NetAnalyzers.dll;
+                                              $(NetSdkCodeStyle)vb\**\*;
+                                              $(InstallerOutputDirectory)**\*.resources.dll;
+                                              $(InstallerOutputDirectory)**\ref\*.dll" />
     </ItemGroup>
 
     <AddMetadataIsPE Items="@(RoslynFiles)">
@@ -141,17 +157,26 @@
     <AddMetadataIsPE Items="@(RemainingFiles)">
       <Output TaskParameter="ResultItems" ItemName="RemainingFilesWithPEMarker" />
     </AddMetadataIsPE>
+    <AddMetadataIsPE Items="@(RemainingRoslynOptimizationFiles)">
+      <Output TaskParameter="ResultItems" ItemName="RemainingRoslynOptimizationFilesWithPEMarker" />
+    </AddMetadataIsPE>
 
     <ItemGroup>
       <RoslynTargets Include="%(RoslynFilesWithPEMarker.FullPath)" Condition=" '%(RoslynFilesWithPEMarker.IsPE)' == 'True' " />
       <FSharpTargets Include="%(FSharpFilesWithPEMarker.FullPath)" Condition=" '%(FSharpFilesWithPEMarker.IsPE)' == 'True' " />
       <RazorToolTargets Include="%(RazorToolFilesWithPEMarker.FullPath)" Condition=" '%(RazorToolFilesWithPEMarker.IsPE)' == 'True' " />
       <RemainingTargets Include="%(RemainingFilesWithPEMarker.FullPath)" Condition=" '%(RemainingFilesWithPEMarker.IsPE)' == 'True' " />
+      <RemainingRoslynOptimizationTargets Include="%(RemainingRoslynOptimizationFilesWithPEMarker.FullPath)"
+                                          Condition=" '%(RemainingRoslynOptimizationFilesWithPEMarker.IsPE)' == 'True' " />
+
+      <RemainingStandaloneTargets Include="@(RemainingTargets)"
+                                  Exclude="@(RemainingRoslynOptimizationTargets)" />
 
       <RoslynFolders Include="@(RoslynTargets-&gt;DirectoryName()-&gt;Distinct())" />
       <FSharpFolders Include="@(FSharpTargets-&gt;DirectoryName()-&gt;Distinct())" />
       <RazorToolFolders Include="@(RazorToolTargets-&gt;DirectoryName()-&gt;Distinct())" />
       <RemainingFolders Include="@(RemainingTargets-&gt;DirectoryName()-&gt;Distinct())" />
+      <RemainingRoslynOptimizationFolders Include="@(RemainingRoslynOptimizationTargets-&gt;DirectoryName()-&gt;Distinct())" />
 
       <!-- FSharp.Build.dll causes the FSharp folder to be included. Remove it, as we don't want other FSharp dlls being included in the crossgen. -->
       <RemainingFolders Remove="$(PublishDir)FSharp\**\*" />
@@ -164,8 +189,11 @@
       <RemainingFolders Include="$(InstallerOutputDirectory.TrimEnd('\').TrimEnd('/'))" />
     </ItemGroup>
 
+    <Error Text="Potentially missed crossgen for '$(NetSdkAnalyzers)', directory does not exist" Condition= "!EXISTS('$(NetSdkAnalyzers)') " />
+    <Error Text="Potentially missed crossgen for '$(NetSdkCodeStyle)', directory does not exist" Condition= "!EXISTS('$(NetSdkCodeStyle)') " />
     <Error Text="Potentially missed crossgen for '$(NetSdkTools)', directory does not exist" Condition= "!EXISTS('$(NetSdkTools)') " />
     <Error Text="Potentially missed crossgen for '$(BlazorWasmTools)', directory does not exist" Condition= "!EXISTS('$(BlazorWasmTools)') " />
+    <Error Text="Potentially missed crossgen for '$(RazorSourceGenerators)', directory does not exist" Condition= "!EXISTS('$(RazorSourceGenerators)') " />
     <Error Text="Potentially missed crossgen for '$(RazorTasks)', directory does not exist" Condition= "!EXISTS('$(RazorTasks)') " />
     <Error Text="Potentially missed crossgen for '$(WindowsDesktopTools)', directory does not exist" Condition= "!EXISTS('$(WindowsDesktopTools)') AND '$(DotNetBuildSourceOnly)' != 'true'" />
     <Error Text="Potentially missed crossgen for '$(PublishTools)', directory does not exist" Condition= "!EXISTS('$(PublishTools)') " />
@@ -175,7 +203,12 @@
     <Error Text="Potentially missed crossgen for Roslyn, RoslynTargets is empty" Condition= "@(RoslynTargets) == ''" />
     <Error Text="Potentially missed crossgen for FSharp, FSharpTargets is empty" Condition= "@(FSharpTargets) == ''" />
     <Error Text="Potentially missed crossgen for Razor, RazorToolTargets is empty" Condition= "@(RazorToolTargets) == ''" />
+    <Error Text="Potentially missed optimized crossgen for Roslyn dependencies, RemainingRoslynOptimizationTargets is empty" Condition= "@(RemainingRoslynOptimizationTargets) == ''" />
     <Error Text="Potentially missed crossgen for other SDK files, RemainingTargets is empty" Condition= "@(RemainingTargets) == ''" />
+
+    <ItemGroup>
+      <RoslynCrossModuleInliningAssembly Include="System.Reflection.Metadata;System.Collections.Immutable" />
+    </ItemGroup>
 
     <Crossgen
         SourceAssembly="%(RoslynTargets.FullPath)"
@@ -184,6 +217,8 @@
         TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
         CreateSymbols="$(CreateCrossgenSymbols)"
+        CrossModuleInliningAssemblies="@(RoslynCrossModuleInliningAssembly)"
+        NonLocalGenericsModule="%(RoslynTargets.Filename)"
         PlatformAssemblyPaths="@(RoslynFolders);$(SharedFrameworkNameVersionPath)" />
 
     <Crossgen
@@ -196,8 +231,9 @@
         PlatformAssemblyPaths="@(FSharpFolders);$(SharedFrameworkNameVersionPath)" />
 
     <Crossgen
-        SourceAssembly="%(RemainingTargets.FullPath)"
-        DestinationPath="%(RemainingTargets.FullPath)"
+        Condition="'@(RemainingStandaloneTargets)' != ''"
+        SourceAssembly="%(RemainingStandaloneTargets.FullPath)"
+        DestinationPath="%(RemainingStandaloneTargets.FullPath)"
         TargetArchitecture="$(TargetArchitecture)"
         TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
@@ -211,7 +247,19 @@
         TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
         CreateSymbols="$(CreateCrossgenSymbols)"
+        CrossModuleInliningAssemblies="@(RoslynCrossModuleInliningAssembly)"
+        NonLocalGenericsModule="%(RazorToolTargets.Filename)"
         PlatformAssemblyPaths="@(RazorToolFolders);@(RoslynFolders);$(SharedFrameworkNameVersionPath)" />
+
+    <Crossgen
+        SourceAssembly="%(RemainingRoslynOptimizationTargets.FullPath)"
+        DestinationPath="%(RemainingRoslynOptimizationTargets.FullPath)"
+        Architecture="$(TargetArchitecture)"
+        CrossgenPath="$(CrossgenPath)"
+        CreateSymbols="$(CreateCrossgenSymbols)"
+        CrossModuleInliningAssemblies="@(RoslynCrossModuleInliningAssembly)"
+        NonLocalGenericsModule="%(RemainingRoslynOptimizationTargets.Filename)"
+        PlatformAssemblyPaths="@(RemainingRoslynOptimizationFolders);@(RoslynFolders);$(SharedFrameworkNameVersionPath)" />
 
     <ItemGroup>
       <PdbsToMove Include="$(InstallerOutputDirectory)**/*.pdb" />

--- a/src/Layout/redist/targets/Crossgen.targets
+++ b/src/Layout/redist/targets/Crossgen.targets
@@ -254,7 +254,8 @@
     <Crossgen
         SourceAssembly="%(RemainingRoslynOptimizationTargets.FullPath)"
         DestinationPath="%(RemainingRoslynOptimizationTargets.FullPath)"
-        Architecture="$(TargetArchitecture)"
+        TargetArchitecture="$(TargetArchitecture)"
+        TargetOS="$(_CrossgenTargetOS)"
         CrossgenPath="$(CrossgenPath)"
         CreateSymbols="$(CreateCrossgenSymbols)"
         CrossModuleInliningAssemblies="@(RoslynCrossModuleInliningAssembly)"

--- a/src/Tasks/sdk-tasks/Crossgen.cs
+++ b/src/Tasks/sdk-tasks/Crossgen.cs
@@ -3,12 +3,14 @@
 
 #nullable disable
 
+using System.Text;
+
 namespace Microsoft.DotNet.Build.Tasks
 {
     public sealed class Crossgen : ToolTask
     {
         [Required]
-        public string SourceAssembly { get;set; }
+        public string SourceAssembly { get; set; }
 
         [Required]
         public string DestinationPath { get; set; }
@@ -23,18 +25,24 @@ namespace Microsoft.DotNet.Build.Tasks
 
         public bool CreateSymbols { get; set; }
 
+        public ITaskItem[] CrossModuleInliningAssemblies { get; set; }
+
+        public string NonLocalGenericsModule { get; set; }
+
         public ITaskItem[] PlatformAssemblyPaths { get; set; }
 
         private string TempOutputPath { get; set; }
 
         protected override bool ValidateParameters()
         {
-            base.ValidateParameters();
+            if (!base.ValidateParameters())
+            {
+                return false;
+            }
 
             if (!File.Exists(SourceAssembly))
             {
-                Log.LogError($"SourceAssembly '{SourceAssembly}' does not exist.");
-
+                Log.LogError($"Source assembly '{SourceAssembly}' does not exist.");
                 return false;
             }
 
@@ -47,28 +55,35 @@ namespace Microsoft.DotNet.Build.Tasks
             Directory.CreateDirectory(tempDirPath);
             TempOutputPath = Path.Combine(tempDirPath, Path.GetFileName(DestinationPath));
 
-            var toolResult = base.Execute();
-
-            if (toolResult)
+            try
             {
-                var files = Directory.GetFiles(Path.GetDirectoryName(TempOutputPath));
-                var destination = Path.GetDirectoryName(DestinationPath);
-                // Copy both dll and pdb files to the destination folder
-                foreach(var file in files)
+                bool toolResult = base.Execute();
+                if (!toolResult)
                 {
-                    File.Copy(file, Path.Combine(destination, Path.GetFileName(file)), overwrite: true);
-                    // Delete file in temp
-                    File.Delete(file);
+                    return false;
+                }
+
+                if (!File.Exists(TempOutputPath))
+                {
+                    Log.LogError($"Crossgen2 did not produce output assembly '{TempOutputPath}'.");
+                    return false;
+                }
+
+                string destinationDirectory = Path.GetDirectoryName(DestinationPath);
+                foreach (string file in Directory.GetFiles(tempDirPath))
+                {
+                    File.Copy(file, Path.Combine(destinationDirectory, Path.GetFileName(file)), overwrite: true);
+                }
+
+                return true;
+            }
+            finally
+            {
+                if (Directory.Exists(tempDirPath))
+                {
+                    Directory.Delete(tempDirPath, recursive: true);
                 }
             }
-
-            if (File.Exists(TempOutputPath))
-            {
-                File.Delete(TempOutputPath);
-            }
-            Directory.Delete(tempDirPath);
-
-            return toolResult;
         }
 
         protected override string ToolName => "crossgen2";
@@ -105,30 +120,53 @@ namespace Microsoft.DotNet.Build.Tasks
 
         protected override string GenerateFullPathToTool() => CrossgenPath ?? "crossgen2";
 
-        protected override string GenerateCommandLineCommands() => $"{GetInPath()} {GetOutPath()} {GetTargetOS()} {GetArchitecture()} {GetPlatformAssemblyPaths()} {GetCreateSymbols()}";
+        protected override string GenerateCommandLineCommands() => GenerateCommandLineCommands(TempOutputPath);
+
+        private string GenerateCommandLineCommands(string outputPath)
+            => $"{GetInPath()} -o \"{outputPath}\" {GetTargetOS()} {GetArchitecture()} {GetPlatformAssemblyPaths()} {GetCreateSymbols()} {GetCrossModuleOptions()}".Trim();
 
         private string GetArchitecture() => $"--targetarch {TargetArchitecture}";
 
         private string GetTargetOS() => $"--targetos {TargetOS}";
 
-        private string GetCreateSymbols() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "--pdb" : "--perfmap";
+        private string GetCreateSymbols()
+            => CreateSymbols
+                ? RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "--pdb" : "--perfmap"
+                : string.Empty;
 
         private string GetInPath() => $"\"{SourceAssembly}\"";
 
-        private string GetOutPath() => $"-o \"{TempOutputPath}\"";
-
         private string GetPlatformAssemblyPaths()
         {
-            var platformAssemblyPaths = string.Empty;
+            var platformAssemblyPaths = new StringBuilder();
             if (PlatformAssemblyPaths != null)
             {
-                foreach (var excludeTaskItem in PlatformAssemblyPaths)
+                foreach (var platformAssemblyPath in PlatformAssemblyPaths)
                 {
-                    platformAssemblyPaths += $"-r {excludeTaskItem.ItemSpec}{Path.DirectorySeparatorChar}*.dll ";
+                    platformAssemblyPaths.Append($"-r \"{platformAssemblyPath.ItemSpec}{Path.DirectorySeparatorChar}*.dll\" ");
                 }
             }
-            
-            return platformAssemblyPaths;
+
+            return platformAssemblyPaths.ToString();
+        }
+
+        private string GetCrossModuleOptions()
+        {
+            var options = new StringBuilder();
+            if (CrossModuleInliningAssemblies != null)
+            {
+                foreach (var assembly in CrossModuleInliningAssemblies)
+                {
+                    options.Append($"--opt-cross-module:\"{assembly.ItemSpec}\" ");
+                }
+            }
+
+            if (!string.IsNullOrEmpty(NonLocalGenericsModule))
+            {
+                options.Append($"--non-local-generics-module:\"{NonLocalGenericsModule}\"");
+            }
+
+            return options.ToString();
         }
 
         protected override void LogToolCommand(string message) => base.LogToolCommand($"{GetWorkingDirectory()}> {message}");

--- a/src/Tasks/sdk-tasks/sdk-tasks.csproj
+++ b/src/Tasks/sdk-tasks/sdk-tasks.csproj
@@ -12,6 +12,7 @@
   <ItemGroup>
     <Compile Include="$(RepoRoot)src\Resolvers\Microsoft.NET.Sdk.WorkloadManifestReader\SdkFeatureBand.cs" LinkBase="Common"/>
     <Compile Include="$(RepoRoot)src\Common\WorkloadSetVersion.cs" LinkBase="Common" />
+    <InternalsVisibleTo Include="sdk-tasks.Tests" Key="$(MicrosoftAspNetCorePublicKey)" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- enable Crossgen2 cross-module optimization for Roslyn and Razor compiler assemblies using `System.Collections.Immutable` and `System.Reflection.Metadata`
- apply the same optimization mode to Roslyn-related SDK analyzers, C# CodeStyle assemblies, and Razor source generators
- designate each output assembly as its non-local generics module
- pass the required target architecture and target OS to the new Crossgen invocation

## ReadyToRun impact

For a Windows x64 Release SDK layout, compared with the parent commit:

- 27,002 newly emitted R2R method bodies after deduplicating identical assembly copies
- 1,476 previously emitted R2R method bodies removed
- 25,526 net additional R2R method bodies
- 21,251 additions are from four C# CodeStyle assemblies newly entering Crossgen
- 5,751 additions are in assemblies that were already Crossgened

Distinct generic instantiations are counted as separate R2R method bodies.

## Validation

Ran the Release Windows x64 `CrossgenLayout` target with the repository-selected Crossgen2 package.
