### PR TITLE
Optimize top-level command help parsing

### DIFF
--- a/src/Cli/Microsoft.DotNet.Cli.CommandLine/ResultNavigationExtensions.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.CommandLine/ResultNavigationExtensions.cs
@@ -48,7 +48,23 @@ public static class ResultNavigationExtensions
     /// </summary>
     public static T? SafelyGetValueForOption<T>(this ParseResult parseResult, string name)
     {
-        if (parseResult.GetResult(name) is OptionResult optionResult // only return a value if there _is_ a value - default or otherwise
+        Option? option = null;
+        for (CommandResult? commandResult = parseResult.CommandResult;
+            commandResult is not null && option is null;
+            commandResult = commandResult.Parent as CommandResult)
+        {
+            foreach (Option candidate in commandResult.Command.Options)
+            {
+                if (candidate.Name == name || candidate.Aliases.Contains(name))
+                {
+                    option = candidate;
+                    break;
+                }
+            }
+        }
+
+        if (option is not null
+            && parseResult.GetResult(option) is OptionResult optionResult // only return a value if there _is_ a value - default or otherwise
             && !parseResult.Errors.Any(e => e.SymbolResult == optionResult) // only return a value if this isn't a parsing error
             && optionResult.Option.ValueType.IsAssignableTo(typeof(T))) // only return a value if coercing the type won't error
         {
@@ -56,7 +72,7 @@ public static class ResultNavigationExtensions
             // be resistant to errors
             try
             {
-                return optionResult.GetValue<T>(name);
+                return optionResult.GetValueOrDefault<T>();
             }
             catch
             {

--- a/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/New/NewCommandDefinition.cs
+++ b/src/Cli/Microsoft.DotNet.Cli.Definitions/Commands/New/NewCommandDefinition.cs
@@ -167,6 +167,12 @@ public sealed class NewCommandDefinition : Command
         Subcommands.Add(LegacyShowAliasCommand);
     }
 
+    internal static bool IsGenericHelpInvocation(string[] args)
+        => args is [Name, var helpOption] && IsHelpOption(helpOption)
+            || args is [Name, NewCreateCommandDefinition.Name, var createHelpOption] && IsHelpOption(createHelpOption);
+
+    private static bool IsHelpOption(string option) => option is "-h" or "/h" or "--help" or "-?" or "/?";
+
     public static Option<bool> CreateDebugRebuildCacheOption() => new("--debug:rebuild-cache", "--debug:rebuildcache")
     {
         Description = CommandDefinitionStrings.Option_Debug_RebuildCache,

--- a/src/Cli/dotnet-aot/DESIGN.md
+++ b/src/Cli/dotnet-aot/DESIGN.md
@@ -118,10 +118,12 @@ A NativeAOT shared library (`NativeLib=Shared`) that exports a single
 the dual-path dispatch logic.
 
 **Fast path** — Unless `DOTNET_CLI_ENABLEAOT` is explicitly disabled, the AOT
-bridge builds the
-**full** command tree (the same `DotNetCommandDefinition` used by the managed
-CLI) so that parsing and `--help` match the managed CLI exactly. Commands that
-can run entirely in AOT (`--version`, `--info`, the AOT-capable `sln`
+bridge normally builds the **full** command tree (the same `DotNetCommandDefinition`
+used by the managed CLI). Exact top-level `<command> <help-alias>` invocations instead
+build a minimal root containing only the selected static command definition. Dynamic
+`new` and `test` help still defers to the managed CLI, and `completions` remains on the
+full-tree managed path because its configuration is not in the AOT dependency closure.
+Commands that can run entirely in AOT (`--version`, `--info`, the AOT-capable `sln`
 subcommands, the narrow file-based run path, and build-free
 `test --test-modules` invocations described below) execute immediately and return.
 Other built-in command shapes are wired with a fallback action that throws
@@ -258,7 +260,10 @@ the appropriate implementation:
 In the shared files:
 
 - **`Parser.cs`** — A single shared `Parser` class builds the same full
-  `DotNetCommandDefinition` tree in both modes. Only the action wiring differs,
+  `DotNetCommandDefinition` tree in both modes for ordinary parsing. Exact static
+  top-level help may use a minimal root containing one command; managed-only dynamic
+  augmentation and the AOT exclusions above keep its output aligned with the full path.
+  Full-tree action wiring differs,
   isolated to small inline `#if CLI_AOT` regions: the managed build wires the
   real command handlers, while the AOT build attaches a managed-fallback handler
   to every command (overriding it with real implementations where AOT can run

--- a/src/Cli/dotnet-aot/NativeEntryPoint.cs
+++ b/src/Cli/dotnet-aot/NativeEntryPoint.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.DotNet.Cli.CommandFactory;
 using Microsoft.DotNet.Cli.CommandFactory.CommandResolution;
+using Microsoft.DotNet.Cli.Commands.New;
 using Microsoft.DotNet.Cli.Commands.Run;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Utils;
@@ -178,12 +179,22 @@ static unsafe partial class NativeEntryPoint
             // can use it instead of re-probing PATH / environment for the dotnet installation.
             DotnetRoot = string.IsNullOrEmpty(dotnetRoot) ? null : dotnetRoot;
 
-            if (EnvironmentVariableParser.ParseBool(Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_ENABLEAOT), defaultValue: true))
+            if (ShouldAttemptAotExecution(args))
             {
                 ParseResult? parseResult = null;
+                bool genericCommandHelp = false;
                 using (var parse = Activities.Source.StartActivity("parse"))
                 {
-                    parseResult = Parser.Parse(args);
+                    if (Parser.TryParseGenericCommandHelp(args, out ParseResult? genericHelpParseResult))
+                    {
+                        genericCommandHelp = true;
+                        parseResult = genericHelpParseResult;
+                    }
+                    else
+                    {
+                        parseResult = Parser.Parse(args);
+                    }
+
                     mainActivity?.SetDisplayName(parseResult);
                 }
 
@@ -207,7 +218,7 @@ static unsafe partial class NativeEntryPoint
 
                 if (firstRunCompleted)
                 {
-                    if (parseResult.CanBeInvoked())
+                    if (genericCommandHelp || parseResult.CanBeInvoked())
                     {
                         // Parse errors here usually mean the command is contributed dynamically by the managed
                         // CLI (e.g. NuGet's `package update`/`why`) and absent from the static AOT tree, so defer.
@@ -288,6 +299,12 @@ static unsafe partial class NativeEntryPoint
             }
         }
     }
+
+    internal static bool ShouldAttemptAotExecution(string[] args)
+        => EnvironmentVariableParser.ParseBool(
+            Environment.GetEnvironmentVariable(EnvironmentVariableNames.DOTNET_CLI_ENABLEAOT),
+            defaultValue: true)
+        && !NewCommandDefinition.IsGenericHelpInvocation(args);
 
     /// <summary>
     ///  Attempts to resolve and invoke an external/tool command (e.g. <c>dotnet ef</c>, a global or

--- a/src/Cli/dotnet/Commands/Package/PackageCommandParser.cs
+++ b/src/Cli/dotnet/Commands/Package/PackageCommandParser.cs
@@ -41,6 +41,9 @@ internal sealed class PackageCommandParser
 
     internal static void ConfigureAddCommand(PackageAddCommandDefinitionBase def)
     {
+        // Keep network-backed shell completions out of help usage labels.
+        def.PackageIdArgument.HelpName ??= def.PackageIdArgument.Name;
+
         def.PackageIdArgument.CompletionSources.Add(context =>
         {
             // we should take --prerelease flags into account for version completion

--- a/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
@@ -138,9 +138,13 @@ public static class ParseResultExtensions
         parseResult.IsDotnetBuiltInCommand()
         || parseResult.Tokens.Any(token => token.Type == TokenType.Directive);
 
-    public static bool IsDotnetBuiltInCommand(this ParseResult parseResult) =>
-        string.IsNullOrEmpty(parseResult.RootSubCommandResult())
-        || parseResult.RootCommandResult.Children.OfType<CommandResult>().Any();
+    public static bool IsDotnetBuiltInCommand(this ParseResult parseResult)
+    {
+        string rootSubCommand = parseResult.RootSubCommandResult();
+        return string.IsNullOrEmpty(rootSubCommand)
+            || parseResult.RootCommandResult.Children.OfType<CommandResult>()
+                .Any(result => result.Command.Name.Equals(rootSubCommand, StringComparison.OrdinalIgnoreCase));
+    }
 
     public static void ShowHelpOrErrorIfAppropriate(this ParseResult parseResult)
     {

--- a/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
@@ -138,7 +138,7 @@ public static class ParseResultExtensions
 
     public static bool IsDotnetBuiltInCommand(this ParseResult parseResult) =>
         string.IsNullOrEmpty(parseResult.RootSubCommandResult())
-        || Parser.GetBuiltInCommand(parseResult.RootSubCommandResult()) != null;
+        || parseResult.RootCommandResult.Children.OfType<CommandResult>().Any();
 
     public static void ShowHelpOrErrorIfAppropriate(this ParseResult parseResult)
     {

--- a/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
+++ b/src/Cli/dotnet/Extensions/ParseResultExtensions.cs
@@ -109,7 +109,10 @@ public static class ParseResultExtensions
     }
 
     public static string[] GetArguments(this ParseResult parseResult) =>
-        parseResult.Tokens.Select(t => t.Value).ToArray().GetSubArguments();
+        [.. parseResult.Tokens
+            .SkipWhile(static token => token.Type != TokenType.Command)
+            .Skip(1)
+            .Select(static token => token.Value)];
 
     public static string[] GetSubArguments(this string[] args)
     {
@@ -132,9 +135,8 @@ public static class ParseResultExtensions
     }
 
     public static bool CanBeInvoked(this ParseResult parseResult) =>
-        Parser.GetBuiltInCommand(parseResult.RootSubCommandResult()) != null
-        || parseResult.Tokens.Any(token => token.Type == TokenType.Directive)
-        || (parseResult.IsTopLevelDotnetCommand() && string.IsNullOrEmpty(parseResult.GetValue(Parser.RootCommand.DotnetSubCommand)));
+        parseResult.IsDotnetBuiltInCommand()
+        || parseResult.Tokens.Any(token => token.Type == TokenType.Directive);
 
     public static bool IsDotnetBuiltInCommand(this ParseResult parseResult) =>
         string.IsNullOrEmpty(parseResult.RootSubCommandResult())

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -144,12 +144,17 @@ public static class Parser
 
         rootCommand.Subcommands.Add(command);
 #if !CLI_AOT
-        if (command is CompletionsCommandDefinition completionsCommand)
+        if (command is AddCommandDefinition addCommand)
+        {
+            AddCommandParser.ConfigureCommand(addCommand);
+        }
+        else if (command is CompletionsCommandDefinition completionsCommand)
         {
             CompletionsCommandParser.ConfigureCommand(completionsCommand);
         }
-        else if (command is PackageCommandDefinition)
+        else if (command is PackageCommandDefinition packageCommand)
         {
+            PackageCommandParser.ConfigureCommand(packageCommand);
             NuGet.CommandLine.XPlat.NuGetCommands.Add(rootCommand, CommonOptions.CreateInteractiveOption(acceptArgument: true), NuGetVirtualProjectBuilder.Instance);
         }
 #endif

--- a/src/Cli/dotnet/Parser.cs
+++ b/src/Cli/dotnet/Parser.cs
@@ -3,22 +3,43 @@
 
 using System.CommandLine;
 using System.CommandLine.Help;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Microsoft.DotNet.Cli.Commands;
+using Microsoft.DotNet.Cli.Commands.Build;
+using Microsoft.DotNet.Cli.Commands.BuildServer;
+using Microsoft.DotNet.Cli.Commands.Clean;
+using Microsoft.DotNet.Cli.Commands.Dnx;
 using Microsoft.DotNet.Cli.Commands.Format;
 using Microsoft.DotNet.Cli.Commands.Fsi;
+using Microsoft.DotNet.Cli.Commands.Help;
 using Microsoft.DotNet.Cli.Commands.Hidden.Add;
 using Microsoft.DotNet.Cli.Commands.Hidden.Add.Package;
+using Microsoft.DotNet.Cli.Commands.Hidden.Complete;
+using Microsoft.DotNet.Cli.Commands.Hidden.InternalReportInstallSuccess;
 using Microsoft.DotNet.Cli.Commands.Hidden.List;
 using Microsoft.DotNet.Cli.Commands.Hidden.List.Reference;
+using Microsoft.DotNet.Cli.Commands.Hidden.Parse;
+using Microsoft.DotNet.Cli.Commands.Hidden.Remove;
 using Microsoft.DotNet.Cli.Commands.MSBuild;
+using Microsoft.DotNet.Cli.Commands.New;
 using Microsoft.DotNet.Cli.Commands.NuGet;
+using Microsoft.DotNet.Cli.Commands.Pack;
+using Microsoft.DotNet.Cli.Commands.Package;
+using Microsoft.DotNet.Cli.Commands.Project;
+using Microsoft.DotNet.Cli.Commands.Publish;
+using Microsoft.DotNet.Cli.Commands.Reference;
+using Microsoft.DotNet.Cli.Commands.Restore;
 using Microsoft.DotNet.Cli.Commands.Run;
+using Microsoft.DotNet.Cli.Commands.Run.Api;
 using Microsoft.DotNet.Cli.Commands.Sdk;
 using Microsoft.DotNet.Cli.Commands.Solution;
 using Microsoft.DotNet.Cli.Commands.Test;
 using Microsoft.DotNet.Cli.Commands.Tool;
+using Microsoft.DotNet.Cli.Commands.Tool.Store;
 using Microsoft.DotNet.Cli.Commands.VSTest;
+using Microsoft.DotNet.Cli.Commands.Workload;
 using Microsoft.DotNet.Cli.Commands.Workload.Search;
 using Microsoft.DotNet.Cli.Extensions;
 using Microsoft.DotNet.Cli.Help;
@@ -26,38 +47,17 @@ using Microsoft.DotNet.Cli.Utils;
 using Microsoft.DotNet.Cli.Utils.Extensions;
 using Microsoft.TemplateEngine.Cli;
 using Command = System.CommandLine.Command;
-using System.Diagnostics.CodeAnalysis;
-using System.Runtime.CompilerServices;
-
-
 
 #if !CLI_AOT
 using System.CommandLine.StaticCompletions;
-using Microsoft.DotNet.Cli.Commands.Build;
-using Microsoft.DotNet.Cli.Commands.BuildServer;
-using Microsoft.DotNet.Cli.Commands.Clean;
-using Microsoft.DotNet.Cli.Commands.Dnx;
-using Microsoft.DotNet.Cli.Commands.Help;
-using Microsoft.DotNet.Cli.Commands.Hidden.Complete;
-using Microsoft.DotNet.Cli.Commands.Hidden.InternalReportInstallSuccess;
-using Microsoft.DotNet.Cli.Commands.Hidden.Parse;
-using Microsoft.DotNet.Cli.Commands.Hidden.Remove;
-using Microsoft.DotNet.Cli.Commands.New;
-using Microsoft.DotNet.Cli.Commands.Pack;
-using Microsoft.DotNet.Cli.Commands.Package;
-using Microsoft.DotNet.Cli.Commands.Project;
-using Microsoft.DotNet.Cli.Commands.Publish;
-using Microsoft.DotNet.Cli.Commands.Reference;
-using Microsoft.DotNet.Cli.Commands.Restore;
-using Microsoft.DotNet.Cli.Commands.Run.Api;
-using Microsoft.DotNet.Cli.Commands.Tool.Store;
-using Microsoft.DotNet.Cli.Commands.Workload;
 #endif
 
 namespace Microsoft.DotNet.Cli;
 
 public static class Parser
 {
+    private static readonly Lazy<DotNetCommandDefinition> s_rootCommand = new(CreateCommand);
+
     /// <summary>
     /// The root command for the .NET CLI.
     /// </summary>
@@ -66,7 +66,7 @@ public static class Parser
     /// and <see cref="InvocationConfiguration"/> to ensure that the command line parser
     /// and invoker are configured correctly.
     /// </remarks>
-    internal static DotNetCommandDefinition RootCommand { get; } = CreateCommand();
+    internal static DotNetCommandDefinition RootCommand => s_rootCommand.Value;
 
     private static DotNetCommandDefinition CreateCommand()
     {
@@ -105,6 +105,99 @@ public static class Parser
 
         return rootCommand;
     }
+
+    internal static bool TryParseGenericCommandHelp(string[] args, [NotNullWhen(true)] out ParseResult? parseResult)
+    {
+        Command? command;
+#if !CLI_AOT
+        if (NewCommandDefinition.IsGenericHelpInvocation(args))
+        {
+            command = NewCommandParser.ConfigureCommand(new NewCommandDefinition());
+        }
+        else
+#endif
+        if (args is [var commandName, var helpArgument] && IsHelpOption(helpArgument))
+        {
+            command = CreateCommandForGenericHelp(commandName);
+            if (command is null)
+            {
+                parseResult = null;
+                return false;
+            }
+        }
+        else
+        {
+            parseResult = null;
+            return false;
+        }
+
+        RootCommand rootCommand = new();
+        foreach (Option option in rootCommand.Options)
+        {
+            if (option is HelpOption helpOption)
+            {
+                helpOption.Action = new PrintHelpAction(helpOption, DotnetHelpBuilder.Instance.Value);
+                helpOption.Description = CliStrings.ShowHelpDescription;
+                break;
+            }
+        }
+
+        rootCommand.Subcommands.Add(command);
+#if !CLI_AOT
+        if (command is CompletionsCommandDefinition completionsCommand)
+        {
+            CompletionsCommandParser.ConfigureCommand(completionsCommand);
+        }
+        else if (command is PackageCommandDefinition)
+        {
+            NuGet.CommandLine.XPlat.NuGetCommands.Add(rootCommand, CommonOptions.CreateInteractiveOption(acceptArgument: true), NuGetVirtualProjectBuilder.Instance);
+        }
+#endif
+
+        parseResult = rootCommand.Parse(args, ParserConfiguration);
+        return true;
+    }
+
+    private static bool IsHelpOption(string option)
+        => option is "-h" or "/h" or "--help" or "-?" or "/?";
+
+    private static Command? CreateCommandForGenericHelp(string commandName)
+        => commandName switch
+        {
+            "add" => new AddCommandDefinition(),
+            "build" => new BuildCommandDefinition(),
+            "build-server" => new BuildServerCommandDefinition(),
+            "clean" => new CleanCommandDefinition(),
+            "complete" => new CompleteCommandDefinition(),
+#if !CLI_AOT
+            "completions" => new CompletionsCommandDefinition(),
+#endif
+            "dnx" => new DnxCommandDefinition(),
+            "format" => new FormatCommandDefinition(),
+            "fsi" => new FsiCommandDefinition(),
+            "help" => new HelpCommandDefinition(),
+            "internal-reportinstallsuccess" => new InternalReportInstallSuccessCommandDefinition(),
+            "list" => new ListCommandDefinition(),
+            "msbuild" => new MSBuildCommandDefinition(),
+            "nuget" => new NuGetCommandDefinition(),
+            "pack" => new PackCommandDefinition(),
+            "package" => new PackageCommandDefinition(),
+            "parse" => new ParseCommandDefinition(),
+            "project" => new ProjectCommandDefinition(),
+            "publish" => new PublishCommandDefinition(),
+            "reference" => new ReferenceCommandDefinition(),
+            "remove" => new RemoveCommandDefinition(),
+            "restore" => new RestoreCommandDefinition(),
+            "run" => new RunCommandDefinition(),
+            "run-api" => new RunApiCommandDefinition(),
+            "sdk" => new SdkCommandDefinition(),
+            "sln" or "solution" => new SolutionCommandDefinition(),
+            "store" => new StoreCommandDefinition(),
+            "tool" => new ToolCommandDefinition(),
+            "vstest" => new VSTestCommandDefinition(),
+            "workload" => new WorkloadCommandDefinition(),
+            _ => null
+        };
 
     /// <summary>
     /// Applies tweaks to the options that <see cref="DotNetCommandDefinition"/> inherits from
@@ -449,7 +542,7 @@ public static class Parser
             var command = context.Command;
 
             // custom help overrides
-            if (command.Equals(RootCommand))
+            if (ReferenceEquals(command, context.ParseResult.RootCommandResult.Command))
             {
                 Console.Out.WriteLine(CliUsage.HelpText);
                 return;

--- a/src/Cli/dotnet/Program.cs
+++ b/src/Cli/dotnet/Program.cs
@@ -131,14 +131,14 @@ public class Program
 
     internal static int ProcessArgsAndExecute(string[] args)
     {
-        ParseResult parseResult = ParseArgs(args);
+        ParseResult parseResult = ParseArgs(args, out bool genericCommandHelp);
         // Run the cross-cutting first-run experience (first-time-use notice, telemetry message,
         // ASP.NET dev cert, global-tools PATH, workload integrity check). Terminating options such as
         // "dotnet --version" are skipped inside Setup.
         FirstRunExperience.Setup(parseResult);
 
         TelemetryEventEntry.SendFiltered(new ParseResultWithGlobalJsonState(parseResult, s_globalJsonState));
-        if (parseResult.CanBeInvoked())
+        if (genericCommandHelp || parseResult.CanBeInvoked())
         {
             return CommandInvocation.ExecuteInternalCommand(parseResult);
         }
@@ -154,12 +154,21 @@ public class Program
             return 1;
         }
 
-        static ParseResult ParseArgs(string[] args)
+        static ParseResult ParseArgs(string[] args, out bool genericCommandHelp)
         {
             ParseResult parseResult;
             using (var parseActivity = Activities.Source.StartActivity("parse"))
             {
-                parseResult = Parser.Parse(args);
+                if (Parser.TryParseGenericCommandHelp(args, out ParseResult? genericHelpParseResult))
+                {
+                    genericCommandHelp = true;
+                    parseResult = genericHelpParseResult;
+                }
+                else
+                {
+                    genericCommandHelp = false;
+                    parseResult = Parser.Parse(args);
+                }
 
                 // Avoid create temp directory with root permission and later prevent access in non sudo
                 // This method need to be run very early before temp folder get created

--- a/test/dotnet-aot.Tests/AotParserTests.cs
+++ b/test/dotnet-aot.Tests/AotParserTests.cs
@@ -69,6 +69,51 @@ public partial class AotParserTests
     }
 
     [TestMethod]
+    [DataRow("build --help")]
+    [DataRow("package --help")]
+    [DataRow("sln --help")]
+    [DataRow("tool --help")]
+    [DataRow("workload --help")]
+    public void ParseGenericCommandHelp_UsesMinimalTreeWithFullParserParity(string commandLine)
+    {
+        string[] args = commandLine.Split(' ');
+        Assert.IsTrue(Parser.TryParseGenericCommandHelp(args, out ParseResult? minimalResult));
+        Assert.HasCount(1, minimalResult.RootCommandResult.Command.Subcommands);
+
+        (int minimalExitCode, string minimalOutput, string minimalError) = InvokeWithCapture(minimalResult);
+        (int fullExitCode, string fullOutput, string fullError) = InvokeWithCapture(Parser.Parse(args));
+
+        Assert.AreEqual(fullExitCode, minimalExitCode);
+        Assert.AreEqual(fullOutput, minimalOutput);
+        Assert.AreEqual(fullError, minimalError);
+    }
+
+    [TestMethod]
+    [DataRow("new --help")]
+    [DataRow("new create --help")]
+    [DataRow("test --help")]
+    [DataRow("completions --help")]
+    public void ParseGenericCommandHelp_RejectsDynamicHelp(string commandLine)
+    {
+        Assert.IsFalse(Parser.TryParseGenericCommandHelp(commandLine.Split(' '), out ParseResult? parseResult));
+        Assert.IsNull(parseResult);
+    }
+
+    [TestMethod]
+    public void ParseGenericCommandHelp_CoversEveryEligibleTopLevelCommand()
+    {
+        HashSet<string> excludedCommands = ["new", "test", "completions"];
+
+        foreach (System.CommandLine.Command command in Parser.RootCommand.Subcommands)
+        {
+            Assert.AreEqual(
+                !excludedCommands.Contains(command.Name),
+                Parser.TryParseGenericCommandHelp([command.Name, "--help"], out _),
+                command.Name);
+        }
+    }
+
+    [TestMethod]
     public void ParseSdkCheck_HasNoErrors()
     {
         // `sdk check` is AOT-capable, so it parses cleanly from the shared command tree.

--- a/test/dotnet-aot.Tests/NativeEntryPointTests.cs
+++ b/test/dotnet-aot.Tests/NativeEntryPointTests.cs
@@ -680,6 +680,24 @@ public partial class NativeEntryPointTests
         });
     }
 
+    [TestMethod]
+    [DataRow("new --help", false)]
+    [DataRow("new -h", false)]
+    [DataRow("new create --help", false)]
+    [DataRow("new create -h", false)]
+    [DataRow("new console --help", true)]
+    [DataRow("new install --help", true)]
+    [DataRow("build --help", true)]
+    public void ShouldAttemptAotExecution_SkipsOnlyGenericNewHelp(string commandLine, bool expected)
+    {
+        WithEnvRestore(() =>
+        {
+            Environment.SetEnvironmentVariable("DOTNET_CLI_ENABLEAOT", "true");
+
+            Assert.AreEqual(expected, NativeEntryPoint.ShouldAttemptAotExecution(commandLine.Split(' ')));
+        });
+    }
+
 
     [TestMethod]
     public void ExecuteCore_SetsHostfxrPathInAppContext()

--- a/test/dotnet.Tests/ParserTests/GenericCommandHelpParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/GenericCommandHelpParserTests.cs
@@ -3,6 +3,8 @@
 
 using System.CommandLine;
 using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Commands.Hidden.Add;
+using Microsoft.DotNet.Cli.Commands.Package;
 using Microsoft.DotNet.Cli.Extensions;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
@@ -128,11 +130,31 @@ public class GenericCommandHelpParserTests
     }
 
     [TestMethod]
-    public void IsDotnetBuiltInCommand_DistinguishesBuiltInAndExternalCommands()
+    [DataRow("add")]
+    [DataRow("package")]
+    public void TryParseGenericCommandHelp_PreservesPackageIdCompletionSources(string commandName)
     {
-        Assert.IsTrue(Parser.Parse(["build"]).IsDotnetBuiltInCommand());
-        Assert.IsFalse(Parser.Parse(["external-command"]).IsDotnetBuiltInCommand());
+        Assert.IsTrue(Parser.TryParseGenericCommandHelp([commandName, "--help"], out ParseResult? parseResult));
+
+        Command minimalCommand = parseResult.RootCommandResult.Command.Subcommands.Single();
+        Command fullCommand = Parser.RootCommand.Subcommands.Single(command => command.Name == commandName);
+
+        Assert.AreEqual(
+            GetPackageIdCompletionSourceCount(fullCommand),
+            GetPackageIdCompletionSourceCount(minimalCommand));
     }
+
+    [TestMethod]
+    [DataRow("build")]
+    [DataRow("sln")]
+    public void IsDotnetBuiltInCommand_RecognizesBuiltInCommands(string commandName)
+    {
+        Assert.IsTrue(Parser.Parse([commandName]).IsDotnetBuiltInCommand());
+    }
+
+    [TestMethod]
+    public void IsDotnetBuiltInCommand_RejectsExternalCommand()
+        => Assert.IsFalse(Parser.Parse(["external-command"]).IsDotnetBuiltInCommand());
 
     [TestMethod]
     [DataRow("new --help")]
@@ -188,4 +210,11 @@ public class GenericCommandHelpParserTests
 
         return (parseResult.Invoke(configuration), output.ToString(), error.ToString());
     }
+
+    private static int GetPackageIdCompletionSourceCount(Command command) => command switch
+    {
+        AddCommandDefinition add => add.PackageCommand.PackageIdArgument.CompletionSources.Count,
+        PackageCommandDefinition package => package.AddCommand.PackageIdArgument.CompletionSources.Count,
+        _ => throw new ArgumentException($"Unexpected command '{command.Name}'.", nameof(command))
+    };
 }

--- a/test/dotnet.Tests/ParserTests/GenericCommandHelpParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/GenericCommandHelpParserTests.cs
@@ -1,0 +1,191 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.CommandLine;
+using Microsoft.DotNet.Cli.CommandLine;
+using Microsoft.DotNet.Cli.Extensions;
+using Parser = Microsoft.DotNet.Cli.Parser;
+
+namespace Microsoft.DotNet.Tests.ParserTests;
+
+[TestClass]
+public class GenericCommandHelpParserTests
+{
+    [TestMethod]
+    public void SafelyGetValueForOption_ReturnsDefaultWhenOptionIsNotInCommandTree()
+    {
+        ParseResult parseResult = new RootCommand().Parse([]);
+
+        Assert.IsNull(parseResult.SafelyGetValueForOption<string>("--missing"));
+    }
+
+    [TestMethod]
+    public void SafelyGetValueForOption_ReturnsValueWhenOptionExists()
+    {
+        RootCommand rootCommand = new();
+        Command childCommand = new("child");
+        Option<string> option = new("--value");
+        childCommand.Options.Add(option);
+        rootCommand.Subcommands.Add(childCommand);
+        ParseResult parseResult = rootCommand.Parse(["child", "--value", "expected"]);
+
+        Assert.AreEqual("expected", parseResult.SafelyGetValueForOption<string>("--value"));
+    }
+
+    [TestMethod]
+    public void TryParseGenericCommandHelp_CoversEveryEligibleTopLevelCommand()
+    {
+        foreach (Command command in Parser.RootCommand.Subcommands)
+        {
+            bool expected = command.Name != "test";
+
+            Assert.AreEqual(
+                expected,
+                Parser.TryParseGenericCommandHelp([command.Name, "--help"], out _),
+                command.Name);
+        }
+    }
+
+    [TestMethod]
+    [DataRow("new -h")]
+    [DataRow("new /h")]
+    [DataRow("new --help")]
+    [DataRow("new -?")]
+    [DataRow("new /?")]
+    [DataRow("new create -h")]
+    [DataRow("new create /h")]
+    [DataRow("new create --help")]
+    [DataRow("new create -?")]
+    [DataRow("new create /?")]
+    [DataRow("build -h")]
+    [DataRow("build /h")]
+    [DataRow("build --help")]
+    [DataRow("build -?")]
+    [DataRow("build /?")]
+    [DataRow("add --help")]
+    [DataRow("build-server --help")]
+    [DataRow("clean --help")]
+    [DataRow("complete --help")]
+    [DataRow("completions --help")]
+    [DataRow("dnx --help")]
+    [DataRow("format --help")]
+    [DataRow("fsi --help")]
+    [DataRow("help --help")]
+    [DataRow("internal-reportinstallsuccess --help")]
+    [DataRow("list --help")]
+    [DataRow("msbuild --help")]
+    [DataRow("nuget --help")]
+    [DataRow("pack --help")]
+    [DataRow("package --help")]
+    [DataRow("parse --help")]
+    [DataRow("project --help")]
+    [DataRow("publish --help")]
+    [DataRow("reference --help")]
+    [DataRow("remove --help")]
+    [DataRow("restore --help")]
+    [DataRow("run --help")]
+    [DataRow("run-api --help")]
+    [DataRow("sdk --help")]
+    [DataRow("sln --help")]
+    [DataRow("solution --help")]
+    [DataRow("store --help")]
+    [DataRow("tool --help")]
+    [DataRow("vstest --help")]
+    [DataRow("workload --help")]
+    public void TryParseGenericCommandHelp_UsesMinimalCommandTree(string commandLine)
+    {
+        string[] args = commandLine.Split(' ');
+
+        Assert.IsTrue(Parser.TryParseGenericCommandHelp(args, out ParseResult? parseResult));
+        Assert.IsNotNull(parseResult);
+        Assert.IsEmpty(parseResult.Errors);
+        Assert.AreEqual("PrintHelpAction", parseResult.Action?.GetType().Name);
+        Assert.IsTrue(parseResult.IsDotnetBuiltInCommand());
+        Assert.HasCount(1, parseResult.RootCommandResult.Command.Subcommands);
+
+        ParseResult fullParseResult = Parser.Parse(args);
+        Command minimalCommand = parseResult.RootCommandResult.Command.Subcommands.Single();
+        Command fullCommand = fullParseResult.RootCommandResult.Command.Subcommands.Single(command => command.Name == minimalCommand.Name);
+        Assert.AreEqual(fullParseResult.RootSubCommandResult(), parseResult.RootSubCommandResult());
+        Assert.AreEqual(fullCommand.GetType(), minimalCommand.GetType());
+        Assert.AreEqual(fullParseResult.GetCommandName(), parseResult.GetCommandName());
+        Assert.AreEqual(fullParseResult.CommandResult.Command.Name, parseResult.CommandResult.Command.Name);
+        Assert.AreEqual(fullParseResult.Action?.GetType(), parseResult.Action?.GetType());
+    }
+
+    [TestMethod]
+    [DataRow("new")]
+    [DataRow("new console --help")]
+    [DataRow("new install --help")]
+    [DataRow("new --help --debug:ephemeral-hive")]
+    [DataRow("build")]
+    [DataRow("build --help --no-restore")]
+    [DataRow("test --help")]
+    public void TryParseGenericCommandHelp_RejectsOtherCommandShapes(string commandLine)
+    {
+        Assert.IsFalse(Parser.TryParseGenericCommandHelp(commandLine.Split(' '), out ParseResult? parseResult));
+        Assert.IsNull(parseResult);
+    }
+
+    [TestMethod]
+    public void IsDotnetBuiltInCommand_DistinguishesBuiltInAndExternalCommands()
+    {
+        Assert.IsTrue(Parser.Parse(["build"]).IsDotnetBuiltInCommand());
+        Assert.IsFalse(Parser.Parse(["external-command"]).IsDotnetBuiltInCommand());
+    }
+
+    [TestMethod]
+    [DataRow("new --help")]
+    [DataRow("new create --help")]
+    [DataRow("build --help")]
+    [DataRow("add --help")]
+    [DataRow("build-server --help")]
+    [DataRow("clean --help")]
+    [DataRow("complete --help")]
+    [DataRow("completions --help")]
+    [DataRow("dnx --help")]
+    [DataRow("help --help")]
+    [DataRow("internal-reportinstallsuccess --help")]
+    [DataRow("list --help")]
+    [DataRow("pack --help")]
+    [DataRow("package --help")]
+    [DataRow("parse --help")]
+    [DataRow("project --help")]
+    [DataRow("publish --help")]
+    [DataRow("reference --help")]
+    [DataRow("remove --help")]
+    [DataRow("restore --help")]
+    [DataRow("run --help")]
+    [DataRow("run-api --help")]
+    [DataRow("sdk --help")]
+    [DataRow("sln --help")]
+    [DataRow("solution --help")]
+    [DataRow("store --help")]
+    [DataRow("tool --help")]
+    [DataRow("workload --help")]
+    public void TryParseGenericCommandHelp_RendersSameOutputAsFullParser(string commandLine)
+    {
+        string[] args = commandLine.Split(' ');
+        Assert.IsTrue(Parser.TryParseGenericCommandHelp(args, out ParseResult? parseResult));
+
+        (int fastExitCode, string fastOutput, string fastError) = InvokeWithCapture(parseResult);
+        (int fullExitCode, string fullOutput, string fullError) = InvokeWithCapture(Parser.Parse(args));
+
+        Assert.AreEqual(fullExitCode, fastExitCode);
+        Assert.AreEqual(fullOutput, fastOutput);
+        Assert.AreEqual(fullError, fastError);
+    }
+
+    private static (int ExitCode, string Output, string Error) InvokeWithCapture(ParseResult parseResult)
+    {
+        StringWriter output = new();
+        StringWriter error = new();
+        InvocationConfiguration configuration = new()
+        {
+            Output = output,
+            Error = error
+        };
+
+        return (parseResult.Invoke(configuration), output.ToString(), error.ToString());
+    }
+}

--- a/test/dotnet.Tests/ParserTests/GenericCommandHelpParserTests.cs
+++ b/test/dotnet.Tests/ParserTests/GenericCommandHelpParserTests.cs
@@ -145,6 +145,25 @@ public class GenericCommandHelpParserTests
     }
 
     [TestMethod]
+    [DataRow("add")]
+    [DataRow("package")]
+    public void TryParseGenericCommandHelp_DoesNotEvaluatePackageIdCompletionsWhenRenderingParentHelp(string commandName)
+    {
+        Assert.IsTrue(Parser.TryParseGenericCommandHelp([commandName, "--help"], out ParseResult? parseResult));
+
+        Argument packageIdArgument = GetPackageIdArgument(parseResult.RootCommandResult.Command.Subcommands.Single());
+        packageIdArgument.CompletionSources.Clear();
+        packageIdArgument.CompletionSources.Add(_ => throw new InvalidOperationException("Package ID completions should not be evaluated when rendering help."));
+
+        (int exitCode, string output, string error) = InvokeWithCapture(parseResult);
+
+        Assert.AreEqual(0, exitCode);
+        Assert.IsNotEmpty(output);
+        Assert.IsEmpty(error);
+        Assert.HasCount(1, packageIdArgument.CompletionSources);
+    }
+
+    [TestMethod]
     [DataRow("build")]
     [DataRow("sln")]
     public void IsDotnetBuiltInCommand_RecognizesBuiltInCommands(string commandName)
@@ -211,10 +230,12 @@ public class GenericCommandHelpParserTests
         return (parseResult.Invoke(configuration), output.ToString(), error.ToString());
     }
 
-    private static int GetPackageIdCompletionSourceCount(Command command) => command switch
+    private static int GetPackageIdCompletionSourceCount(Command command) => GetPackageIdArgument(command).CompletionSources.Count;
+
+    private static Argument GetPackageIdArgument(Command command) => command switch
     {
-        AddCommandDefinition add => add.PackageCommand.PackageIdArgument.CompletionSources.Count,
-        PackageCommandDefinition package => package.AddCommand.PackageIdArgument.CompletionSources.Count,
+        AddCommandDefinition add => add.PackageCommand.PackageIdArgument,
+        PackageCommandDefinition package => package.AddCommand.PackageIdArgument,
         _ => throw new ArgumentException($"Unexpected command '{command.Name}'.", nameof(command))
     };
 }

--- a/test/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
+++ b/test/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
@@ -61,5 +61,16 @@ namespace Microsoft.DotNet.Tests.ParserTests
 
             rootCommand.Parse(["command"]).CanBeInvoked().Should().BeTrue();
         }
+
+        [TestMethod]
+        [DataRow("watch run")]
+        [DataRow("Program.cs build")]
+        public void CanBeInvoked_BuiltInLookingArgument_DoesNotMakeExternalCommandInvocable(string input)
+        {
+            ParseResult parseResult = Parser.Parse(input);
+
+            parseResult.IsDotnetBuiltInCommand().Should().BeFalse();
+            parseResult.CanBeInvoked().Should().BeFalse();
+        }
     }
 }

--- a/test/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
+++ b/test/dotnet.Tests/ParserTests/ParseResultExtensionsTests.cs
@@ -1,6 +1,7 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.CommandLine;
 using Microsoft.DotNet.Cli.Extensions;
 using Parser = Microsoft.DotNet.Cli.Parser;
 
@@ -39,6 +40,26 @@ namespace Microsoft.DotNet.Tests.ParserTests
         {
             input.GetSubArguments()
                 .Should().BeEquivalentTo(expected);
+        }
+
+        [TestMethod]
+        public void GetArguments_RemovesCommandFromReducedTree()
+        {
+            RootCommand rootCommand = new();
+            Command command = new("command");
+            rootCommand.Subcommands.Add(command);
+            ParseResult parseResult = rootCommand.Parse(["command", "--help"]);
+
+            parseResult.GetArguments().Should().Equal("--help");
+        }
+
+        [TestMethod]
+        public void CanBeInvoked_RecognizesCommandFromReducedTree()
+        {
+            RootCommand rootCommand = new();
+            rootCommand.Subcommands.Add(new Command("command"));
+
+            rootCommand.Parse(["command"]).CanBeInvoked().Should().BeTrue();
         }
     }
 }

