### PR TITLE
Fix CA1859 suggestions for anonymous types

### DIFF
--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.Collector.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.Collector.cs
@@ -34,6 +34,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
             public ConcurrentDictionary<IMethodSymbol, bool> MethodsAssignedToDelegate { get; } = new(SymbolEqualityComparer.Default);
 
             public INamedTypeSymbol? Void { get; private set; }
+            public INamedTypeSymbol? Unknown { get; private set; }
             private Func<ISymbol, bool>? _checkVisibility;
 
             private Collector()
@@ -57,6 +58,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 MethodsAssignedToDelegate.Clear();
 
                 Void = null;
+                Unknown = null;
                 _checkVisibility = null;
 
                 static void DrainDictionary<T, U>(ConcurrentDictionary<T, PooledConcurrentSet<U>> d)
@@ -71,10 +73,11 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 }
             }
 
-            public static Collector GetInstance(INamedTypeSymbol voidType, Func<ISymbol, bool> visibilityChecker)
+            public static Collector GetInstance(INamedTypeSymbol voidType, INamedTypeSymbol unknownType, Func<ISymbol, bool> visibilityChecker)
             {
                 var c = _pool.Allocate();
                 c.Void = voidType;
+                c.Unknown = unknownType;
                 c._checkVisibility = visibilityChecker;
                 return c;
             }
@@ -500,6 +503,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                     case OperationKind.Invocation:
                     case OperationKind.ArrayElementReference:
                     case OperationKind.ObjectCreation:
+                    case OperationKind.AnonymousObjectCreation:
                     case OperationKind.ParameterReference:
                     case OperationKind.PropertyReference:
                     case OperationKind.MethodReference:
@@ -539,6 +543,13 @@ namespace Microsoft.NetCore.Analyzers.Performance
                             }
 
                             break;
+                        }
+
+                    default:
+                        {
+                            // Unhandled operations must disqualify the candidate instead of silently disappearing.
+                            values.Add(Unknown!);
+                            return;
                         }
                 }
             }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/src/Microsoft.CodeAnalysis.NetAnalyzers/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeAnalyzer.cs
