### PR TITLE
Send process id from the agent to the client in initial response.

### DIFF
--- a/src/Dotnet.Watch/HotReloadAgent.Host/Listener.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/Listener.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.DotNet.HotReload;
 
-internal sealed class Listener(Transport transport, IHotReloadAgent agent, Action<string> log)
+internal sealed class Listener(Transport transport, IHotReloadAgent agent, int processId, Action<string> log)
 {
     /// <summary>
     /// Messages to the client sent after the initial <see cref="ClientInitializationResponse"/> is sent
@@ -72,7 +72,8 @@ internal sealed class Listener(Transport transport, IHotReloadAgent agent, Actio
     {
         agent.Reporter.Report("Writing capabilities: " + agent.Capabilities, AgentMessageSeverity.Verbose);
 
-        await transport.SendAsync(new ClientInitializationResponse(agent.Capabilities), cancellationToken).ConfigureAwait(false);
+        var response = new ClientInitializationResponse(processId, capabilities: agent.Capabilities);
+        await transport.SendAsync(response, cancellationToken).ConfigureAwait(false);
 
         // Apply updates made before this process was launched to avoid executing unupdated versions of the affected modules.
 

--- a/src/Dotnet.Watch/HotReloadAgent.Host/StartupHook.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.Host/StartupHook.cs
@@ -36,8 +36,9 @@ internal sealed class StartupHook
     {
         var processPath = Environment.GetCommandLineArgs().FirstOrDefault();
         var processDir = Path.GetDirectoryName(processPath)!;
+        var processId = Environment.ProcessId;
 
-        Log($"Loaded into process: {processPath} ({typeof(StartupHook).Assembly.Location})");
+        Log($"Loaded into process {processId}: {processPath} ({typeof(StartupHook).Assembly.Location})");
 
         var transport = Transport.TryCreate(Log);
 
@@ -93,7 +94,7 @@ internal sealed class StartupHook
                 }
             });
 
-        listener = new Listener(transport, agent, Log);
+        listener = new Listener(transport, agent, processId, Log);
 
         // fire and forget:
         _ = listener.Listen(CancellationToken.None);

--- a/src/Dotnet.Watch/HotReloadAgent.PipeRpc/NamedPipeContract.cs
+++ b/src/Dotnet.Watch/HotReloadAgent.PipeRpc/NamedPipeContract.cs
@@ -144,17 +144,19 @@ internal readonly struct UpdateResponse(IReadOnlyCollection<(string message, Age
     }
 }
 
-internal readonly struct ClientInitializationResponse(string capabilities) : IResponse
+internal readonly struct ClientInitializationResponse(int processId, string capabilities) : IResponse
 {
-    private const byte Version = 0;
+    private const byte Version = 1;
 
     public ResponseType Type => ResponseType.InitializationResponse;
 
     public string Capabilities { get; } = capabilities;
+    public int ProcessId { get; } = processId;
 
     public async ValueTask WriteAsync(Stream stream, CancellationToken cancellationToken)
     {
         await stream.WriteAsync(Version, cancellationToken);
+        await stream.WriteAsync(ProcessId, cancellationToken);
         await stream.WriteAsync(Capabilities, cancellationToken);
     }
 
@@ -166,8 +168,9 @@ internal readonly struct ClientInitializationResponse(string capabilities) : IRe
             throw new NotSupportedException($"Unsupported version {version}.");
         }
 
+        var processId = await stream.ReadInt32Async(cancellationToken);
         var capabilities = await stream.ReadStringAsync(cancellationToken);
-        return new ClientInitializationResponse(capabilities);
+        return new ClientInitializationResponse(processId, capabilities);
     }
 }
 

--- a/src/Dotnet.Watch/HotReloadClient/DefaultHotReloadClient.cs
+++ b/src/Dotnet.Watch/HotReloadClient/DefaultHotReloadClient.cs
@@ -16,10 +16,25 @@ using Microsoft.Extensions.Logging;
 
 namespace Microsoft.DotNet.HotReload;
 
-internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger, string startupHookPath, bool handlesStaticAssetUpdates, ClientTransport transport)
+/// <summary>
+/// Default Hot Reload client. Used for local app or an app running on a device.
+/// </summary>
+/// <param name="logger">Logger for client messages.</param>
+/// <param name="agentLogger">Logger for messages received from the agent.</param>
+/// <param name="startupHookPath">Path to the startup hook to be loaded to the target process.</param>
+/// <param name="transport">Transport layer (e.g. named pipe or web socket)</param>
+/// <param name="handlesStaticAssetUpdates">True if the agent handles static asset updates. False if static assets are updated via browser refresh server.</param>
+/// <param name="hasRemoteAgent">True if the agent runs on a remote machine (device).</param>
+internal sealed class DefaultHotReloadClient(
+    ILogger logger,
+    ILogger agentLogger,
+    string startupHookPath,
+    ClientTransport transport,
+    bool handlesStaticAssetUpdates,
+    bool hasRemoteAgent)
     : HotReloadClient(logger, agentLogger)
 {
-    private Task<ImmutableArray<string>>? _capabilitiesTask;
+    private Task<HotReloadAgentInfo>? _connectedAgentTask;
     private bool _managedCodeUpdateFailedOrCancelled;
 
     // The status of the last update response.
@@ -40,9 +55,9 @@ internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger
         // It is important to establish the connection (WaitForConnectionAsync) before we return,
         // otherwise the client wouldn't be able to connect.
         // However, we don't want to wait for the task to complete, so that we can start the client process.
-        _capabilitiesTask = ConnectAsync();
+        _connectedAgentTask = ConnectAsync();
 
-        async Task<ImmutableArray<string>> ConnectAsync()
+        async Task<HotReloadAgentInfo> ConnectAsync()
         {
             try
             {
@@ -52,26 +67,37 @@ internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger
                 var initResponse = await transport.ReadAsync(cancellationToken);
                 if (initResponse == null)
                 {
-                    return [];
+                    // connection dropped before we could read the initialization response.
+                    return HotReloadAgentInfo.Unavailable;
                 }
 
                 using var r = initResponse.Value;
                 if (r.Type != ResponseType.InitializationResponse)
                 {
                     Logger.LogError("Expected initialization response, got: {ResponseType}", r.Type);
-                    return [];
+                    return HotReloadAgentInfo.Unavailable;
                 }
 
-                var capabilities = (await ClientInitializationResponse.ReadAsync(r.Data, cancellationToken)).Capabilities;
+                var response = await ClientInitializationResponse.ReadAsync(r.Data, cancellationToken);
 
-                if (string.IsNullOrEmpty(capabilities))
+                // Remote process id has no meaning on the client's machine:
+                var localProcessId = hasRemoteAgent ? (int?)null : response.ProcessId;
+
+                if (response.Capabilities is "")
                 {
-                    return [];
+                    // Hot Reload not supported by the runtime:
+                    Logger.Log(LogEvents.Capabilities, "");
+
+                    return new HotReloadAgentInfo
+                    {
+                        ManagedCodeUpdateCapabilities = [],
+                        LocalProcessId = localProcessId
+                    };
                 }
 
-                var result = AddImplicitCapabilities(capabilities.Split(' '));
+                var effectiveCapabilities = AddImplicitCapabilities(response.Capabilities.Split(' '));
 
-                Logger.Log(LogEvents.Capabilities, string.Join(" ", result));
+                Logger.Log(LogEvents.Capabilities, string.Join(" ", effectiveCapabilities));
 
                 // Initialize process:
                 await SetEnvironmentVariablesAsync(environmentVariables, cancellationToken);
@@ -79,7 +105,11 @@ internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger
                 // fire and forget:
                 _ = ListenForResponsesAsync(cancellationToken);
 
-                return result;
+                return new HotReloadAgentInfo
+                {
+                    ManagedCodeUpdateCapabilities = effectiveCapabilities,
+                    LocalProcessId = localProcessId
+                };
             }
             catch (Exception e) when (e is not OperationCanceledException)
             {
@@ -90,7 +120,7 @@ internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger
                     Logger.LogError("Failed to read capabilities: {Message}", e.Message);
                 }
 
-                return [];
+                return HotReloadAgentInfo.Unavailable;
             }
         }
     }
@@ -137,15 +167,15 @@ internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger
         }
     }
 
-    [MemberNotNull(nameof(_capabilitiesTask))]
-    private Task<ImmutableArray<string>> GetCapabilitiesTask()
-        => _capabilitiesTask ?? throw new InvalidOperationException();
+    [MemberNotNull(nameof(_connectedAgentTask))]
+    private Task<HotReloadAgentInfo> GetAgentConnectedTask()
+        => _connectedAgentTask ?? throw new InvalidOperationException();
 