--- a/test/dotnet.Tests/TelemetryTests/TelemetryCommandTest.cs
+++ b/test/dotnet.Tests/TelemetryTests/TelemetryCommandTest.cs
@@ -67,6 +67,19 @@ public class TelemetryCommandTests : SdkTest
     }
 
     [TestMethod]
+    public void DotnetNewHelpShouldBeSentToTelemetry()
+    {
+        Cli.Program.ProcessArgsAndExecute(["new", "--help"]);
+
+        _fakeTelemetry.LogEntries.Should().Contain(e =>
+            e.EventName == "toplevelparser/command"
+            && e.Properties.ContainsKey("verb")
+            && e.Properties["verb"] == Sha256Hasher.Hash("NEW")
+            && e.Properties.ContainsKey("help")
+            && e.Properties["help"] == Sha256Hasher.Hash("TRUE"));
+    }
+
+    [TestMethod]
     public void DotnetHelpCommandFirstArgumentShouldBeSentToTelemetry()
     {
         const string argumentToSend = "something";


### PR DESCRIPTION
## Summary

- avoid constructing the complete `dotnet` command tree for exact top-level `<command> <help-alias>` invocations
- build a minimal root containing only the selected command while preserving command-specific help augmentation for `new`, `package`, and managed `completions`
- keep nested help, additional options, unknown commands, external commands, and dynamically generated `test` help on the existing full-parser path
- keep the complete root lazy and make cross-cutting telemetry option lookup safe when an option is absent from the selected tree
- apply the same optimization in NativeAOT, excluding dynamic `new`/`test` help and `completions`, which is not available in the AOT dependency closure

This changes parser construction only; help output and exit behavior are unchanged.

## Performance

Measured on Windows x64 with Release ReadyToRun `11.0.100-dev` SDKs, alternating fresh processes and byte-for-byte output checks:

- managed definition-backed help was **8.18% to 13.19% faster** across representative `add`, `build`, `package`, `tool`, and `workload` commands
- managed `completions --help` was **10.43% faster**; forwarded `format --help` was **7.17% faster**
- NativeAOT definition-backed help was **4.04% to 5.57% faster**; forwarded `format --help` was **1.57% faster**
- managed sampled allocation fell by **526,584 B to 642,984 B (38.04% to 46.10%)** across `add`, `build`, `completions`, and `workload`
- `DotNetCommandDefinition..ctor` was absent from all 20 candidate allocation traces

A review follow-up removed a remaining full-tree lookup from forwarded NuGet help. Across three alternating EventPipe pairs, managed `nuget --help` sampled allocation fell from **1,490,776 B to 853,480 B: 637,296 B (42.75%) lower**. `Parser.CreateCommand` and `DotNetCommandDefinition..ctor` each fell from 530,952 B in every control trace to zero in every candidate trace. The result was analyzed with the direct local Filtrace build at `7246c896`; output and exit behavior remained byte-identical, including the `why` command.

Timing used 30 alternating pairs per scenario. The original allocation results used five alternating EventPipe `gc-verbose` pairs per scenario.

## Validation

Current `main` validation after rebasing:

- full Debug SDK build: 0 warnings, 0 errors
- full Release SDK build: 0 warnings, 0 errors
- generic help parser tests: 84 passed in Debug and Release
- managed parser suite before the review follow-up: 832 passed, 1 expected skip in Debug and Release
- review follow-up: managed parser suite 834 passed, 1 expected skip in Debug; focused NativeAOT help tests 17 passed
- telemetry command suite: 20 passed, 1 expected skip in Debug and Release
- complete `dotnet-aot.Tests`: 183 passed, 12 expected skips in Debug and Release
- initialized product parity: 68 comparisons / 136 process launches, 0 exit/stdout/stderr mismatches
- fresh-state product parity: 68 comparisons / 136 process launches, 0 exit/stdout/stderr mismatches
- review follow-up NuGet parity: identical exit code, 1,527-byte stdout, empty stderr, and matching hashes

The product matrices cover every registered top-level command plus `new create --help` in both NativeAOT-enabled and managed-only modes.