@@ -124,7 +124,8 @@ namespace Microsoft.NetCore.Analyzers.Performance
             context.RegisterCompilationStartAction(context =>
             {
                 var voidType = context.Compilation.GetSpecialType(SpecialType.System_Void);
-                var publicOrInternalColl = Collector.GetInstance(voidType, symbol => symbol.IsInSource() && context.Options.MatchesConfiguredVisibility(UseConcreteTypeForMethodReturn, symbol, context.Compilation, SymbolVisibilityGroup.Private));
+                var objectType = context.Compilation.GetSpecialType(SpecialType.System_Object);
+                var publicOrInternalColl = Collector.GetInstance(voidType, objectType, symbol => symbol.IsInSource() && context.Options.MatchesConfiguredVisibility(UseConcreteTypeForMethodReturn, symbol, context.Compilation, SymbolVisibilityGroup.Private));
 
                 context.RegisterSymbolStartAction(context =>
                 {
@@ -135,7 +136,7 @@ namespace Microsoft.NetCore.Analyzers.Performance
                         return;
                     }
 
-                    var coll = Collector.GetInstance(voidType, symbol => symbol.IsInSource() && context.Options.MatchesConfiguredVisibility(UseConcreteTypeForMethodReturn, symbol, context.Compilation, SymbolVisibilityGroup.Private));
+                    var coll = Collector.GetInstance(voidType, objectType, symbol => symbol.IsInSource() && context.Options.MatchesConfiguredVisibility(UseConcreteTypeForMethodReturn, symbol, context.Compilation, SymbolVisibilityGroup.Private));
 
                     // we accumulate a bunch of info in the collector object
                     context.RegisterOperationAction(context => coll.HandleInvocation((IInvocationOperation)context.Operation), OperationKind.Invocation);
@@ -261,6 +262,12 @@ namespace Microsoft.NetCore.Analyzers.Performance
                 if (assignedNull || fromType.NullableAnnotation == NullableAnnotation.Annotated)
                 {
                     toType = toType.WithNullableAnnotation(NullableAnnotation.Annotated);
+                }
+
+                if (ContainsAnonymousType(toType))
+                {
+                    // Anonymous types cannot be named in a declaration, including when nested in another type.
+                    return;
                 }
 
                 if (!toType.DerivesFrom(fromType.OriginalDefinition))
@@ -400,6 +407,16 @@ namespace Microsoft.NetCore.Analyzers.Performance
             }
 
             bool CanUpgrade(IMethodSymbol methodSym) => !coll.MethodsAssignedToDelegate.ContainsKey(methodSym);
+
+            static bool ContainsAnonymousType(ITypeSymbol type)
+                => type switch
+                {
+                    IArrayTypeSymbol arrayType => ContainsAnonymousType(arrayType.ElementType),
+                    INamedTypeSymbol namedType => namedType.IsAnonymousType
+                        || namedType.TypeArguments.Any(ContainsAnonymousType)
+                        || namedType.ContainingType is { } containingType && ContainsAnonymousType(containingType),
+                    _ => false,
+                };
 
             static string GetTypeName(ITypeSymbol type) => type.ToDisplayString(SymbolDisplayFormat.CSharpErrorMessageFormat);
         }

--- a/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.Disqualification.cs
+++ b/src/Microsoft.CodeAnalysis.NetAnalyzers/tests/Microsoft.CodeAnalysis.NetAnalyzers.UnitTests/Microsoft.NetCore.Analyzers/Performance/UseConcreteTypeTests.Disqualification.cs
@@ -3,12 +3,181 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using VerifyVB = Test.Utilities.VisualBasicCodeFixVerifier<
+    Microsoft.NetCore.Analyzers.Performance.UseConcreteTypeAnalyzer,
+    Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
 
 namespace Microsoft.NetCore.Analyzers.Performance.UnitTests
 {
     [TestClass]
     public partial class UseConcreteTypeTests
     {
+        [TestMethod]
+        [WorkItem(56233, "https://github.com/dotnet/sdk/issues/56233")]
+        public async Task ShouldNotTrigger_MixedAnonymousAndConcreteMethodReturns_CSharp()
+        {
+            await TestCSAsync("""
+                class ConcreteType
+                {
+                    private object GetNewConcreteTypeInstance(bool returnAnonymousObjectInstead)
+                    {
+                        if (returnAnonymousObjectInstead)
+                        {
+                            return new { };
+                        }
+
+                        return new ConcreteType();
+                    }
+                }
+                """);
+        }
+
+        [TestMethod]
+        [WorkItem(50366, "https://github.com/dotnet/sdk/issues/50366")]
+        public async Task ShouldNotTrigger_AnonymousLocalMethodReturn_CSharp()
+        {
+            await TestCSAsync("""
+                class C
+                {
+                    private object BuildObject()
+                    {
+                        var outputData = new
+                        {
+                            Name = "Alex"
+                        };
+
+                        return outputData;
+                    }
+                }
+                """);
+        }
+
+        [TestMethod]
+        [WorkItem(56233, "https://github.com/dotnet/sdk/issues/56233")]
+        public async Task ShouldNotTrigger_NestedAnonymousMethodReturn_CSharp()
+        {
+            await TestCSAsync("""
+                using System.Linq;
+
+                class C
+                {
+                    private object BuildArray() => new[] { new { Name = "Alex" } };
+
+                    private object BuildList() => new[] { new { Name = "Alex" } }.ToList();
+                }
+                """);
+        }
+
+        [TestMethod]
+        [WorkItem(56233, "https://github.com/dotnet/sdk/issues/56233")]
+        public async Task ShouldNotTrigger_AnonymousContainingTypeMethodReturn_CSharp()
+        {
+            await TestCSAsync("""
+                class C
+                {
+                    private object BuildObject() => Create(new { Name = "Alex" });
+
+                    private static Outer<T>.Inner Create<T>(T value) => new();
+                }
+
+                class Outer<T>
+                {
+                    public class Inner
+                    {
+                    }
+                }
+                """);
+        }
+
+        [TestMethod]
+        [WorkItem(56233, "https://github.com/dotnet/sdk/issues/56233")]
+        public async Task ShouldNotTrigger_WhenAnotherReturnOperationWasNotExplicitlyHandled_CSharp()
+        {
+            await TestCSAsync("""
+                record RecordType(int Value);
+
+                class C
+                {
+                    private object BuildObject(bool returnRecord, RecordType record)
+                    {
+                        if (returnRecord)
+                        {
+                            return record with { Value = 1 };
+                        }
+
+                        return new C();
+                    }
+                }
+                """);
+        }
+
+        [TestMethod]
+        [WorkItem(56233, "https://github.com/dotnet/sdk/issues/56233")]
+        public async Task ShouldNotTrigger_AnonymousAssignments_CSharp()
+        {
+            await TestCSAsync("""
+                class C
+                {
+                    private object _field = new { Name = "Alex" };
+
+                    public void M()
+                    {
+                        _field.ToString();
+
+                        object local = new { Name = "Alex" };
+                        local.ToString();
+                    }
+                }
+                """);
+        }
+
+        [TestMethod]
+        [WorkItem(56233, "https://github.com/dotnet/sdk/issues/56233")]
+        public async Task ShouldNotTrigger_MixedAnonymousAndConcreteMethodReturns_VisualBasic()
+        {
+            await VerifyVB.VerifyAnalyzerAsync("""
+                Class ConcreteType
+                    Private Function GetNewConcreteTypeInstance(returnAnonymousObjectInstead As Boolean) As Object
+                        If returnAnonymousObjectInstead Then
+                            Return New With {.Name = "Alex"}
+                        End If
+
+                        Return New ConcreteType()
+                    End Function
+                End Class
+                """);
+        }
+
+        [TestMethod]
+        [WorkItem(50366, "https://github.com/dotnet/sdk/issues/50366")]
+        public async Task ShouldNotTrigger_AnonymousLocalMethodReturn_VisualBasic()
+        {
+            await VerifyVB.VerifyAnalyzerAsync("""
+                Class C
+                    Private Function BuildObject() As Object
+                        Dim outputData = New With {
+                            .Name = "Alex"
+                        }
+
+                        Return outputData
+                    End Function
+                End Class
+                """);
+        }
+
+        [TestMethod]
+        [WorkItem(56233, "https://github.com/dotnet/sdk/issues/56233")]
+        public async Task ShouldNotTrigger_NestedAnonymousMethodReturn_VisualBasic()
+        {
+            await VerifyVB.VerifyAnalyzerAsync("""
+                Class C
+                    Private Function BuildArray() As Object
+                        Return {New With {.Name = "Alex"}}
+                    End Function
+                End Class
+                """);
+        }
+
         [TestMethod]
         [DynamicData(nameof(DisqualifiedSources))]
         public async Task Disqualication(string insert)


### PR DESCRIPTION
## Summary

- track anonymous object creations and conservatively disqualify unhandled value operations in CA1859 type inference
- suppress suggestions for types that directly or transitively contain anonymous types
- add C# and Visual Basic regression coverage for mixed returns, local returns, nested anonymous types, containing generic types, and assignment paths

Fixes #56233
Fixes #50366

## Testing

- `\.dotnet\dotnet.exe scripts\RunTests.cs -- --project src\Microsoft.CodeAnalysis.NetAnalyzers\tests\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests\Microsoft.CodeAnalysis.NetAnalyzers.UnitTests.csproj --filter "FullyQualifiedName~UseConcreteTypeTests" --skip-redist-check` (61 passed)
- `build.cmd -projects src\Microsoft.CodeAnalysis.NetAnalyzers\Microsoft.CodeAnalysis.NetAnalyzers.slnx -c Debug`