-    [MemberNotNull(nameof(_capabilitiesTask))]
+    [MemberNotNull(nameof(_connectedAgentTask))]
     private void RequireReadyForUpdates()
     {
         // should only be called after connection has been created:
-        _ = GetCapabilitiesTask();
+        _ = GetAgentConnectedTask();
     }
 
     public override void ConfigureLaunchEnvironment(IDictionary<string, string> environmentBuilder)
@@ -159,10 +189,10 @@ internal sealed class DefaultHotReloadClient(ILogger logger, ILogger agentLogger
     }
 
     public override Task WaitForConnectionEstablishedAsync(CancellationToken cancellationToken)
-        => GetCapabilitiesTask();
+        => GetAgentConnectedTask();
 
-    public override Task<ImmutableArray<string>> GetUpdateCapabilitiesAsync(CancellationToken cancellationToken)
-        => GetCapabilitiesTask();
+    public override Task<HotReloadAgentInfo> GetConnectedAgentInfoAsync(CancellationToken cancellationToken)
+        => GetAgentConnectedTask();
 
     private ResponseLoggingLevel ResponseLoggingLevel
         => Logger.IsEnabled(LogLevel.Debug) ? ResponseLoggingLevel.Verbose : ResponseLoggingLevel.WarningsAndErrors;

--- a/src/Dotnet.Watch/HotReloadClient/HotReloadAgentInfo.cs
+++ b/src/Dotnet.Watch/HotReloadClient/HotReloadAgentInfo.cs
@@ -1,0 +1,28 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Text;
+
+namespace Microsoft.DotNet.HotReload;
+
+/// <summary>
+/// Information 
+/// </summary>
+internal readonly struct HotReloadAgentInfo
+{
+    internal static readonly HotReloadAgentInfo Unavailable = new() { ManagedCodeUpdateCapabilities = [] };
+
+    /// <summary>
+    /// Capabilities of the runtime the agent is loaded to.
+    /// </summary>
+    public required ImmutableArray<string> ManagedCodeUpdateCapabilities { get; init; }
+
+    /// <summary>
+    /// The id of the process the agent is loaded to, if available and the agent runs on the same machine as the client.
+    /// Null if the agent runs on a device or in the browser.
+    /// </summary>
+    public int? LocalProcessId { get; init; }
+}

--- a/src/Dotnet.Watch/HotReloadClient/HotReloadClient.cs
+++ b/src/Dotnet.Watch/HotReloadClient/HotReloadClient.cs
@@ -64,10 +64,10 @@ internal abstract class HotReloadClient(ILogger logger, ILogger agentLogger) : I
     public abstract Task WaitForConnectionEstablishedAsync(CancellationToken cancellationToken);
 
     /// <summary>
-    /// Returns update capabilities of the target process.
+    /// Returns information about the connected agent.
     /// </summary>
     /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
-    public abstract Task<ImmutableArray<string>> GetUpdateCapabilitiesAsync(CancellationToken cancellationToken);
+    public abstract Task<HotReloadAgentInfo> GetConnectedAgentInfoAsync(CancellationToken cancellationToken);
 
     /// <summary>
     /// Returns a task that applies managed code updates to the target process.
@@ -111,7 +111,7 @@ internal abstract class HotReloadClient(ILogger logger, ILogger agentLogger) : I
 
     protected async Task<IReadOnlyList<HotReloadManagedCodeUpdate>> FilterApplicableUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, CancellationToken cancellationToken)
     {
-        var availableCapabilities = await GetUpdateCapabilitiesAsync(cancellationToken);
+        var agentInfo = await GetConnectedAgentInfoAsync(cancellationToken);
         var applicableUpdates = new List<HotReloadManagedCodeUpdate>();
 
         foreach (var update in updates)
@@ -122,7 +122,7 @@ internal abstract class HotReloadClient(ILogger logger, ILogger agentLogger) : I
                 continue;
             }
 
