### PR TITLE
File-based apps: avoid processing directives after `#if`

### DIFF
--- a/documentation/general/dotnet-run-file.md
+++ b/documentation/general/dotnet-run-file.md
@@ -301,7 +301,7 @@ In other directives, all variables are preserved during conversion.
 
 Because these directives are limited by the C# language to only appear before the first "C# token" and any `#if`,
 dotnet CLI can look for them via a regex or Roslyn lexer without any knowledge of defined conditional symbols
-and can do that efficiently by stopping the search when it sees the first "C# token".
+and can do that efficiently by stopping the search when it sees the first "C# token" or `#if`.
 
 For a given `dotnet run file.cs`, we include directives from the current entry point file (`file.cs`) and all other non-entry-point C# files,
 specifically from all `Compile` items included in the project, no matter whether the `Compile` items are specified in some MSBuild code or inferred from `#:include`.

--- a/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
+++ b/src/Cli/Microsoft.DotNet.FileBasedPrograms/FileLevelDirectiveHelpers.cs
@@ -98,8 +98,8 @@ internal static class FileLevelDirectiveHelpers
         for (var index = 0; index < triviaList.Count; index++)
         {
             var trivia = triviaList[index];
-            // Stop when the trivia contains an error (e.g., because it's after #if).
-            if (trivia.ContainsDiagnostics)
+            // Inactive directives after #if may have no diagnostics, but must not affect the project.
+            if (trivia.ContainsDiagnostics || trivia.IsKind(SyntaxKind.IfDirectiveTrivia))
             {
                 break;
             }

--- a/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
+++ b/test/dotnet.Tests/CommandTests/Project/Convert/DotnetProjectConvertTests.cs
@@ -3301,14 +3301,15 @@ public sealed class DotnetProjectConvertTests : SdkTest
     /// <summary>
     /// <c>#:</c> directives after <c>#if</c> are ignored.
     /// </summary>
-    [TestMethod]
-    public void Directives_AfterIf()
+    [TestMethod, CombinatorialData]
+    public void Directives_AfterIf(bool active)
     {
-        string source = """
+        string condition = active ? "X" : "false";
+        string source = $"""
             #:property Prop1=1
             #define X
             #:property Prop2=2
-            #if X
+            #if {condition}
             #:property Prop1=3
             #endif
             #:property Prop2=4
@@ -3335,18 +3336,61 @@ public sealed class DotnetProjectConvertTests : SdkTest
                 </Project>
 
                 """,
-            expectedCSharp: """
+            expectedCSharp: $"""
                 #define X
-                #if X
+                #if {condition}
                 #:property Prop1=3
                 #endif
                 #:property Prop2=4
                 """,
-            expectedErrors:
+            expectedErrors: active ?
             [
                 (5, FileBasedProgramsResources.CannotConvertDirective),
                 (7, FileBasedProgramsResources.CannotConvertDirective),
+            ] :
+            [
+                (7, FileBasedProgramsResources.CannotConvertDirective),
             ]);
+    }
+
+    [TestMethod]
+    [DataRow("#:package MyPackage@1.0")]
+    [DataRow(""""
+        Console.WriteLine("""
+            #:package MyPackage@1.0
+            """);
+        """")]
+    [DataRow("""
+        /*
+        #:package MyPackage@1.0
+        */
+        """)]
+    public void Directives_InInactiveRegion(string disabledText)
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        VerifyConversion(
+            baseDirectory: testInstance.Path,
+            inputCSharp: $"""
+                #if false
+                {disabledText}
+                #endif
+                Console.WriteLine();
+                """,
+            expectedProject: $"""
+                <Project Sdk="Microsoft.NET.Sdk">
+
+                  <PropertyGroup>
+                    <OutputType>Exe</OutputType>
+                    <TargetFramework>{ToolsetInfo.CurrentTargetFramework}</TargetFramework>
+                    <ImplicitUsings>enable</ImplicitUsings>
+                    <Nullable>enable</Nullable>
+                    <PublishAot>true</PublishAot>
+                    <PackAsTool>true</PackAsTool>
+                  </PropertyGroup>
+
+                </Project>
+
+                """);
     }
 
     /// <summary>

--- a/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
+++ b/test/dotnet.Tests/CommandTests/Run/RunFileTests_Directives.cs
@@ -70,6 +70,72 @@ public sealed class RunFileTests_Directives : RunFileTestBase
     }
 
     [TestMethod]
+    public void PackageReference_InRegion_Active()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            #if true
+            #:package System.CommandLine@2.0.0-beta4.22272.1
+            #endif
+            using System.CommandLine;
+            Console.WriteLine(typeof(RootCommand).Name);
+            """);
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            // error CS9299: '#:' directives cannot be after '#if' directive
+            .And.HaveStdOutContaining("error CS9299:")
+            // NO error CS0234: The type or namespace name 'CommandLine' does not exist in the namespace 'System'
+            .And.NotHaveStdOutContaining("error CS0234:");
+    }
+
+    [TestMethod]
+    public void PackageReference_InRegion_Conditional()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            #if X
+            #:package System.CommandLine@2.0.0-beta4.22272.1
+            #endif
+            using System.CommandLine;
+            Console.WriteLine(typeof(RootCommand).Name);
+            """);
+
+        new DotnetCommand(Log, "run", "Program.cs", "-p:DefineConstants=X")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            // error CS9299: '#:' directives cannot be after '#if' directive
+            .And.HaveStdOutContaining("error CS9299:")
+            // NO error CS0234: The type or namespace name 'CommandLine' does not exist in the namespace 'System'
+            .And.NotHaveStdOutContaining("error CS0234:");
+    }
+
+    [TestMethod]
+    public void PackageReference_InRegion_Inactive()
+    {
+        var testInstance = TestAssetsManager.CreateTestDirectory();
+        File.WriteAllText(Path.Join(testInstance.Path, "Program.cs"), """
+            #if false
+            #:package System.CommandLine@2.0.0-beta4.22272.1
+            #endif
+            using System.CommandLine;
+            Console.WriteLine(typeof(RootCommand).Name);
+            """);
+
+        new DotnetCommand(Log, "run", "Program.cs")
+            .WithWorkingDirectory(testInstance.Path)
+            .Execute()
+            .Should().Fail()
+            // NO error CS9299: '#:' directives cannot be after '#if' directive
+            .And.NotHaveStdOutContaining("error CS9299:")
+            // error CS0234: The type or namespace name 'CommandLine' does not exist in the namespace 'System'
+            .And.HaveStdOutContaining("error CS0234:");
+    }
+
+    [TestMethod]
     public void PackageReference_CentralVersion()
     {
         var testInstance = TestAssetsManager.CreateTestDirectory();


### PR DESCRIPTION
Fixes https://github.com/dotnet/roslyn/issues/85203.