### PR TITLE
[release/10.0.1xx] Backport Helix Job Monitor support

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "microsoft.dotnet.helix.jobmonitor": {
+      "version": "10.0.0-beta.26458.105",
+      "commands": [
+        "dotnet-helix-job-monitor"
+      ]
+    }
+  }
+}

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -91,6 +91,12 @@ extends:
     - stage: build
       displayName: Build
       jobs:
+      ############### HELIX JOB MONITOR ###############
+      - ${{ if or(eq(parameters.runTestBuild, true), eq(variables['Build.Reason'], 'PullRequest')) }}:
+        - template: /eng/common/core-templates/job/helix-job-monitor.yml@self
+          parameters:
+            helixAccessToken: $(HelixApiAccessToken)
+
       ############### WINDOWS ###############
       - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
         parameters:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -43,6 +43,9 @@ stages:
 - stage: build
   displayName: Build
   jobs:
+  ############### HELIX JOB MONITOR ###############
+  - template: /eng/common/core-templates/job/helix-job-monitor.yml
+
   ############### WINDOWS ###############
   - template: /eng/pipelines/templates/jobs/sdk-job-matrix.yml@self
     parameters:

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -549,6 +549,10 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>69b8232456f310042636be171c2c9ddd549f9c23</Sha>
     </Dependency>
+    <Dependency Name="Microsoft.DotNet.Helix.JobMonitor" Version="10.0.0-beta.26458.105">
+      <Uri>https://github.com/dotnet/dotnet</Uri>
+      <Sha>69b8232456f310042636be171c2c9ddd549f9c23</Sha>
+    </Dependency>
     <Dependency Name="Microsoft.DotNet.SignTool" Version="10.0.0-beta.26458.105">
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>69b8232456f310042636be171c2c9ddd549f9c23</Sha>

--- a/eng/pipelines/templates/jobs/sdk-build.yml
+++ b/eng/pipelines/templates/jobs/sdk-build.yml
@@ -150,9 +150,9 @@ jobs:
             /p:TargetArchitecture=${{ parameters.targetArchitecture }}
             ${{ parameters.runtimeSourceProperties }}
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}
+            /p:EnableHelixJobMonitor=true
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
-          displayName: 🟣 Run ${{ parameters.categoryName }} Tests
-          condition: succeeded()
+          displayName: 🟣 Queue Tests
           env:
             # Required by Arcade for running in Helix.
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
@@ -174,9 +174,9 @@ jobs:
             ${{ parameters.osProperties }}
             ${{ parameters.runtimeSourceProperties }}
             /p:CustomHelixTargetQueue=${{ parameters.helixTargetQueue }}${{ parameters.helixTargetContainer }}
+            /p:EnableHelixJobMonitor=true
             /bl:$(Build.SourcesDirectory)/artifacts/log/$(buildConfiguration)/${{ parameters.categoryName }}Tests.binlog
-          displayName: 🟣 Run ${{ parameters.categoryName }} Tests
-          condition: succeeded()
+          displayName: 🟣 Queue Tests
           env:
             # Required by Arcade for running in Helix.
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/test/UnitTests.proj
+++ b/test/UnitTests.proj
@@ -8,7 +8,7 @@
 
     <EnableAzurePipelinesReporter Condition="'$(BUILD_BUILDNUMBER)' != ''">true</EnableAzurePipelinesReporter>
 
-    <XUnitWorkItemTimeout>02:00:00</XUnitWorkItemTimeout>
+    <XUnitWorkItemTimeout>01:00:00</XUnitWorkItemTimeout>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
🤖 Backports the Helix Job Monitor integration from #54583 so .NET 10 servicing pipelines no longer keep each build leg waiting for its Helix work items.

The build legs now queue tests with monitor metadata enabled, while a dedicated monitor job tracks completion, publishes results, and supports retrying failed work items. The monitor tool is pinned to the matching 10.0 Arcade/Helix build, and individual work-item timeouts are reduced to one hour so infrastructure failures surface sooner.

The official monitor job retains the existing test-build and pull-request condition and receives the internal Helix access token. The public PR monitor remains unconditional.

Fixes: #55456