-            if (update.RequiredCapabilities.Except(availableCapabilities).Any())
+            if (update.RequiredCapabilities.Except(agentInfo.ManagedCodeUpdateCapabilities).Any())
             {
                 // required capability not available:
                 _frozenModules.Add(update.ModuleId);

--- a/src/Dotnet.Watch/HotReloadClient/HotReloadClients.cs
+++ b/src/Dotnet.Watch/HotReloadClient/HotReloadClients.cs
@@ -110,24 +110,19 @@ internal sealed class HotReloadClients(
     }
 
     /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
-    public async ValueTask<ImmutableArray<string>> GetUpdateCapabilitiesAsync(CancellationToken cancellationToken)
+    public async ValueTask<ImmutableArray<HotReloadAgentInfo>> GetConnectedAgentsInfoAsync(CancellationToken cancellationToken)
     {
         if (!IsManagedAgentSupported)
         {
-            // empty capabilities will cause rude edit ENC0097: NotSupportedByRuntime.
             return [];
         }
 
         if (clients is [var singleClient])
         {
-            return await singleClient.GetUpdateCapabilitiesAsync(cancellationToken);
+            return [await singleClient.GetConnectedAgentInfoAsync(cancellationToken)];
         }
 
-        var results = await Task.WhenAll(clients.Select(c => c.GetUpdateCapabilitiesAsync(cancellationToken)));
-
-        // Allow updates that are supported by at least one process.
-        // When applying changes we will filter updates applied to a specific process based on their required capabilities.
-        return [.. results.SelectMany(r => r).Distinct(StringComparer.Ordinal).OrderBy(c => c)];
+        return [.. await Task.WhenAll(clients.Select(c => c.GetConnectedAgentInfoAsync(cancellationToken)))];
     }
 
     /// <summary>
@@ -225,4 +220,13 @@ internal sealed class HotReloadClients(
     /// <param name="cancellationToken">Cancellation token. The cancellation should trigger on process terminatation.</param>
     public ValueTask ReportCompilationErrorsInApplicationAsync(ImmutableArray<string> compilationErrors, CancellationToken cancellationToken)
         => browserRefreshServer?.ReportCompilationErrorsInBrowserAsync(compilationErrors, cancellationToken) ?? ValueTask.CompletedTask;
+
+    /// <summary>
+    /// Returns union of capabilities reported by each agent.
+    /// When applying changes the updates applied to a specific process will be filtered based on their required capabilities.
+    /// </summary>
+    public static ImmutableArray<string> UnionCapabilities(ImmutableArray<HotReloadAgentInfo> agentInfos)
+        => agentInfos is [var singleInfo]
+            ? singleInfo.ManagedCodeUpdateCapabilities
+            : [.. agentInfos.SelectMany(r => r.ManagedCodeUpdateCapabilities).Distinct(StringComparer.Ordinal).OrderBy(c => c)];
 }

--- a/src/Dotnet.Watch/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
+++ b/src/Dotnet.Watch/HotReloadClient/Web/WebAssemblyHotReloadClient.cs
@@ -90,8 +90,12 @@ internal sealed class WebAssemblyHotReloadClient(
         // Wait for the browser connection to be established. Currently we need the browser to be running in order to apply changes.
         => await browserRefreshServer.WaitForClientConnectionAsync(cancellationToken);
 
-    public override Task<ImmutableArray<string>> GetUpdateCapabilitiesAsync(CancellationToken cancellationToken)
-        => Task.FromResult(_capabilities);
+    public override Task<HotReloadAgentInfo> GetConnectedAgentInfoAsync(CancellationToken cancellationToken)
+        => Task.FromResult(new HotReloadAgentInfo
+        {
+            ManagedCodeUpdateCapabilities = _capabilities,
+            LocalProcessId = null
+        });
 
     public override async Task<Task<bool>> ApplyManagedCodeUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, CancellationToken applyOperationCancellationToken, CancellationToken cancellationToken)
     {

--- a/src/Dotnet.Watch/Watch/AppModels/BlazorWebAssemblyHostedAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/BlazorWebAssemblyHostedAppModel.cs
@@ -27,7 +27,13 @@ internal sealed class BlazorWebAssemblyHostedAppModel(DotNetWatchContext context
         return
         [
             CreateWebAssemblyClient(clientLogger, agentLogger, browserRefreshServer, clientProject),
-            new DefaultHotReloadClient(clientLogger, agentLogger, GetStartupHookPath(serverProject), handlesStaticAssetUpdates: false, new NamedPipeClientTransport(clientLogger))
+            new DefaultHotReloadClient(
+                clientLogger,
+                agentLogger,
+                GetStartupHookPath(serverProject),
+                new NamedPipeClientTransport(clientLogger),
+                handlesStaticAssetUpdates: false,
+                hasRemoteAgent: false)
         ];
     }
 }

--- a/src/Dotnet.Watch/Watch/AppModels/DefaultAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/DefaultAppModel.cs
@@ -15,7 +15,13 @@ internal sealed class DefaultAppModel(ProjectGraphNode project) : HotReloadAppMo
     public override ValueTask<HotReloadClients> CreateClientsAsync(ILogger clientLogger, ILogger agentLogger, CancellationToken cancellationToken)
         => new(new HotReloadClients(
             clients: IsManagedAgentSupported(project, clientLogger)
-                ? [new DefaultHotReloadClient(clientLogger, agentLogger, GetStartupHookPath(project), handlesStaticAssetUpdates: true, new NamedPipeClientTransport(clientLogger))]
+                ? [new DefaultHotReloadClient(
+                    clientLogger,
+                    agentLogger,
+                    GetStartupHookPath(project),
+                    new NamedPipeClientTransport(clientLogger),
+                    handlesStaticAssetUpdates: true,
+                    hasRemoteAgent: false)]
                 : [],
             browserRefreshServer: null,
             useRefreshServerToApplyStaticAssets: false));

--- a/src/Dotnet.Watch/Watch/AppModels/MobileAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/MobileAppModel.cs
@@ -24,7 +24,7 @@ internal sealed class MobileAppModel(DotNetWatchContext context, ProjectGraphNod
                 clientLogger,
                 cancellationToken);
 
-            clients = [new DefaultHotReloadClient(clientLogger, agentLogger, GetStartupHookPath(project), handlesStaticAssetUpdates: true, transport)];
+            clients = [new DefaultHotReloadClient(clientLogger, agentLogger, GetStartupHookPath(project), transport, handlesStaticAssetUpdates: true, hasRemoteAgent: true)];
         }
         else
         {

--- a/src/Dotnet.Watch/Watch/AppModels/WebServerAppModel.cs
+++ b/src/Dotnet.Watch/Watch/AppModels/WebServerAppModel.cs
@@ -17,5 +17,11 @@ internal sealed class WebServerAppModel(DotNetWatchContext context, ProjectGraph
         => false;
 
     protected override ImmutableArray<HotReloadClient> CreateManagedClients(ILogger clientLogger, ILogger agentLogger, BrowserRefreshServer? browserRefreshServer)
-        => [new DefaultHotReloadClient(clientLogger, agentLogger, GetStartupHookPath(serverProject), handlesStaticAssetUpdates: true, new NamedPipeClientTransport(clientLogger))];
+        => [new DefaultHotReloadClient(
+            clientLogger,
+            agentLogger,
+            GetStartupHookPath(serverProject),
+            new NamedPipeClientTransport(clientLogger),
+            handlesStaticAssetUpdates: true,
+            hasRemoteAgent: false)];
 }

--- a/src/Dotnet.Watch/Watch/HotReload/RunningProjectsManager.cs
+++ b/src/Dotnet.Watch/Watch/HotReload/RunningProjectsManager.cs
@@ -129,7 +129,8 @@ internal sealed class RunningProjectsManager(ProcessRunner processRunner, ILogge
         {
             // Wait for agent to create the named pipe and send capabilities over.
             // the agent blocks the app execution until initial updates are applied (if any).
-            var managedCodeUpdateCapabilities = await clients.GetUpdateCapabilitiesAsync(processCommunicationCancellationToken);
+            var managedCodeUpdateCapabilities = HotReloadClients.UnionCapabilities(
+                await clients.GetConnectedAgentsInfoAsync(processCommunicationCancellationToken));
 
             var runningProject = new RunningProject(
                 projectNode,

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientTests.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/HotReloadClientTests.cs
@@ -9,26 +9,28 @@ namespace Microsoft.DotNet.HotReload.UnitTests;
 public class HotReloadClientTests
 {
     public TestContext TestContext { get; set; } = null!;
+
     private sealed class Test : IAsyncDisposable
     {
+        public const int ProcessId = 654321;
         public readonly TestLogger Logger;
         public readonly TestLogger AgentLogger;
         public readonly DefaultHotReloadClient Client;
         private readonly CancellationTokenSource _cancellationSource;
         private readonly Task<Task> _listenerTaskFactory;
 
-        public Test(TestContext testContext, TestHotReloadAgent agent)
+        public Test(TestContext testContext, TestHotReloadAgent agent, bool hasRemoteAgent)
         {
             Logger = new TestLogger(testContext);
             AgentLogger = new TestLogger(testContext);
             var clientTransport = new NamedPipeClientTransport(Logger);
-            Client = new DefaultHotReloadClient(Logger, AgentLogger, startupHookPath: "", handlesStaticAssetUpdates: true, clientTransport);
+            Client = new DefaultHotReloadClient(Logger, AgentLogger, startupHookPath: "", transport: clientTransport, handlesStaticAssetUpdates: true, hasRemoteAgent);
 
             _cancellationSource = new CancellationTokenSource();
 
             Client.InitiateConnection(environmentVariables: [], CancellationToken.None);
             var agentTransport = new NamedPipeTransport(clientTransport.NamedPipeName, log: _ => { }, timeoutMS: Timeout.Infinite);
-            var listener = new Listener(agentTransport, agent, log: _ => { });
+            var listener = new Listener(agentTransport, agent, ProcessId, log: _ => { });
             _listenerTaskFactory = Task.Run<Task>(() => listener.Listen(_cancellationSource.Token), testContext.CancellationToken);
         }
 
@@ -58,10 +60,11 @@ public class HotReloadClientTests
             Capabilities = "Baseline AddMethodToExistingType AddStaticFieldToExistingType",
         };
 
-        await using var test = new Test(TestContext, agent);
+        await using var test = new Test(TestContext, agent, hasRemoteAgent: false);
 
-        var actualCapabilities = await test.Client.GetUpdateCapabilitiesAsync(CancellationToken.None);
-        Assert.AreSequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType", "AddExplicitInterfaceImplementation"], actualCapabilities);
+        var agentInfo = await test.Client.GetConnectedAgentInfoAsync(CancellationToken.None);
+        Assert.AreEqual(Test.ProcessId, agentInfo.LocalProcessId);
+        Assert.AreSequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType", "AddExplicitInterfaceImplementation"], agentInfo.ManagedCodeUpdateCapabilities);
 
         var update = new HotReloadManagedCodeUpdate(
             moduleId: moduleId,
@@ -92,10 +95,11 @@ public class HotReloadClientTests
             ApplyManagedCodeUpdatesImpl = updates => throw new Exception("Bug!")
         };
 
-        await using var test = new Test(TestContext, agent);
+        await using var test = new Test(TestContext, agent, hasRemoteAgent: true);
 
-        var actualCapabilities = await test.Client.GetUpdateCapabilitiesAsync(CancellationToken.None);
-        Assert.AreSequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType", "AddExplicitInterfaceImplementation"], actualCapabilities);
+        var agentInfo = await test.Client.GetConnectedAgentInfoAsync(CancellationToken.None);
+        Assert.IsNull(agentInfo.LocalProcessId);
+        Assert.AreSequenceEqual(["Baseline", "AddMethodToExistingType", "AddStaticFieldToExistingType", "AddExplicitInterfaceImplementation"], agentInfo.ManagedCodeUpdateCapabilities);
 
         var update = new HotReloadManagedCodeUpdate(
             moduleId: Guid.NewGuid(),

--- a/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestHotReloadClient.cs
+++ b/test/Microsoft.Extensions.DotNetDeltaApplier.Tests/Mocks/TestHotReloadClient.cs
@@ -22,8 +22,12 @@ internal sealed class TestHotReloadClient() : HotReloadClient(new TestLogger(), 
     public override Task WaitForConnectionEstablishedAsync(CancellationToken cancellationToken)
         => Task.CompletedTask;
 
-    public override Task<ImmutableArray<string>> GetUpdateCapabilitiesAsync(CancellationToken cancellationToken)
-        => Task.FromResult(ImmutableArray<string>.Empty);
+    public override Task<HotReloadAgentInfo> GetConnectedAgentInfoAsync(CancellationToken cancellationToken)
+        => Task.FromResult(new HotReloadAgentInfo
+        {
+            ManagedCodeUpdateCapabilities = [],
+            LocalProcessId = null
+        });
 
     public override Task<Task<bool>> ApplyManagedCodeUpdatesAsync(ImmutableArray<HotReloadManagedCodeUpdate> updates, CancellationToken applyOperationCancellationToken, CancellationToken cancellationToken)
     {


### PR DESCRIPTION
Allows a Hot Reload implementation that does entirely control the process launch to associate Hot Reload session with a process id.

For example, in CDK the Hot Reload session for a project is created when the launch configuration is resolved. Then VS Code launches the process and vsdbg-ui receives DAP protocol event. There is no connection back to the code that created the session that would start it.

This change allows to implement "auto-start" -- when the agent in the launched process connects to the named pipe/web socket created for the launch (when the Hot Reload session is created) we can start the session and associate it to the process via proces id.