### PR TITLE
Dotnetup: Avoid "hive" terminology in user-facing documentation.

### DIFF
--- a/documentation/general/dotnetup/channels/daily.md
+++ b/documentation/general/dotnetup/channels/daily.md
@@ -68,8 +68,8 @@ Garbage collection removes older files that no remaining specification needs.
 
 ## Isolate daily builds
 
-Use a separate hive when you do not want daily builds to share files with your
-default managed installation:
+Use a separate installation root when you do not want daily builds to share
+files with your default managed installation:
 
 ```dotnetcli
 dotnetup sdk install 11.0.1xx-daily --install-path .\.dotnet-daily
@@ -77,5 +77,6 @@ dotnetup sdk install 11.0.1xx-daily --install-path .\.dotnet-daily
 ```
 
 The `dotnetup dotnet` forwarding command does not automatically select an
-arbitrary custom hive. To run a custom hive directly, use its `dotnet`
-executable or activate it with `dotnetup env script --dotnet-install-path`.
+arbitrary custom installation root. To use a custom installation directly,
+run its `dotnet` executable or activate it with
+`dotnetup env script --dotnet-install-path`.

--- a/documentation/general/dotnetup/concepts/how-dotnetup-works.md
+++ b/documentation/general/dotnetup/concepts/how-dotnetup-works.md
@@ -1,6 +1,6 @@
 ---
 title: How dotnetup works
-description: Learn about dotnetup hives, components, install specifications, installations, and state files.
+description: Learn about dotnetup installation roots, components, install specifications, installations, and state files.
 ms.topic: conceptual
 ms.date: 08/07/2026
 ---
@@ -11,9 +11,10 @@ ms.date: 08/07/2026
 model lets several requirements share one .NET installation and lets
 `dotnetup` remove files that are no longer required.
 
-## Hives
+## Installation roots
 
-A **hive** is a .NET installation root that `dotnetup` tracks. A hive has:
+A **.NET installation root** is a directory that `dotnetup` tracks. An
+installation root has:
 
 - A fully qualified directory path.
 - An architecture: `x86`, `x64`, or `arm64`.
@@ -23,17 +24,18 @@ A **hive** is a .NET installation root that `dotnetup` tracks. A hive has:
 The current CLI installs for the architecture of the running `dotnetup`
 process. It does not have an architecture option.
 
-The default hive is the `dotnet` subdirectory of the dotnetup data directory:
+The default dotnetup-managed .NET installation root is the `dotnet`
+subdirectory of the dotnetup data directory:
 
-| Platform | Default hive |
+| Platform | Default installation root |
 | --- | --- |
 | Windows | `%LOCALAPPDATA%\dotnetup\dotnet` |
 | macOS | `~/Library/Application Support/dotnetup/dotnet` |
 | Linux | `$XDG_DATA_HOME/dotnetup/dotnet`, or `~/.local/share/dotnetup/dotnet` when `XDG_DATA_HOME` is not set |
 
-Use `--install-path` to select another hive. An explicit install path takes
+Use `--install-path` to select another installation root. An explicit install path takes
 precedence over a path from `global.json`, which takes precedence over the
-default hive.
+default installation root.
 
 `dotnetup` does not write to a system-managed .NET directory, such as
 `Program Files\dotnet` or `/usr/share/dotnet`.
@@ -102,7 +104,7 @@ The dotnetup data directory contains these user-level state files:
 
 | File | Purpose |
 | --- | --- |
-| `dotnetup_manifest.json` | Tracks hives, install specifications, installations, and shared subcomponents. |
+| `dotnetup_manifest.json` | Tracks installation roots, install specifications, installations, and shared subcomponents. |
 | `dotnetup_manifest.json.sha256` | Detects changes to manifest content that dotnetup did not write. |
 | `dotnetup.config.json` | Stores the .NET access mode and whether the `dotnetup` directory is on `PATH`. |
 
@@ -111,7 +113,7 @@ Do not edit these files. Use `dotnetup install`, `update`, `uninstall`, and
 
 The `DOTNET_DOTNETUP_DATA_DIR` environment variable changes the data
 directory. The `--manifest-path` option changes only the manifest used by one
-command. It does not change the configuration file or default hive.
+command. It does not change the configuration file or default installation root.
 
 ## Concurrent operations
 

--- a/documentation/general/dotnetup/concepts/repositories.md
+++ b/documentation/general/dotnetup/concepts/repositories.md
@@ -47,7 +47,7 @@ Installation-path precedence is:
 
 1. `--install-path`.
 1. The first `sdk.paths` entry in the nearest `global.json`.
-1. The default dotnetup hive.
+1. The default dotnetup-managed .NET installation root.
 
 ## Keep repository files current
 

--- a/documentation/general/dotnetup/index.md
+++ b/documentation/general/dotnetup/index.md
@@ -62,7 +62,7 @@ Or open a new terminal.
 > dotnetup list
 Installations (managed by dotnetup):
 
-  <default-hive>
+  <default-installation-root>
 
     Tracked channels:
       SDK latest  (source: explicit)
@@ -92,8 +92,8 @@ Open a new terminal for the change to take effect.
 <resolved-version>
 ```
 
-The mode, resolved version, architecture, hive path, and shell command depend
-on your system and the available releases.
+The mode, resolved version, architecture, installation path, and shell command
+depend on your system and the available releases.
 
 ## How dotnetup manages .NET
 
@@ -107,7 +107,7 @@ For more information, see [How dotnetup works](concepts/how-dotnetup-works.md).
 
 | Goal | Article |
 | --- | --- |
-| Understand channels, hives, and tracking | [How dotnetup works](concepts/how-dotnetup-works.md) |
+| Understand channels, installation roots, and tracking | [How dotnetup works](concepts/how-dotnetup-works.md) |
 | Use a repository's `global.json` | [Manage repository SDK requirements](usecases/install-with-global-json.md) |
 | Install SDKs and runtimes | [Install .NET components](usecases/install-components.md) |
 | Update or remove installations | [Update installations](usecases/update-installations.md) |

--- a/documentation/general/dotnetup/reference/dotnetup-dotnet.md
+++ b/documentation/general/dotnetup/reference/dotnetup-dotnet.md
@@ -20,21 +20,21 @@ dotnetup dotnet [--] [<ARGUMENT>...]
 
 ## Description
 
-The command selects the current default dotnetup hive. It uses the `PATH`
-location if that location is the default managed hive. Otherwise, it uses the
-default hive.
+The command selects the current default dotnetup-managed .NET installation
+root. It uses the `PATH` location if that location is the default managed
+installation root. Otherwise, it uses the default installation root.
 
 Before it starts the child process, it sets `DOTNET_ROOT` to the selected
-hive and prepends the hive to `PATH`. It forwards all remaining arguments and
-inherits standard input, output, and error. Its exit code is the child
-process exit code.
+installation root and prepends that root to `PATH`. It forwards all remaining
+arguments and inherits standard input, output, and error. Its exit code is the
+child process exit code.
 
-This command does not automatically select an arbitrary hive supplied earlier
-with `--install-path`.
+This command does not automatically select an arbitrary installation root
+supplied earlier with `--install-path`.
 
 `dotnetup dotnet` changes the environment only for the command that it starts.
-Other applications do not use this hive by default. This includes IDEs such as
-Visual Studio Code.
+Other applications do not use this installation by default. This includes IDEs
+such as Visual Studio Code.
 
 Use Terminal Mode and launch the IDE from that terminal. On Windows, use
 Everywhere Mode to configure all applications. For more information, see

--- a/documentation/general/dotnetup/reference/dotnetup-env-script.md
+++ b/documentation/general/dotnetup/reference/dotnetup-env-script.md
@@ -30,7 +30,7 @@ With selection options, it includes only the requested parts.
 | Option | Description |
 | --- | --- |
 | `-s`, `--shell [<bash\|zsh\|fish\|pwsh>]` | Select the script syntax. If omitted, detect the current shell. |
-| `-d`, `--dotnet-install-path <PATH>` | Use a specific .NET installation root. The default is the default dotnetup hive. |
+| `-d`, `--dotnet-install-path <PATH>` | Use a specific .NET installation root. The default is the default dotnetup-managed installation root. |
 | `--dotnet` | Add the selected .NET root to `PATH` and set `DOTNET_ROOT`. |
 | `--dotnetup` | Add the directory that contains `dotnetup` to `PATH`. |
 | `-?`, `-h`, `--help` | Show command help. |

--- a/documentation/general/dotnetup/reference/dotnetup-install.md
+++ b/documentation/general/dotnetup/reference/dotnetup-install.md
@@ -33,7 +33,7 @@ derive one, it uses `latest`.
 | --- | --- |
 | `--install-path <INSTALL_PATH>` | Select the installation root. |
 | `--set-default-install [<true\|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
-| `--migrate-from-system [<true\|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected hive. |
+| `--migrate-from-system [<true\|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected installation root. |
 | `--update-global-json [<true\|false>]` | Replace `sdk.version` in the applicable `global.json` with the installed version. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--interactive [<true\|false>]` | Allow first-use onboarding to wait for input. |
@@ -63,7 +63,7 @@ Install the requirement from `global.json` and write the resolved version:
 dotnetup install --update-global-json
 ```
 
-Install in a repository-local hive:
+Install in a repository-local installation root:
 
 ```dotnetcli
 dotnetup install 10.0.1xx --install-path .\.dotnet

--- a/documentation/general/dotnetup/reference/dotnetup-runtime-install.md
+++ b/documentation/general/dotnetup/reference/dotnetup-runtime-install.md
@@ -37,7 +37,7 @@ only on Windows.
 | --- | --- |
 | `--install-path <INSTALL_PATH>` | Select the installation root. |
 | `--set-default-install [<true\|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
-| `--migrate-from-system [<true\|false>]` | Install matching native-architecture runtimes from a system-managed installation into the selected hive. |
+| `--migrate-from-system [<true\|false>]` | Install matching native-architecture runtimes from a system-managed installation into the selected installation root. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--interactive [<true\|false>]` | Allow first-use onboarding to wait for input. |
 | `--no-progress [<true\|false>]` | Disable progress display. |

--- a/documentation/general/dotnetup/reference/dotnetup-sdk-install.md
+++ b/documentation/general/dotnetup/reference/dotnetup-sdk-install.md
@@ -33,7 +33,7 @@ When no value is present, `dotnetup` derives the channel from the nearest
 | --- | --- |
 | `--install-path <INSTALL_PATH>` | Select the installation root. |
 | `--set-default-install [<true\|false>]` | The current parser accepts this option. The current install handler does not apply its environment changes. Use `dotnetup env set` after installation. |
-| `--migrate-from-system [<true\|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected hive. |
+| `--migrate-from-system [<true\|false>]` | Install matching native-architecture SDKs from a system-managed installation into the selected installation root. |
 | `--update-global-json [<true\|false>]` | Replace `sdk.version` in the applicable `global.json` with the installed version. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
 | `--interactive [<true\|false>]` | Allow first-use onboarding to wait for input. |

--- a/documentation/general/dotnetup/reference/dotnetup-uninstall.md
+++ b/documentation/general/dotnetup/reference/dotnetup-uninstall.md
@@ -33,7 +33,7 @@ find the stored value.
 | --- | --- |
 | `--source <explicit\|globaljson\|all>` | Remove specifications from the selected source. The default is `explicit`. |
 | `--manifest-path <MANIFEST_PATH>` | Use a custom manifest file. |
-| `--install-path <INSTALL_PATH>` | Select the installation root. Without this option, use the current managed default or the default hive. |
+| `--install-path <INSTALL_PATH>` | Select the installation root. Without this option, use the current managed root or the default installation root. |
 | `-?`, `-h`, `--help` | Show command help. |
 
 ## Examples

--- a/documentation/general/dotnetup/reference/dotnetup-update.md
+++ b/documentation/general/dotnetup/reference/dotnetup-update.md
@@ -46,7 +46,7 @@ Update all tracked components:
 dotnetup update
 ```
 
-Update one hive and its repository files:
+Update one installation root and its repository files:
 
 ```dotnetcli
 dotnetup update --install-path .\.dotnet --update-global-json

--- a/documentation/general/dotnetup/toc.yml
+++ b/documentation/general/dotnetup/toc.yml
@@ -68,8 +68,8 @@
     href: usecases/update-installations.md
   - name: Manage the environment
     href: usecases/manage-environment.md
-  - name: Manage custom hives
-    href: usecases/manage-custom-hives.md
+  - name: Manage custom installation roots
+    href: usecases/manage-custom-installation-roots.md
   - name: Use preview and daily builds
     href: usecases/try-daily-builds.md
   - name: Use dotnetup in automation

--- a/documentation/general/dotnetup/usecases/automation.md
+++ b/documentation/general/dotnetup/usecases/automation.md
@@ -35,7 +35,8 @@ dotnetup sdk install 10.0.1xx --install-path .\.dotnet --no-progress
 ```
 
 Run the local executable directly or activate it with `dotnetup env script`.
-The forwarding command uses the default dotnetup hive.
+The forwarding command uses the default dotnetup-managed .NET installation
+root.
 
 ## Read state as JSON
 
@@ -62,5 +63,5 @@ manifest. Use an isolated `--manifest-path` for independent jobs.
 ## See also
 
 - [dotnetup list](../reference/dotnetup-list.md)
-- [Manage custom hives](manage-custom-hives.md)
+- [Manage custom installation roots](manage-custom-installation-roots.md)
 - [Update tracked installations](update-installations.md)

--- a/documentation/general/dotnetup/usecases/install-components.md
+++ b/documentation/general/dotnetup/usecases/install-components.md
@@ -55,7 +55,7 @@ untracked install.
 ## Migrate native-architecture components
 
 To copy matching components from system-managed .NET locations into the
-selected hive, run:
+selected installation root, run:
 
 ```dotnetcli
 dotnetup sdk install --migrate-from-system

--- a/documentation/general/dotnetup/usecases/install-with-global-json.md
+++ b/documentation/general/dotnetup/usecases/install-with-global-json.md
@@ -61,7 +61,7 @@ The install-path precedence is:
 
 1. `--install-path`
 2. The first `sdk.paths` entry
-3. The default dotnetup hive
+3. The default dotnetup-managed .NET installation root
 
 ### The `$host$` sentinel
 
@@ -70,10 +70,10 @@ The install-path precedence is:
 | First meaningful `sdk.paths` entry | Where dotnetup installs |
 |------------------------------------|-------------------------|
 | A relative or absolute path (e.g. `.dotnet`) | That path, resolved relative to the directory containing `global.json` |
-| `$host$` | The default dotnetup hive (e.g. `~/.dotnet`) |
-| *(no usable entry — empty, or only null/whitespace)* | The default dotnetup hive |
+| `$host$` | The default dotnetup-managed .NET installation root |
+| *(no usable entry — empty, or only null/whitespace)* | The default dotnetup-managed .NET installation root |
 
-Because `sdk.paths` is ordered, the first meaningful entry wins. `["$host$", ".dotnet"]` installs to the default hive and ignores `.dotnet`, while `[".dotnet", "$host$"]` installs to `.dotnet`. A literal path does *not* take precedence over `$host$` unless it appears first.
+Because `sdk.paths` is ordered, the first meaningful entry wins. `["$host$", ".dotnet"]` installs to the default installation root and ignores `.dotnet`, while `[".dotnet", "$host$"]` installs to `.dotnet`. A literal path does *not* take precedence over `$host$` unless it appears first.
 
 ## Update `global.json`
 

--- a/documentation/general/dotnetup/usecases/manage-custom-installation-roots.md
+++ b/documentation/general/dotnetup/usecases/manage-custom-installation-roots.md
@@ -1,14 +1,14 @@
 ---
-title: Manage custom dotnetup hives
+title: Manage custom dotnetup installation roots
 description: Install and manage .NET in custom roots and isolated manifests.
 ms.topic: how-to
 ms.date: 08/07/2026
 ---
 
-# Manage custom dotnetup hives
+# Manage custom dotnetup installation roots
 
-A custom hive can isolate repository, test, or tool installations from the
-default dotnetup root.
+A custom installation root can isolate repository, test, or tool installations
+from the default dotnetup-managed .NET installation root.
 
 ## Track a custom root in the default manifest
 
@@ -46,9 +46,9 @@ dotnetup sdk install 10.0 \
 
 Repeat `--manifest-path` for later list, update, and uninstall operations.
 This option applies to one command. It does not move the dotnetup configuration
-file or change the default hive.
+file or change the default installation root.
 
-## Run the custom hive
+## Run the custom installation
 
 Run its executable directly, or activate it for the current shell:
 

--- a/documentation/general/dotnetup/usecases/try-daily-builds.md
+++ b/documentation/general/dotnetup/usecases/try-daily-builds.md
@@ -29,14 +29,14 @@ dotnetup sdk install 11.0.1xx-preview.5-daily
 
 ## Isolate a daily SDK
 
-Use a separate hive when you do not want daily and stable installations in the
-same root:
+Use a separate installation root when you do not want daily and stable
+installations in the same root:
 
 ```dotnetcli
 dotnetup sdk install daily --install-path .\.dotnet-daily
 ```
 
-Run the hive executable directly:
+Run the installation's executable directly:
 
 ```powershell
 .\.dotnet-daily\dotnet.exe --version
@@ -48,8 +48,8 @@ On Linux or macOS, run:
 ./.dotnet-daily/dotnet --version
 ```
 
-`dotnetup dotnet` selects the default dotnetup hive. It does not automatically
-select an arbitrary `--install-path`.
+`dotnetup dotnet` selects the default dotnetup-managed .NET installation root.
+It does not automatically select an arbitrary `--install-path`.
 
 ## Install daily runtimes
 
@@ -75,4 +75,4 @@ An exact prerelease version is pinned and is not changed by update commands.
 
 - [Daily channels](../channels/daily.md)
 - [Preview channels](../channels/preview.md)
-- [Manage custom hives](manage-custom-hives.md)
+- [Manage custom installation roots](manage-custom-installation-roots.md)


### PR DESCRIPTION
"Hive" seems to be a term we invented for dotnetup and I think we should avoid it in user-facing documentation.  This PR switches to other terminology, mostly "installation root".